### PR TITLE
Fixed issue with anonymous structs

### DIFF
--- a/src/bindgen.odin
+++ b/src/bindgen.odin
@@ -2283,7 +2283,7 @@ gen :: proc(input: string, c: Config) {
 					}
 					strings.write_string(&b, val[start:i + 1])
 				case .Other:
-					if val[i] == '~' {
+					if val[i] == '~' || val[i] == '#' {
 						comment_out = true
 					}
 

--- a/test/test.h
+++ b/test/test.h
@@ -8,7 +8,7 @@
 #define SUB(x, y) (float) (x) - (float)(y)
 
 #define FIVE_SUB_TWO SUB(5, 2)
-#define UNNEST NEST("Test") // Sould resolve to ("Test")
+#define UNNEST NEST("Test")
 
 #define ARRAY {1}
 
@@ -28,5 +28,22 @@
 
 #define ufbx_pack_version(major, minor, patch) ((uint32_t)(major)*1000000u + (uint32_t)(minor)*1000u + (uint32_t)(patch))
 #define UFBX_HEADER_VERSION ufbx_pack_version(0, 18, 0)
+
+#define NO_INDEX (uint32_t)0
+
+#define VALUE 20010
+#define VALUE_STRING #VALUE
+
+#define CINDEX_VERSION_MAJOR 0
+#define CINDEX_VERSION_MINOR 64
+
+#define CINDEX_VERSION_STRING #CINDEX_VERSION_MAJOR "." #CINDEX_VERSION_MINOR
+
+struct Color {
+    int r;
+    int g;
+    int b;
+    int a;
+};
 
 #pragma GCC pop_options

--- a/test/test/test.odin
+++ b/test/test/test.odin
@@ -1,17 +1,41 @@
 package test
 
+import "core:c"
 
+_ :: c
 
 
 
 FIVE_SUB_TWO :: (f32) (5) - (f32)(2)
 UNNEST :: "Test"
+
 ARRAY :: {1}
+
 LIGHTGRAY :: (Color){ 200, 200, 200, 255 }
+
 FUNC_TEST_RESULT :: 1 + 2 + 3
+
 ARRAY_TEST :: {1, 2, 3}
-FALSE :: ! true
-TRUE :: !false
+
+// FALSE :: ! true
+// TRUE :: !false
+
 UFBX_HEADER_VERSION :: (u32)(0)*1000000 + (u32)(18)*1000 + (u32)(0)
 
+NO_INDEX :: (u32)0
+
+VALUE :: 20010
+// VALUE_STRING :: #VALUE
+
+CINDEX_VERSION_MAJOR :: 0
+CINDEX_VERSION_MINOR :: 64
+
+// CINDEX_VERSION_STRING :: #CINDEX_VERSION_MAJOR "." #CINDEX_VERSION_MINOR
+
+Color :: struct {
+	r: i32,
+	g: i32,
+	b: i32,
+	a: i32,
+}
 


### PR DESCRIPTION
Had an issue when trying to generate bindings for libclang. Some of the strucst suck as:
```c
typedef struct {
  const void *data;
  unsigned private_flags;
} CXString;
```
Weren't being brought over into the odin wrapper. I tracked the issue down to the fact that fdor some reason when clang makes the AST it anonymized the structure meaning there's a typedef decl with the struct name and some comment info and then a seperate record decl that contains the struct info.

<strike>I had to make a few changes to fix this issue. The first is removing the name requirement when reading the AST to allow for the anonymized struct data to be loaded. Then when we write the typedefs to the file if it's a scruct type def (which we detect by if the type is a hex number) we look up the id accociated with the typedef and then output that struct. I also added checks to the code responsible for outputting stucts to avoid outputting the anonamized struct without its proper type name.</strike>