### PR TITLE
add rawptr to c type map for void, fixes bug where the generetor was …

### DIFF
--- a/src/bindgen.odin
+++ b/src/bindgen.odin
@@ -519,7 +519,6 @@ c_type_mapping := map[string]string {
 	"char" = "u8",
 	"unsigned short" = "u16",
 	"unsigned char" = "u8",
-	"void" = "rawptr",
 	"unsigned int" = "u32",
 	"unsigned long" = "c.ulong",
 	"Bool" = "bool",
@@ -585,6 +584,9 @@ translate_type :: proc(s: Gen_State, t: string) -> string {
 
 	if t == "void *" || t == "const void *" {
 		return "rawptr"
+	}
+	if t == "void **" || t == "const void **" {
+		return "^rawptr"
 	}
 
 	if t == "const char *const *" {

--- a/src/bindgen.odin
+++ b/src/bindgen.odin
@@ -519,6 +519,7 @@ c_type_mapping := map[string]string {
 	"char" = "u8",
 	"unsigned short" = "u16",
 	"unsigned char" = "u8",
+	"void" = "rawptr",
 	"unsigned int" = "u32",
 	"unsigned long" = "c.ulong",
 	"Bool" = "bool",


### PR DESCRIPTION
…generating void** instead of rawptr for odin types

for example for this c signature:
```
void add(void * p, void ** pp, void *** ppp);
```
the generator would output

```
add :: proc(p: rawptr, pp: ^^void, ppp: ^^^void) ---
```
Now it would generate
```
add :: proc(p: rawptr, pp: ^^rawptr, ppp: ^^^rawptr) ---
```