### PR TITLE
Fix for detecting c/libc/posix types. Updated c_type_mapping

### DIFF
--- a/examples/box2d/box2d/base.odin
+++ b/examples/box2d/box2d/base.odin
@@ -14,14 +14,14 @@ foreign import lib "box2d.lib"
 /// Prototype for user allocation function
 /// @param size the allocation size in bytes
 /// @param alignment the required alignment, guaranteed to be a power of 2
-AllocFcn :: proc "c" (u32, i32) -> rawptr
+AllocFcn :: proc "c" (c.uint, c.int) -> rawptr
 
 /// Prototype for user free function
 /// @param mem the memory previously allocated through `b2AllocFcn`
 FreeFcn :: proc "c" (rawptr)
 
 /// Prototype for the user assert callback. Return 0 to skip the debugger break.
-AssertFcn :: proc "c" (cstring, cstring, i32) -> i32
+AssertFcn :: proc "c" (cstring, cstring, c.int) -> c.int
 
 // BREAKPOINT :: _debugbreak()
 
@@ -29,13 +29,13 @@ AssertFcn :: proc "c" (cstring, cstring, i32) -> i32
 /// See https://semver.org/
 Version :: struct {
 	/// Significant changes
-	major: i32,
+	major: c.int,
 
 	/// Incremental changes
-	minor: i32,
+	minor: c.int,
 
 	/// Bug fixes
-	revision: i32,
+	revision: c.int,
 }
 
 /// Simple djb2 hash function for determinism testing
@@ -48,26 +48,26 @@ foreign lib {
 	SetAllocator :: proc(allocFcn: AllocFcn, freeFcn: FreeFcn) ---
 
 	/// @return the total bytes allocated by Box2D
-	GetByteCount :: proc() -> i32 ---
+	GetByteCount :: proc() -> c.int ---
 
 	/// Override the default assert callback
 	/// @param assertFcn a non-null assert callback
 	SetAssertFcn      :: proc(assertFcn: AssertFcn) ---
-	InternalAssertFcn :: proc(condition: cstring, fileName: cstring, lineNumber: i32) -> i32 ---
+	InternalAssertFcn :: proc(condition: cstring, fileName: cstring, lineNumber: c.int) -> c.int ---
 
 	/// Get the current version of Box2D
 	GetVersion :: proc() -> Version ---
 
 	/// Get the absolute number of system ticks. The value is platform specific.
-	GetTicks :: proc() -> u64 ---
+	GetTicks :: proc() -> c.uint64_t ---
 
 	/// Get the milliseconds passed from an initial tick value.
-	GetMilliseconds :: proc(ticks: u64) -> f32 ---
+	GetMilliseconds :: proc(ticks: c.uint64_t) -> c.float ---
 
 	/// Get the milliseconds passed from an initial tick value.
-	GetMillisecondsAndReset :: proc(ticks: ^u64) -> f32 ---
+	GetMillisecondsAndReset :: proc(ticks: ^c.uint64_t) -> c.float ---
 
 	/// Yield to be used in a busy loop.
 	Yield :: proc() ---
-	Hash  :: proc(hash: u32, data: ^u8, count: i32) -> u32 ---
+	Hash  :: proc(hash: c.uint32_t, data: ^c.uint8_t, count: c.int) -> c.uint32_t ---
 }

--- a/examples/box2d/box2d/base.odin
+++ b/examples/box2d/box2d/base.odin
@@ -59,15 +59,15 @@ foreign lib {
 	GetVersion :: proc() -> Version ---
 
 	/// Get the absolute number of system ticks. The value is platform specific.
-	GetTicks :: proc() -> c.uint64_t ---
+	GetTicks :: proc() -> u64 ---
 
 	/// Get the milliseconds passed from an initial tick value.
-	GetMilliseconds :: proc(ticks: c.uint64_t) -> c.float ---
+	GetMilliseconds :: proc(ticks: u64) -> f32 ---
 
 	/// Get the milliseconds passed from an initial tick value.
-	GetMillisecondsAndReset :: proc(ticks: ^c.uint64_t) -> c.float ---
+	GetMillisecondsAndReset :: proc(ticks: ^u64) -> f32 ---
 
 	/// Yield to be used in a busy loop.
 	Yield :: proc() ---
-	Hash  :: proc(hash: c.uint32_t, data: ^c.uint8_t, count: c.int) -> c.uint32_t ---
+	Hash  :: proc(hash: u32, data: ^u8, count: c.int) -> u32 ---
 }

--- a/examples/box2d/box2d/box2d.odin
+++ b/examples/box2d/box2d/box2d.odin
@@ -19,13 +19,13 @@ foreign lib {
 	DestroyWorld :: proc(worldId: WorldId) ---
 
 	/// World id validation. Provides validation for up to 64K allocations.
-	World_IsValid :: proc(id: WorldId) -> bool ---
+	World_IsValid :: proc(id: WorldId) -> c.bool ---
 
 	/// Simulate a world for one time step. This performs collision detection, integration, and constraint solution.
 	/// @param worldId The world to simulate
 	/// @param timeStep The amount of time to simulate, this should be a fixed number. Usually 1/60.
 	/// @param subStepCount The number of sub-steps, increasing the sub-step count can increase accuracy. Usually 4.
-	World_Step :: proc(worldId: WorldId, timeStep: f32, subStepCount: i32) ---
+	World_Step :: proc(worldId: WorldId, timeStep: c.float, subStepCount: c.int) ---
 
 	/// Call this to draw shapes and other debug draw data
 	World_Draw :: proc(worldId: WorldId, draw: ^DebugDraw) ---
@@ -86,35 +86,35 @@ foreign lib {
 	/// Enable/disable sleep. If your application does not need sleeping, you can gain some performance
 	/// by disabling sleep completely at the world level.
 	/// @see b2WorldDef
-	World_EnableSleeping :: proc(worldId: WorldId, flag: bool) ---
+	World_EnableSleeping :: proc(worldId: WorldId, flag: c.bool) ---
 
 	/// Is body sleeping enabled?
-	World_IsSleepingEnabled :: proc(worldId: WorldId) -> bool ---
+	World_IsSleepingEnabled :: proc(worldId: WorldId) -> c.bool ---
 
 	/// Enable/disable continuous collision between dynamic and static bodies. Generally you should keep continuous
 	/// collision enabled to prevent fast moving objects from going through static objects. The performance gain from
 	/// disabling continuous collision is minor.
 	/// @see b2WorldDef
-	World_EnableContinuous :: proc(worldId: WorldId, flag: bool) ---
+	World_EnableContinuous :: proc(worldId: WorldId, flag: c.bool) ---
 
 	/// Is continuous collision enabled?
-	World_IsContinuousEnabled :: proc(worldId: WorldId) -> bool ---
+	World_IsContinuousEnabled :: proc(worldId: WorldId) -> c.bool ---
 
 	/// Adjust the restitution threshold. It is recommended not to make this value very small
 	/// because it will prevent bodies from sleeping. Usually in meters per second.
 	/// @see b2WorldDef
-	World_SetRestitutionThreshold :: proc(worldId: WorldId, value: f32) ---
+	World_SetRestitutionThreshold :: proc(worldId: WorldId, value: c.float) ---
 
 	/// Get the the restitution speed threshold. Usually in meters per second.
-	World_GetRestitutionThreshold :: proc(worldId: WorldId) -> f32 ---
+	World_GetRestitutionThreshold :: proc(worldId: WorldId) -> c.float ---
 
 	/// Adjust the hit event threshold. This controls the collision speed needed to generate a b2ContactHitEvent.
 	/// Usually in meters per second.
 	/// @see b2WorldDef::hitEventThreshold
-	World_SetHitEventThreshold :: proc(worldId: WorldId, value: f32) ---
+	World_SetHitEventThreshold :: proc(worldId: WorldId, value: c.float) ---
 
 	/// Get the the hit event speed threshold. Usually in meters per second.
-	World_GetHitEventThreshold :: proc(worldId: WorldId) -> f32 ---
+	World_GetHitEventThreshold :: proc(worldId: WorldId) -> c.float ---
 
 	/// Register the custom filter callback. This is optional.
 	World_SetCustomFilterCallback :: proc(worldId: WorldId, fcn: ^CustomFilterFcn, _context: rawptr) ---
@@ -141,30 +141,30 @@ foreign lib {
 	/// @param dampingRatio The contact bounciness with 1 being critical damping (non-dimensional)
 	/// @param pushSpeed The maximum contact constraint push out speed (meters per second)
 	/// @note Advanced feature
-	World_SetContactTuning :: proc(worldId: WorldId, hertz: f32, dampingRatio: f32, pushSpeed: f32) ---
+	World_SetContactTuning :: proc(worldId: WorldId, hertz: c.float, dampingRatio: c.float, pushSpeed: c.float) ---
 
 	/// Adjust joint tuning parameters
 	/// @param worldId The world id
 	/// @param hertz The contact stiffness (cycles per second)
 	/// @param dampingRatio The contact bounciness with 1 being critical damping (non-dimensional)
 	/// @note Advanced feature
-	World_SetJointTuning :: proc(worldId: WorldId, hertz: f32, dampingRatio: f32) ---
+	World_SetJointTuning :: proc(worldId: WorldId, hertz: c.float, dampingRatio: c.float) ---
 
 	/// Set the maximum linear speed. Usually in m/s.
-	World_SetMaximumLinearSpeed :: proc(worldId: WorldId, maximumLinearSpeed: f32) ---
+	World_SetMaximumLinearSpeed :: proc(worldId: WorldId, maximumLinearSpeed: c.float) ---
 
 	/// Get the maximum linear speed. Usually in m/s.
-	World_GetMaximumLinearSpeed :: proc(worldId: WorldId) -> f32 ---
+	World_GetMaximumLinearSpeed :: proc(worldId: WorldId) -> c.float ---
 
 	/// Enable/disable constraint warm starting. Advanced feature for testing. Disabling
 	/// sleeping greatly reduces stability and provides no performance gain.
-	World_EnableWarmStarting :: proc(worldId: WorldId, flag: bool) ---
+	World_EnableWarmStarting :: proc(worldId: WorldId, flag: c.bool) ---
 
 	/// Is constraint warm starting enabled?
-	World_IsWarmStartingEnabled :: proc(worldId: WorldId) -> bool ---
+	World_IsWarmStartingEnabled :: proc(worldId: WorldId) -> c.bool ---
 
 	/// Get the number of awake bodies.
-	World_GetAwakeBodyCount :: proc(worldId: WorldId) -> i32 ---
+	World_GetAwakeBodyCount :: proc(worldId: WorldId) -> c.int ---
 
 	/// Get the current world performance profile
 	World_GetProfile :: proc(worldId: WorldId) -> Profile ---
@@ -191,7 +191,7 @@ foreign lib {
 	World_RebuildStaticTree :: proc(worldId: WorldId) ---
 
 	/// This is for internal testing
-	World_EnableSpeculative :: proc(worldId: WorldId, flag: bool) ---
+	World_EnableSpeculative :: proc(worldId: WorldId, flag: c.bool) ---
 
 	/// Create a rigid body given a definition. No reference to the definition is retained. So you can create the definition
 	/// on the stack and pass it as a pointer.
@@ -207,7 +207,7 @@ foreign lib {
 	DestroyBody :: proc(bodyId: BodyId) ---
 
 	/// Body identifier validation. Can be used to detect orphaned ids. Provides validation for up to 64K allocations.
-	Body_IsValid :: proc(id: BodyId) -> bool ---
+	Body_IsValid :: proc(id: BodyId) -> c.bool ---
 
 	/// Get the body type: static, kinematic, or dynamic
 	Body_GetType :: proc(bodyId: BodyId) -> BodyType ---
@@ -258,13 +258,13 @@ foreign lib {
 	Body_GetLinearVelocity :: proc(bodyId: BodyId) -> Vec2 ---
 
 	/// Get the angular velocity of a body in radians per second
-	Body_GetAngularVelocity :: proc(bodyId: BodyId) -> f32 ---
+	Body_GetAngularVelocity :: proc(bodyId: BodyId) -> c.float ---
 
 	/// Set the linear velocity of a body. Usually in meters per second.
 	Body_SetLinearVelocity :: proc(bodyId: BodyId, linearVelocity: Vec2) ---
 
 	/// Set the angular velocity of a body in radians per second
-	Body_SetAngularVelocity :: proc(bodyId: BodyId, angularVelocity: f32) ---
+	Body_SetAngularVelocity :: proc(bodyId: BodyId, angularVelocity: c.float) ---
 
 	/// Get the linear velocity of a local point attached to a body. Usually in meters per second.
 	Body_GetLocalPointVelocity :: proc(bodyId: BodyId, localPoint: Vec2) -> Vec2 ---
@@ -279,21 +279,21 @@ foreign lib {
 	/// @param force The world force vector, usually in newtons (N)
 	/// @param point The world position of the point of application
 	/// @param wake Option to wake up the body
-	Body_ApplyForce :: proc(bodyId: BodyId, force: Vec2, point: Vec2, wake: bool) ---
+	Body_ApplyForce :: proc(bodyId: BodyId, force: Vec2, point: Vec2, wake: c.bool) ---
 
 	/// Apply a force to the center of mass. This optionally wakes up the body.
 	/// The force is ignored if the body is not awake.
 	/// @param bodyId The body id
 	/// @param force the world force vector, usually in newtons (N).
 	/// @param wake also wake up the body
-	Body_ApplyForceToCenter :: proc(bodyId: BodyId, force: Vec2, wake: bool) ---
+	Body_ApplyForceToCenter :: proc(bodyId: BodyId, force: Vec2, wake: c.bool) ---
 
 	/// Apply a torque. This affects the angular velocity without affecting the linear velocity.
 	/// This optionally wakes the body. The torque is ignored if the body is not awake.
 	/// @param bodyId The body id
 	/// @param torque about the z-axis (out of the screen), usually in N*m.
 	/// @param wake also wake up the body
-	Body_ApplyTorque :: proc(bodyId: BodyId, torque: f32, wake: bool) ---
+	Body_ApplyTorque :: proc(bodyId: BodyId, torque: c.float, wake: c.bool) ---
 
 	/// Apply an impulse at a point. This immediately modifies the velocity.
 	/// It also modifies the angular velocity if the point of application
@@ -305,7 +305,7 @@ foreign lib {
 	/// @param wake also wake up the body
 	/// @warning This should be used for one-shot impulses. If you need a steady force,
 	/// use a force instead, which will work better with the sub-stepping solver.
-	Body_ApplyLinearImpulse :: proc(bodyId: BodyId, impulse: Vec2, point: Vec2, wake: bool) ---
+	Body_ApplyLinearImpulse :: proc(bodyId: BodyId, impulse: Vec2, point: Vec2, wake: c.bool) ---
 
 	/// Apply an impulse to the center of mass. This immediately modifies the velocity.
 	/// The impulse is ignored if the body is not awake. This optionally wakes the body.
@@ -314,7 +314,7 @@ foreign lib {
 	/// @param wake also wake up the body
 	/// @warning This should be used for one-shot impulses. If you need a steady force,
 	/// use a force instead, which will work better with the sub-stepping solver.
-	Body_ApplyLinearImpulseToCenter :: proc(bodyId: BodyId, impulse: Vec2, wake: bool) ---
+	Body_ApplyLinearImpulseToCenter :: proc(bodyId: BodyId, impulse: Vec2, wake: c.bool) ---
 
 	/// Apply an angular impulse. The impulse is ignored if the body is not awake.
 	/// This optionally wakes the body.
@@ -323,13 +323,13 @@ foreign lib {
 	/// @param wake also wake up the body
 	/// @warning This should be used for one-shot impulses. If you need a steady force,
 	/// use a force instead, which will work better with the sub-stepping solver.
-	Body_ApplyAngularImpulse :: proc(bodyId: BodyId, impulse: f32, wake: bool) ---
+	Body_ApplyAngularImpulse :: proc(bodyId: BodyId, impulse: c.float, wake: c.bool) ---
 
 	/// Get the mass of the body, usually in kilograms
-	Body_GetMass :: proc(bodyId: BodyId) -> f32 ---
+	Body_GetMass :: proc(bodyId: BodyId) -> c.float ---
 
 	/// Get the rotational inertia of the body, usually in kg*m^2
-	Body_GetRotationalInertia :: proc(bodyId: BodyId) -> f32 ---
+	Body_GetRotationalInertia :: proc(bodyId: BodyId) -> c.float ---
 
 	/// Get the center of mass position of the body in local space
 	Body_GetLocalCenterOfMass :: proc(bodyId: BodyId) -> Vec2 ---
@@ -353,46 +353,46 @@ foreign lib {
 	Body_ApplyMassFromShapes :: proc(bodyId: BodyId) ---
 
 	/// Adjust the linear damping. Normally this is set in b2BodyDef before creation.
-	Body_SetLinearDamping :: proc(bodyId: BodyId, linearDamping: f32) ---
+	Body_SetLinearDamping :: proc(bodyId: BodyId, linearDamping: c.float) ---
 
 	/// Get the current linear damping.
-	Body_GetLinearDamping :: proc(bodyId: BodyId) -> f32 ---
+	Body_GetLinearDamping :: proc(bodyId: BodyId) -> c.float ---
 
 	/// Adjust the angular damping. Normally this is set in b2BodyDef before creation.
-	Body_SetAngularDamping :: proc(bodyId: BodyId, angularDamping: f32) ---
+	Body_SetAngularDamping :: proc(bodyId: BodyId, angularDamping: c.float) ---
 
 	/// Get the current angular damping.
-	Body_GetAngularDamping :: proc(bodyId: BodyId) -> f32 ---
+	Body_GetAngularDamping :: proc(bodyId: BodyId) -> c.float ---
 
 	/// Adjust the gravity scale. Normally this is set in b2BodyDef before creation.
 	/// @see b2BodyDef::gravityScale
-	Body_SetGravityScale :: proc(bodyId: BodyId, gravityScale: f32) ---
+	Body_SetGravityScale :: proc(bodyId: BodyId, gravityScale: c.float) ---
 
 	/// Get the current gravity scale
-	Body_GetGravityScale :: proc(bodyId: BodyId) -> f32 ---
+	Body_GetGravityScale :: proc(bodyId: BodyId) -> c.float ---
 
 	/// @return true if this body is awake
-	Body_IsAwake :: proc(bodyId: BodyId) -> bool ---
+	Body_IsAwake :: proc(bodyId: BodyId) -> c.bool ---
 
 	/// Wake a body from sleep. This wakes the entire island the body is touching.
 	/// @warning Putting a body to sleep will put the entire island of bodies touching this body to sleep,
 	/// which can be expensive and possibly unintuitive.
-	Body_SetAwake :: proc(bodyId: BodyId, awake: bool) ---
+	Body_SetAwake :: proc(bodyId: BodyId, awake: c.bool) ---
 
 	/// Enable or disable sleeping for this body. If sleeping is disabled the body will wake.
-	Body_EnableSleep :: proc(bodyId: BodyId, enableSleep: bool) ---
+	Body_EnableSleep :: proc(bodyId: BodyId, enableSleep: c.bool) ---
 
 	/// Returns true if sleeping is enabled for this body
-	Body_IsSleepEnabled :: proc(bodyId: BodyId) -> bool ---
+	Body_IsSleepEnabled :: proc(bodyId: BodyId) -> c.bool ---
 
 	/// Set the sleep threshold, usually in meters per second
-	Body_SetSleepThreshold :: proc(bodyId: BodyId, sleepThreshold: f32) ---
+	Body_SetSleepThreshold :: proc(bodyId: BodyId, sleepThreshold: c.float) ---
 
 	/// Get the sleep threshold, usually in meters per second.
-	Body_GetSleepThreshold :: proc(bodyId: BodyId) -> f32 ---
+	Body_GetSleepThreshold :: proc(bodyId: BodyId) -> c.float ---
 
 	/// Returns true if this body is enabled
-	Body_IsEnabled :: proc(bodyId: BodyId) -> bool ---
+	Body_IsEnabled :: proc(bodyId: BodyId) -> c.bool ---
 
 	/// Disable a body by removing it completely from the simulation. This is expensive.
 	Body_Disable :: proc(bodyId: BodyId) ---
@@ -401,52 +401,52 @@ foreign lib {
 	Body_Enable :: proc(bodyId: BodyId) ---
 
 	/// Set this body to have fixed rotation. This causes the mass to be reset in all cases.
-	Body_SetFixedRotation :: proc(bodyId: BodyId, flag: bool) ---
+	Body_SetFixedRotation :: proc(bodyId: BodyId, flag: c.bool) ---
 
 	/// Does this body have fixed rotation?
-	Body_IsFixedRotation :: proc(bodyId: BodyId) -> bool ---
+	Body_IsFixedRotation :: proc(bodyId: BodyId) -> c.bool ---
 
 	/// Set this body to be a bullet. A bullet does continuous collision detection
 	/// against dynamic bodies (but not other bullets).
-	Body_SetBullet :: proc(bodyId: BodyId, flag: bool) ---
+	Body_SetBullet :: proc(bodyId: BodyId, flag: c.bool) ---
 
 	/// Is this body a bullet?
-	Body_IsBullet :: proc(bodyId: BodyId) -> bool ---
+	Body_IsBullet :: proc(bodyId: BodyId) -> c.bool ---
 
 	/// Enable/disable contact events on all shapes.
 	/// @see b2ShapeDef::enableContactEvents
 	/// @warning changing this at runtime may cause mismatched begin/end touch events
-	Body_EnableContactEvents :: proc(bodyId: BodyId, flag: bool) ---
+	Body_EnableContactEvents :: proc(bodyId: BodyId, flag: c.bool) ---
 
 	/// Enable/disable hit events on all shapes
 	/// @see b2ShapeDef::enableHitEvents
-	Body_EnableHitEvents :: proc(bodyId: BodyId, flag: bool) ---
+	Body_EnableHitEvents :: proc(bodyId: BodyId, flag: c.bool) ---
 
 	/// Get the world that owns this body
 	Body_GetWorld :: proc(bodyId: BodyId) -> WorldId ---
 
 	/// Get the number of shapes on this body
-	Body_GetShapeCount :: proc(bodyId: BodyId) -> i32 ---
+	Body_GetShapeCount :: proc(bodyId: BodyId) -> c.int ---
 
 	/// Get the shape ids for all shapes on this body, up to the provided capacity.
 	/// @returns the number of shape ids stored in the user array
-	Body_GetShapes :: proc(bodyId: BodyId, shapeArray: ^ShapeId, capacity: i32) -> i32 ---
+	Body_GetShapes :: proc(bodyId: BodyId, shapeArray: ^ShapeId, capacity: c.int) -> c.int ---
 
 	/// Get the number of joints on this body
-	Body_GetJointCount :: proc(bodyId: BodyId) -> i32 ---
+	Body_GetJointCount :: proc(bodyId: BodyId) -> c.int ---
 
 	/// Get the joint ids for all joints on this body, up to the provided capacity
 	/// @returns the number of joint ids stored in the user array
-	Body_GetJoints :: proc(bodyId: BodyId, jointArray: ^JointId, capacity: i32) -> i32 ---
+	Body_GetJoints :: proc(bodyId: BodyId, jointArray: ^JointId, capacity: c.int) -> c.int ---
 
 	/// Get the maximum capacity required for retrieving all the touching contacts on a body
-	Body_GetContactCapacity :: proc(bodyId: BodyId) -> i32 ---
+	Body_GetContactCapacity :: proc(bodyId: BodyId) -> c.int ---
 
 	/// Get the touching contact data for a body.
 	/// @note Box2D uses speculative collision so some contact points may be separated.
 	/// @returns the number of elements filled in the provided array
 	/// @warning do not ignore the return value, it specifies the valid number of elements
-	Body_GetContactData :: proc(bodyId: BodyId, contactData: ^ContactData, capacity: i32) -> i32 ---
+	Body_GetContactData :: proc(bodyId: BodyId, contactData: ^ContactData, capacity: c.int) -> c.int ---
 
 	/// Get the current world AABB that contains all the attached shapes. Note that this may not encompass the body origin.
 	/// If there are no shapes attached then the returned AABB is empty and centered on the body origin.
@@ -475,10 +475,10 @@ foreign lib {
 	/// Destroy a shape. You may defer the body mass update which can improve performance if several shapes on a
 	///	body are destroyed at once.
 	///	@see b2Body_ApplyMassFromShapes
-	DestroyShape :: proc(shapeId: ShapeId, updateBodyMass: bool) ---
+	DestroyShape :: proc(shapeId: ShapeId, updateBodyMass: c.bool) ---
 
 	/// Shape identifier validation. Provides validation for up to 64K allocations.
-	Shape_IsValid :: proc(id: ShapeId) -> bool ---
+	Shape_IsValid :: proc(id: ShapeId) -> c.bool ---
 
 	/// Get the type of a shape
 	Shape_GetType :: proc(shapeId: ShapeId) -> ShapeType ---
@@ -490,7 +490,7 @@ foreign lib {
 	Shape_GetWorld :: proc(shapeId: ShapeId) -> WorldId ---
 
 	/// Returns true If the shape is a sensor
-	Shape_IsSensor :: proc(shapeId: ShapeId) -> bool ---
+	Shape_IsSensor :: proc(shapeId: ShapeId) -> c.bool ---
 
 	/// Set the user data for a shape
 	Shape_SetUserData :: proc(shapeId: ShapeId, userData: rawptr) ---
@@ -502,31 +502,31 @@ foreign lib {
 	/// Set the mass density of a shape, usually in kg/m^2.
 	/// This will optionally update the mass properties on the parent body.
 	/// @see b2ShapeDef::density, b2Body_ApplyMassFromShapes
-	Shape_SetDensity :: proc(shapeId: ShapeId, density: f32, updateBodyMass: bool) ---
+	Shape_SetDensity :: proc(shapeId: ShapeId, density: c.float, updateBodyMass: c.bool) ---
 
 	/// Get the density of a shape, usually in kg/m^2
-	Shape_GetDensity :: proc(shapeId: ShapeId) -> f32 ---
+	Shape_GetDensity :: proc(shapeId: ShapeId) -> c.float ---
 
 	/// Set the friction on a shape
 	/// @see b2ShapeDef::friction
-	Shape_SetFriction :: proc(shapeId: ShapeId, friction: f32) ---
+	Shape_SetFriction :: proc(shapeId: ShapeId, friction: c.float) ---
 
 	/// Get the friction of a shape
-	Shape_GetFriction :: proc(shapeId: ShapeId) -> f32 ---
+	Shape_GetFriction :: proc(shapeId: ShapeId) -> c.float ---
 
 	/// Set the shape restitution (bounciness)
 	/// @see b2ShapeDef::restitution
-	Shape_SetRestitution :: proc(shapeId: ShapeId, restitution: f32) ---
+	Shape_SetRestitution :: proc(shapeId: ShapeId, restitution: c.float) ---
 
 	/// Get the shape restitution
-	Shape_GetRestitution :: proc(shapeId: ShapeId) -> f32 ---
+	Shape_GetRestitution :: proc(shapeId: ShapeId) -> c.float ---
 
 	/// Set the shape material identifier
 	/// @see b2ShapeDef::material
-	Shape_SetMaterial :: proc(shapeId: ShapeId, material: i32) ---
+	Shape_SetMaterial :: proc(shapeId: ShapeId, material: c.int) ---
 
 	/// Get the shape material identifier
-	Shape_GetMaterial :: proc(shapeId: ShapeId) -> i32 ---
+	Shape_GetMaterial :: proc(shapeId: ShapeId) -> c.int ---
 
 	/// Get the shape filter
 	Shape_GetFilter :: proc(shapeId: ShapeId) -> Filter ---
@@ -540,28 +540,28 @@ foreign lib {
 	/// Enable contact events for this shape. Only applies to kinematic and dynamic bodies. Ignored for sensors.
 	/// @see b2ShapeDef::enableContactEvents
 	/// @warning changing this at run-time may lead to lost begin/end events
-	Shape_EnableContactEvents :: proc(shapeId: ShapeId, flag: bool) ---
+	Shape_EnableContactEvents :: proc(shapeId: ShapeId, flag: c.bool) ---
 
 	/// Returns true if contact events are enabled
-	Shape_AreContactEventsEnabled :: proc(shapeId: ShapeId) -> bool ---
+	Shape_AreContactEventsEnabled :: proc(shapeId: ShapeId) -> c.bool ---
 
 	/// Enable pre-solve contact events for this shape. Only applies to dynamic bodies. These are expensive
 	/// and must be carefully handled due to multithreading. Ignored for sensors.
 	/// @see b2PreSolveFcn
-	Shape_EnablePreSolveEvents :: proc(shapeId: ShapeId, flag: bool) ---
+	Shape_EnablePreSolveEvents :: proc(shapeId: ShapeId, flag: c.bool) ---
 
 	/// Returns true if pre-solve events are enabled
-	Shape_ArePreSolveEventsEnabled :: proc(shapeId: ShapeId) -> bool ---
+	Shape_ArePreSolveEventsEnabled :: proc(shapeId: ShapeId) -> c.bool ---
 
 	/// Enable contact hit events for this shape. Ignored for sensors.
 	/// @see b2WorldDef.hitEventThreshold
-	Shape_EnableHitEvents :: proc(shapeId: ShapeId, flag: bool) ---
+	Shape_EnableHitEvents :: proc(shapeId: ShapeId, flag: c.bool) ---
 
 	/// Returns true if hit events are enabled
-	Shape_AreHitEventsEnabled :: proc(shapeId: ShapeId) -> bool ---
+	Shape_AreHitEventsEnabled :: proc(shapeId: ShapeId) -> c.bool ---
 
 	/// Test a point for overlap with a shape
-	Shape_TestPoint :: proc(shapeId: ShapeId, point: Vec2) -> bool ---
+	Shape_TestPoint :: proc(shapeId: ShapeId, point: Vec2) -> c.bool ---
 
 	/// Ray cast a shape directly
 	Shape_RayCast :: proc(shapeId: ShapeId, input: ^RayCastInput) -> CastOutput ---
@@ -605,19 +605,19 @@ foreign lib {
 	Shape_GetParentChain :: proc(shapeId: ShapeId) -> ChainId ---
 
 	/// Get the maximum capacity required for retrieving all the touching contacts on a shape
-	Shape_GetContactCapacity :: proc(shapeId: ShapeId) -> i32 ---
+	Shape_GetContactCapacity :: proc(shapeId: ShapeId) -> c.int ---
 
 	/// Get the touching contact data for a shape. The provided shapeId will be either shapeIdA or shapeIdB on the contact data.
 	/// @note Box2D uses speculative collision so some contact points may be separated.
 	/// @returns the number of elements filled in the provided array
 	/// @warning do not ignore the return value, it specifies the valid number of elements
-	Shape_GetContactData :: proc(shapeId: ShapeId, contactData: ^ContactData, capacity: i32) -> i32 ---
+	Shape_GetContactData :: proc(shapeId: ShapeId, contactData: ^ContactData, capacity: c.int) -> c.int ---
 
 	/// Get the maximum capacity required for retrieving all the overlapped shapes on a sensor shape.
 	/// This returns 0 if the provided shape is not a sensor.
 	/// @param shapeId the id of a sensor shape
 	/// @returns the required capacity to get all the overlaps in b2Shape_GetSensorOverlaps
-	Shape_GetSensorCapacity :: proc(shapeId: ShapeId) -> i32 ---
+	Shape_GetSensorCapacity :: proc(shapeId: ShapeId) -> c.int ---
 
 	/// Get the overlapped shapes for a sensor shape.
 	/// @param shapeId the id of a sensor shape
@@ -626,7 +626,7 @@ foreign lib {
 	/// @returns the number of elements filled in the provided array
 	/// @warning do not ignore the return value, it specifies the valid number of elements
 	/// @warning overlaps may contain destroyed shapes so use b2Shape_IsValid to confirm each overlap
-	Shape_GetSensorOverlaps :: proc(shapeId: ShapeId, overlaps: ^ShapeId, capacity: i32) -> i32 ---
+	Shape_GetSensorOverlaps :: proc(shapeId: ShapeId, overlaps: ^ShapeId, capacity: c.int) -> c.int ---
 
 	/// Get the current world AABB
 	Shape_GetAABB :: proc(shapeId: ShapeId) -> AABB ---
@@ -649,41 +649,41 @@ foreign lib {
 	Chain_GetWorld :: proc(chainId: ChainId) -> WorldId ---
 
 	/// Get the number of segments on this chain
-	Chain_GetSegmentCount :: proc(chainId: ChainId) -> i32 ---
+	Chain_GetSegmentCount :: proc(chainId: ChainId) -> c.int ---
 
 	/// Fill a user array with chain segment shape ids up to the specified capacity. Returns
 	/// the actual number of segments returned.
-	Chain_GetSegments :: proc(chainId: ChainId, segmentArray: ^ShapeId, capacity: i32) -> i32 ---
+	Chain_GetSegments :: proc(chainId: ChainId, segmentArray: ^ShapeId, capacity: c.int) -> c.int ---
 
 	/// Set the chain friction
 	/// @see b2ChainDef::friction
-	Chain_SetFriction :: proc(chainId: ChainId, friction: f32) ---
+	Chain_SetFriction :: proc(chainId: ChainId, friction: c.float) ---
 
 	/// Get the chain friction
-	Chain_GetFriction :: proc(chainId: ChainId) -> f32 ---
+	Chain_GetFriction :: proc(chainId: ChainId) -> c.float ---
 
 	/// Set the chain restitution (bounciness)
 	/// @see b2ChainDef::restitution
-	Chain_SetRestitution :: proc(chainId: ChainId, restitution: f32) ---
+	Chain_SetRestitution :: proc(chainId: ChainId, restitution: c.float) ---
 
 	/// Get the chain restitution
-	Chain_GetRestitution :: proc(chainId: ChainId) -> f32 ---
+	Chain_GetRestitution :: proc(chainId: ChainId) -> c.float ---
 
 	/// Set the chain material
 	/// @see b2ChainDef::material
-	Chain_SetMaterial :: proc(chainId: ChainId, material: i32) ---
+	Chain_SetMaterial :: proc(chainId: ChainId, material: c.int) ---
 
 	/// Get the chain material
-	Chain_GetMaterial :: proc(chainId: ChainId) -> i32 ---
+	Chain_GetMaterial :: proc(chainId: ChainId) -> c.int ---
 
 	/// Chain identifier validation. Provides validation for up to 64K allocations.
-	Chain_IsValid :: proc(id: ChainId) -> bool ---
+	Chain_IsValid :: proc(id: ChainId) -> c.bool ---
 
 	/// Destroy a joint
 	DestroyJoint :: proc(jointId: JointId) ---
 
 	/// Joint identifier validation. Provides validation for up to 64K allocations.
-	Joint_IsValid :: proc(id: JointId) -> bool ---
+	Joint_IsValid :: proc(id: JointId) -> c.bool ---
 
 	/// Get the joint type
 	Joint_GetType :: proc(jointId: JointId) -> JointType ---
@@ -704,10 +704,10 @@ foreign lib {
 	Joint_GetLocalAnchorB :: proc(jointId: JointId) -> Vec2 ---
 
 	/// Toggle collision between connected bodies
-	Joint_SetCollideConnected :: proc(jointId: JointId, shouldCollide: bool) ---
+	Joint_SetCollideConnected :: proc(jointId: JointId, shouldCollide: c.bool) ---
 
 	/// Is collision allowed between connected bodies?
-	Joint_GetCollideConnected :: proc(jointId: JointId) -> bool ---
+	Joint_GetCollideConnected :: proc(jointId: JointId) -> c.bool ---
 
 	/// Set the user data on a joint
 	Joint_SetUserData :: proc(jointId: JointId, userData: rawptr) ---
@@ -722,7 +722,7 @@ foreign lib {
 	Joint_GetConstraintForce :: proc(jointId: JointId) -> Vec2 ---
 
 	/// Get the current constraint torque for this joint. Usually in Newton * meters.
-	Joint_GetConstraintTorque :: proc(jointId: JointId) -> f32 ---
+	Joint_GetConstraintTorque :: proc(jointId: JointId) -> c.float ---
 
 	/// Create a distance joint
 	/// @see b2DistanceJointDef for details
@@ -731,68 +731,68 @@ foreign lib {
 	/// Set the rest length of a distance joint
 	/// @param jointId The id for a distance joint
 	/// @param length The new distance joint length
-	DistanceJoint_SetLength :: proc(jointId: JointId, length: f32) ---
+	DistanceJoint_SetLength :: proc(jointId: JointId, length: c.float) ---
 
 	/// Get the rest length of a distance joint
-	DistanceJoint_GetLength :: proc(jointId: JointId) -> f32 ---
+	DistanceJoint_GetLength :: proc(jointId: JointId) -> c.float ---
 
 	/// Enable/disable the distance joint spring. When disabled the distance joint is rigid.
-	DistanceJoint_EnableSpring :: proc(jointId: JointId, enableSpring: bool) ---
+	DistanceJoint_EnableSpring :: proc(jointId: JointId, enableSpring: c.bool) ---
 
 	/// Is the distance joint spring enabled?
-	DistanceJoint_IsSpringEnabled :: proc(jointId: JointId) -> bool ---
+	DistanceJoint_IsSpringEnabled :: proc(jointId: JointId) -> c.bool ---
 
 	/// Set the spring stiffness in Hertz
-	DistanceJoint_SetSpringHertz :: proc(jointId: JointId, hertz: f32) ---
+	DistanceJoint_SetSpringHertz :: proc(jointId: JointId, hertz: c.float) ---
 
 	/// Set the spring damping ratio, non-dimensional
-	DistanceJoint_SetSpringDampingRatio :: proc(jointId: JointId, dampingRatio: f32) ---
+	DistanceJoint_SetSpringDampingRatio :: proc(jointId: JointId, dampingRatio: c.float) ---
 
 	/// Get the spring Hertz
-	DistanceJoint_GetSpringHertz :: proc(jointId: JointId) -> f32 ---
+	DistanceJoint_GetSpringHertz :: proc(jointId: JointId) -> c.float ---
 
 	/// Get the spring damping ratio
-	DistanceJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> f32 ---
+	DistanceJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> c.float ---
 
 	/// Enable joint limit. The limit only works if the joint spring is enabled. Otherwise the joint is rigid
 	/// and the limit has no effect.
-	DistanceJoint_EnableLimit :: proc(jointId: JointId, enableLimit: bool) ---
+	DistanceJoint_EnableLimit :: proc(jointId: JointId, enableLimit: c.bool) ---
 
 	/// Is the distance joint limit enabled?
-	DistanceJoint_IsLimitEnabled :: proc(jointId: JointId) -> bool ---
+	DistanceJoint_IsLimitEnabled :: proc(jointId: JointId) -> c.bool ---
 
 	/// Set the minimum and maximum length parameters of a distance joint
-	DistanceJoint_SetLengthRange :: proc(jointId: JointId, minLength: f32, maxLength: f32) ---
+	DistanceJoint_SetLengthRange :: proc(jointId: JointId, minLength: c.float, maxLength: c.float) ---
 
 	/// Get the distance joint minimum length
-	DistanceJoint_GetMinLength :: proc(jointId: JointId) -> f32 ---
+	DistanceJoint_GetMinLength :: proc(jointId: JointId) -> c.float ---
 
 	/// Get the distance joint maximum length
-	DistanceJoint_GetMaxLength :: proc(jointId: JointId) -> f32 ---
+	DistanceJoint_GetMaxLength :: proc(jointId: JointId) -> c.float ---
 
 	/// Get the current length of a distance joint
-	DistanceJoint_GetCurrentLength :: proc(jointId: JointId) -> f32 ---
+	DistanceJoint_GetCurrentLength :: proc(jointId: JointId) -> c.float ---
 
 	/// Enable/disable the distance joint motor
-	DistanceJoint_EnableMotor :: proc(jointId: JointId, enableMotor: bool) ---
+	DistanceJoint_EnableMotor :: proc(jointId: JointId, enableMotor: c.bool) ---
 
 	/// Is the distance joint motor enabled?
-	DistanceJoint_IsMotorEnabled :: proc(jointId: JointId) -> bool ---
+	DistanceJoint_IsMotorEnabled :: proc(jointId: JointId) -> c.bool ---
 
 	/// Set the distance joint motor speed, usually in meters per second
-	DistanceJoint_SetMotorSpeed :: proc(jointId: JointId, motorSpeed: f32) ---
+	DistanceJoint_SetMotorSpeed :: proc(jointId: JointId, motorSpeed: c.float) ---
 
 	/// Get the distance joint motor speed, usually in meters per second
-	DistanceJoint_GetMotorSpeed :: proc(jointId: JointId) -> f32 ---
+	DistanceJoint_GetMotorSpeed :: proc(jointId: JointId) -> c.float ---
 
 	/// Set the distance joint maximum motor force, usually in newtons
-	DistanceJoint_SetMaxMotorForce :: proc(jointId: JointId, force: f32) ---
+	DistanceJoint_SetMaxMotorForce :: proc(jointId: JointId, force: c.float) ---
 
 	/// Get the distance joint maximum motor force, usually in newtons
-	DistanceJoint_GetMaxMotorForce :: proc(jointId: JointId) -> f32 ---
+	DistanceJoint_GetMaxMotorForce :: proc(jointId: JointId) -> c.float ---
 
 	/// Get the distance joint current motor force, usually in newtons
-	DistanceJoint_GetMotorForce :: proc(jointId: JointId) -> f32 ---
+	DistanceJoint_GetMotorForce :: proc(jointId: JointId) -> c.float ---
 
 	/// Create a motor joint
 	/// @see b2MotorJointDef for details
@@ -805,28 +805,28 @@ foreign lib {
 	MotorJoint_GetLinearOffset :: proc(jointId: JointId) -> Vec2 ---
 
 	/// Set the motor joint angular offset target in radians
-	MotorJoint_SetAngularOffset :: proc(jointId: JointId, angularOffset: f32) ---
+	MotorJoint_SetAngularOffset :: proc(jointId: JointId, angularOffset: c.float) ---
 
 	/// Get the motor joint angular offset target in radians
-	MotorJoint_GetAngularOffset :: proc(jointId: JointId) -> f32 ---
+	MotorJoint_GetAngularOffset :: proc(jointId: JointId) -> c.float ---
 
 	/// Set the motor joint maximum force, usually in newtons
-	MotorJoint_SetMaxForce :: proc(jointId: JointId, maxForce: f32) ---
+	MotorJoint_SetMaxForce :: proc(jointId: JointId, maxForce: c.float) ---
 
 	/// Get the motor joint maximum force, usually in newtons
-	MotorJoint_GetMaxForce :: proc(jointId: JointId) -> f32 ---
+	MotorJoint_GetMaxForce :: proc(jointId: JointId) -> c.float ---
 
 	/// Set the motor joint maximum torque, usually in newton-meters
-	MotorJoint_SetMaxTorque :: proc(jointId: JointId, maxTorque: f32) ---
+	MotorJoint_SetMaxTorque :: proc(jointId: JointId, maxTorque: c.float) ---
 
 	/// Get the motor joint maximum torque, usually in newton-meters
-	MotorJoint_GetMaxTorque :: proc(jointId: JointId) -> f32 ---
+	MotorJoint_GetMaxTorque :: proc(jointId: JointId) -> c.float ---
 
 	/// Set the motor joint correction factor, usually in [0, 1]
-	MotorJoint_SetCorrectionFactor :: proc(jointId: JointId, correctionFactor: f32) ---
+	MotorJoint_SetCorrectionFactor :: proc(jointId: JointId, correctionFactor: c.float) ---
 
 	/// Get the motor joint correction factor, usually in [0, 1]
-	MotorJoint_GetCorrectionFactor :: proc(jointId: JointId) -> f32 ---
+	MotorJoint_GetCorrectionFactor :: proc(jointId: JointId) -> c.float ---
 
 	/// Create a mouse joint
 	/// @see b2MouseJointDef for details
@@ -839,22 +839,22 @@ foreign lib {
 	MouseJoint_GetTarget :: proc(jointId: JointId) -> Vec2 ---
 
 	/// Set the mouse joint spring stiffness in Hertz
-	MouseJoint_SetSpringHertz :: proc(jointId: JointId, hertz: f32) ---
+	MouseJoint_SetSpringHertz :: proc(jointId: JointId, hertz: c.float) ---
 
 	/// Get the mouse joint spring stiffness in Hertz
-	MouseJoint_GetSpringHertz :: proc(jointId: JointId) -> f32 ---
+	MouseJoint_GetSpringHertz :: proc(jointId: JointId) -> c.float ---
 
 	/// Set the mouse joint spring damping ratio, non-dimensional
-	MouseJoint_SetSpringDampingRatio :: proc(jointId: JointId, dampingRatio: f32) ---
+	MouseJoint_SetSpringDampingRatio :: proc(jointId: JointId, dampingRatio: c.float) ---
 
 	/// Get the mouse joint damping ratio, non-dimensional
-	MouseJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> f32 ---
+	MouseJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> c.float ---
 
 	/// Set the mouse joint maximum force, usually in newtons
-	MouseJoint_SetMaxForce :: proc(jointId: JointId, maxForce: f32) ---
+	MouseJoint_SetMaxForce :: proc(jointId: JointId, maxForce: c.float) ---
 
 	/// Get the mouse joint maximum force, usually in newtons
-	MouseJoint_GetMaxForce :: proc(jointId: JointId) -> f32 ---
+	MouseJoint_GetMaxForce :: proc(jointId: JointId) -> c.float ---
 
 	/// Create a null joint.
 	/// @see b2NullJointDef for details
@@ -865,218 +865,218 @@ foreign lib {
 	CreatePrismaticJoint :: proc(worldId: WorldId, def: ^PrismaticJointDef) -> JointId ---
 
 	/// Enable/disable the joint spring.
-	PrismaticJoint_EnableSpring :: proc(jointId: JointId, enableSpring: bool) ---
+	PrismaticJoint_EnableSpring :: proc(jointId: JointId, enableSpring: c.bool) ---
 
 	/// Is the prismatic joint spring enabled or not?
-	PrismaticJoint_IsSpringEnabled :: proc(jointId: JointId) -> bool ---
+	PrismaticJoint_IsSpringEnabled :: proc(jointId: JointId) -> c.bool ---
 
 	/// Set the prismatic joint stiffness in Hertz.
 	/// This should usually be less than a quarter of the simulation rate. For example, if the simulation
 	/// runs at 60Hz then the joint stiffness should be 15Hz or less.
-	PrismaticJoint_SetSpringHertz :: proc(jointId: JointId, hertz: f32) ---
+	PrismaticJoint_SetSpringHertz :: proc(jointId: JointId, hertz: c.float) ---
 
 	/// Get the prismatic joint stiffness in Hertz
-	PrismaticJoint_GetSpringHertz :: proc(jointId: JointId) -> f32 ---
+	PrismaticJoint_GetSpringHertz :: proc(jointId: JointId) -> c.float ---
 
 	/// Set the prismatic joint damping ratio (non-dimensional)
-	PrismaticJoint_SetSpringDampingRatio :: proc(jointId: JointId, dampingRatio: f32) ---
+	PrismaticJoint_SetSpringDampingRatio :: proc(jointId: JointId, dampingRatio: c.float) ---
 
 	/// Get the prismatic spring damping ratio (non-dimensional)
-	PrismaticJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> f32 ---
+	PrismaticJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> c.float ---
 
 	/// Enable/disable a prismatic joint limit
-	PrismaticJoint_EnableLimit :: proc(jointId: JointId, enableLimit: bool) ---
+	PrismaticJoint_EnableLimit :: proc(jointId: JointId, enableLimit: c.bool) ---
 
 	/// Is the prismatic joint limit enabled?
-	PrismaticJoint_IsLimitEnabled :: proc(jointId: JointId) -> bool ---
+	PrismaticJoint_IsLimitEnabled :: proc(jointId: JointId) -> c.bool ---
 
 	/// Get the prismatic joint lower limit
-	PrismaticJoint_GetLowerLimit :: proc(jointId: JointId) -> f32 ---
+	PrismaticJoint_GetLowerLimit :: proc(jointId: JointId) -> c.float ---
 
 	/// Get the prismatic joint upper limit
-	PrismaticJoint_GetUpperLimit :: proc(jointId: JointId) -> f32 ---
+	PrismaticJoint_GetUpperLimit :: proc(jointId: JointId) -> c.float ---
 
 	/// Set the prismatic joint limits
-	PrismaticJoint_SetLimits :: proc(jointId: JointId, lower: f32, upper: f32) ---
+	PrismaticJoint_SetLimits :: proc(jointId: JointId, lower: c.float, upper: c.float) ---
 
 	/// Enable/disable a prismatic joint motor
-	PrismaticJoint_EnableMotor :: proc(jointId: JointId, enableMotor: bool) ---
+	PrismaticJoint_EnableMotor :: proc(jointId: JointId, enableMotor: c.bool) ---
 
 	/// Is the prismatic joint motor enabled?
-	PrismaticJoint_IsMotorEnabled :: proc(jointId: JointId) -> bool ---
+	PrismaticJoint_IsMotorEnabled :: proc(jointId: JointId) -> c.bool ---
 
 	/// Set the prismatic joint motor speed, usually in meters per second
-	PrismaticJoint_SetMotorSpeed :: proc(jointId: JointId, motorSpeed: f32) ---
+	PrismaticJoint_SetMotorSpeed :: proc(jointId: JointId, motorSpeed: c.float) ---
 
 	/// Get the prismatic joint motor speed, usually in meters per second
-	PrismaticJoint_GetMotorSpeed :: proc(jointId: JointId) -> f32 ---
+	PrismaticJoint_GetMotorSpeed :: proc(jointId: JointId) -> c.float ---
 
 	/// Set the prismatic joint maximum motor force, usually in newtons
-	PrismaticJoint_SetMaxMotorForce :: proc(jointId: JointId, force: f32) ---
+	PrismaticJoint_SetMaxMotorForce :: proc(jointId: JointId, force: c.float) ---
 
 	/// Get the prismatic joint maximum motor force, usually in newtons
-	PrismaticJoint_GetMaxMotorForce :: proc(jointId: JointId) -> f32 ---
+	PrismaticJoint_GetMaxMotorForce :: proc(jointId: JointId) -> c.float ---
 
 	/// Get the prismatic joint current motor force, usually in newtons
-	PrismaticJoint_GetMotorForce :: proc(jointId: JointId) -> f32 ---
+	PrismaticJoint_GetMotorForce :: proc(jointId: JointId) -> c.float ---
 
 	/// Get the current joint translation, usually in meters.
-	PrismaticJoint_GetTranslation :: proc(jointId: JointId) -> f32 ---
+	PrismaticJoint_GetTranslation :: proc(jointId: JointId) -> c.float ---
 
 	/// Get the current joint translation speed, usually in meters per second.
-	PrismaticJoint_GetSpeed :: proc(jointId: JointId) -> f32 ---
+	PrismaticJoint_GetSpeed :: proc(jointId: JointId) -> c.float ---
 
 	/// Create a revolute joint
 	/// @see b2RevoluteJointDef for details
 	CreateRevoluteJoint :: proc(worldId: WorldId, def: ^RevoluteJointDef) -> JointId ---
 
 	/// Enable/disable the revolute joint spring
-	RevoluteJoint_EnableSpring :: proc(jointId: JointId, enableSpring: bool) ---
+	RevoluteJoint_EnableSpring :: proc(jointId: JointId, enableSpring: c.bool) ---
 
 	/// It the revolute angular spring enabled?
-	RevoluteJoint_IsSpringEnabled :: proc(jointId: JointId) -> bool ---
+	RevoluteJoint_IsSpringEnabled :: proc(jointId: JointId) -> c.bool ---
 
 	/// Set the revolute joint spring stiffness in Hertz
-	RevoluteJoint_SetSpringHertz :: proc(jointId: JointId, hertz: f32) ---
+	RevoluteJoint_SetSpringHertz :: proc(jointId: JointId, hertz: c.float) ---
 
 	/// Get the revolute joint spring stiffness in Hertz
-	RevoluteJoint_GetSpringHertz :: proc(jointId: JointId) -> f32 ---
+	RevoluteJoint_GetSpringHertz :: proc(jointId: JointId) -> c.float ---
 
 	/// Set the revolute joint spring damping ratio, non-dimensional
-	RevoluteJoint_SetSpringDampingRatio :: proc(jointId: JointId, dampingRatio: f32) ---
+	RevoluteJoint_SetSpringDampingRatio :: proc(jointId: JointId, dampingRatio: c.float) ---
 
 	/// Get the revolute joint spring damping ratio, non-dimensional
-	RevoluteJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> f32 ---
+	RevoluteJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> c.float ---
 
 	/// Get the revolute joint current angle in radians relative to the reference angle
 	/// @see b2RevoluteJointDef::referenceAngle
-	RevoluteJoint_GetAngle :: proc(jointId: JointId) -> f32 ---
+	RevoluteJoint_GetAngle :: proc(jointId: JointId) -> c.float ---
 
 	/// Enable/disable the revolute joint limit
-	RevoluteJoint_EnableLimit :: proc(jointId: JointId, enableLimit: bool) ---
+	RevoluteJoint_EnableLimit :: proc(jointId: JointId, enableLimit: c.bool) ---
 
 	/// Is the revolute joint limit enabled?
-	RevoluteJoint_IsLimitEnabled :: proc(jointId: JointId) -> bool ---
+	RevoluteJoint_IsLimitEnabled :: proc(jointId: JointId) -> c.bool ---
 
 	/// Get the revolute joint lower limit in radians
-	RevoluteJoint_GetLowerLimit :: proc(jointId: JointId) -> f32 ---
+	RevoluteJoint_GetLowerLimit :: proc(jointId: JointId) -> c.float ---
 
 	/// Get the revolute joint upper limit in radians
-	RevoluteJoint_GetUpperLimit :: proc(jointId: JointId) -> f32 ---
+	RevoluteJoint_GetUpperLimit :: proc(jointId: JointId) -> c.float ---
 
 	/// Set the revolute joint limits in radians
-	RevoluteJoint_SetLimits :: proc(jointId: JointId, lower: f32, upper: f32) ---
+	RevoluteJoint_SetLimits :: proc(jointId: JointId, lower: c.float, upper: c.float) ---
 
 	/// Enable/disable a revolute joint motor
-	RevoluteJoint_EnableMotor :: proc(jointId: JointId, enableMotor: bool) ---
+	RevoluteJoint_EnableMotor :: proc(jointId: JointId, enableMotor: c.bool) ---
 
 	/// Is the revolute joint motor enabled?
-	RevoluteJoint_IsMotorEnabled :: proc(jointId: JointId) -> bool ---
+	RevoluteJoint_IsMotorEnabled :: proc(jointId: JointId) -> c.bool ---
 
 	/// Set the revolute joint motor speed in radians per second
-	RevoluteJoint_SetMotorSpeed :: proc(jointId: JointId, motorSpeed: f32) ---
+	RevoluteJoint_SetMotorSpeed :: proc(jointId: JointId, motorSpeed: c.float) ---
 
 	/// Get the revolute joint motor speed in radians per second
-	RevoluteJoint_GetMotorSpeed :: proc(jointId: JointId) -> f32 ---
+	RevoluteJoint_GetMotorSpeed :: proc(jointId: JointId) -> c.float ---
 
 	/// Get the revolute joint current motor torque, usually in newton-meters
-	RevoluteJoint_GetMotorTorque :: proc(jointId: JointId) -> f32 ---
+	RevoluteJoint_GetMotorTorque :: proc(jointId: JointId) -> c.float ---
 
 	/// Set the revolute joint maximum motor torque, usually in newton-meters
-	RevoluteJoint_SetMaxMotorTorque :: proc(jointId: JointId, torque: f32) ---
+	RevoluteJoint_SetMaxMotorTorque :: proc(jointId: JointId, torque: c.float) ---
 
 	/// Get the revolute joint maximum motor torque, usually in newton-meters
-	RevoluteJoint_GetMaxMotorTorque :: proc(jointId: JointId) -> f32 ---
+	RevoluteJoint_GetMaxMotorTorque :: proc(jointId: JointId) -> c.float ---
 
 	/// Create a weld joint
 	/// @see b2WeldJointDef for details
 	CreateWeldJoint :: proc(worldId: WorldId, def: ^WeldJointDef) -> JointId ---
 
 	/// Get the weld joint reference angle in radians
-	WeldJoint_GetReferenceAngle :: proc(jointId: JointId) -> f32 ---
+	WeldJoint_GetReferenceAngle :: proc(jointId: JointId) -> c.float ---
 
 	/// Set the weld joint reference angle in radians, must be in [-pi,pi].
-	WeldJoint_SetReferenceAngle :: proc(jointId: JointId, angleInRadians: f32) ---
+	WeldJoint_SetReferenceAngle :: proc(jointId: JointId, angleInRadians: c.float) ---
 
 	/// Set the weld joint linear stiffness in Hertz. 0 is rigid.
-	WeldJoint_SetLinearHertz :: proc(jointId: JointId, hertz: f32) ---
+	WeldJoint_SetLinearHertz :: proc(jointId: JointId, hertz: c.float) ---
 
 	/// Get the weld joint linear stiffness in Hertz
-	WeldJoint_GetLinearHertz :: proc(jointId: JointId) -> f32 ---
+	WeldJoint_GetLinearHertz :: proc(jointId: JointId) -> c.float ---
 
 	/// Set the weld joint linear damping ratio (non-dimensional)
-	WeldJoint_SetLinearDampingRatio :: proc(jointId: JointId, dampingRatio: f32) ---
+	WeldJoint_SetLinearDampingRatio :: proc(jointId: JointId, dampingRatio: c.float) ---
 
 	/// Get the weld joint linear damping ratio (non-dimensional)
-	WeldJoint_GetLinearDampingRatio :: proc(jointId: JointId) -> f32 ---
+	WeldJoint_GetLinearDampingRatio :: proc(jointId: JointId) -> c.float ---
 
 	/// Set the weld joint angular stiffness in Hertz. 0 is rigid.
-	WeldJoint_SetAngularHertz :: proc(jointId: JointId, hertz: f32) ---
+	WeldJoint_SetAngularHertz :: proc(jointId: JointId, hertz: c.float) ---
 
 	/// Get the weld joint angular stiffness in Hertz
-	WeldJoint_GetAngularHertz :: proc(jointId: JointId) -> f32 ---
+	WeldJoint_GetAngularHertz :: proc(jointId: JointId) -> c.float ---
 
 	/// Set weld joint angular damping ratio, non-dimensional
-	WeldJoint_SetAngularDampingRatio :: proc(jointId: JointId, dampingRatio: f32) ---
+	WeldJoint_SetAngularDampingRatio :: proc(jointId: JointId, dampingRatio: c.float) ---
 
 	/// Get the weld joint angular damping ratio, non-dimensional
-	WeldJoint_GetAngularDampingRatio :: proc(jointId: JointId) -> f32 ---
+	WeldJoint_GetAngularDampingRatio :: proc(jointId: JointId) -> c.float ---
 
 	/// Create a wheel joint
 	/// @see b2WheelJointDef for details
 	CreateWheelJoint :: proc(worldId: WorldId, def: ^WheelJointDef) -> JointId ---
 
 	/// Enable/disable the wheel joint spring
-	WheelJoint_EnableSpring :: proc(jointId: JointId, enableSpring: bool) ---
+	WheelJoint_EnableSpring :: proc(jointId: JointId, enableSpring: c.bool) ---
 
 	/// Is the wheel joint spring enabled?
-	WheelJoint_IsSpringEnabled :: proc(jointId: JointId) -> bool ---
+	WheelJoint_IsSpringEnabled :: proc(jointId: JointId) -> c.bool ---
 
 	/// Set the wheel joint stiffness in Hertz
-	WheelJoint_SetSpringHertz :: proc(jointId: JointId, hertz: f32) ---
+	WheelJoint_SetSpringHertz :: proc(jointId: JointId, hertz: c.float) ---
 
 	/// Get the wheel joint stiffness in Hertz
-	WheelJoint_GetSpringHertz :: proc(jointId: JointId) -> f32 ---
+	WheelJoint_GetSpringHertz :: proc(jointId: JointId) -> c.float ---
 
 	/// Set the wheel joint damping ratio, non-dimensional
-	WheelJoint_SetSpringDampingRatio :: proc(jointId: JointId, dampingRatio: f32) ---
+	WheelJoint_SetSpringDampingRatio :: proc(jointId: JointId, dampingRatio: c.float) ---
 
 	/// Get the wheel joint damping ratio, non-dimensional
-	WheelJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> f32 ---
+	WheelJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> c.float ---
 
 	/// Enable/disable the wheel joint limit
-	WheelJoint_EnableLimit :: proc(jointId: JointId, enableLimit: bool) ---
+	WheelJoint_EnableLimit :: proc(jointId: JointId, enableLimit: c.bool) ---
 
 	/// Is the wheel joint limit enabled?
-	WheelJoint_IsLimitEnabled :: proc(jointId: JointId) -> bool ---
+	WheelJoint_IsLimitEnabled :: proc(jointId: JointId) -> c.bool ---
 
 	/// Get the wheel joint lower limit
-	WheelJoint_GetLowerLimit :: proc(jointId: JointId) -> f32 ---
+	WheelJoint_GetLowerLimit :: proc(jointId: JointId) -> c.float ---
 
 	/// Get the wheel joint upper limit
-	WheelJoint_GetUpperLimit :: proc(jointId: JointId) -> f32 ---
+	WheelJoint_GetUpperLimit :: proc(jointId: JointId) -> c.float ---
 
 	/// Set the wheel joint limits
-	WheelJoint_SetLimits :: proc(jointId: JointId, lower: f32, upper: f32) ---
+	WheelJoint_SetLimits :: proc(jointId: JointId, lower: c.float, upper: c.float) ---
 
 	/// Enable/disable the wheel joint motor
-	WheelJoint_EnableMotor :: proc(jointId: JointId, enableMotor: bool) ---
+	WheelJoint_EnableMotor :: proc(jointId: JointId, enableMotor: c.bool) ---
 
 	/// Is the wheel joint motor enabled?
-	WheelJoint_IsMotorEnabled :: proc(jointId: JointId) -> bool ---
+	WheelJoint_IsMotorEnabled :: proc(jointId: JointId) -> c.bool ---
 
 	/// Set the wheel joint motor speed in radians per second
-	WheelJoint_SetMotorSpeed :: proc(jointId: JointId, motorSpeed: f32) ---
+	WheelJoint_SetMotorSpeed :: proc(jointId: JointId, motorSpeed: c.float) ---
 
 	/// Get the wheel joint motor speed in radians per second
-	WheelJoint_GetMotorSpeed :: proc(jointId: JointId) -> f32 ---
+	WheelJoint_GetMotorSpeed :: proc(jointId: JointId) -> c.float ---
 
 	/// Set the wheel joint maximum motor torque, usually in newton-meters
-	WheelJoint_SetMaxMotorTorque :: proc(jointId: JointId, torque: f32) ---
+	WheelJoint_SetMaxMotorTorque :: proc(jointId: JointId, torque: c.float) ---
 
 	/// Get the wheel joint maximum motor torque, usually in newton-meters
-	WheelJoint_GetMaxMotorTorque :: proc(jointId: JointId) -> f32 ---
+	WheelJoint_GetMaxMotorTorque :: proc(jointId: JointId) -> c.float ---
 
 	/// Get the wheel joint current motor torque, usually in newton-meters
-	WheelJoint_GetMotorTorque :: proc(jointId: JointId) -> f32 ---
+	WheelJoint_GetMotorTorque :: proc(jointId: JointId) -> c.float ---
 }

--- a/examples/box2d/box2d/box2d.odin
+++ b/examples/box2d/box2d/box2d.odin
@@ -19,13 +19,13 @@ foreign lib {
 	DestroyWorld :: proc(worldId: WorldId) ---
 
 	/// World id validation. Provides validation for up to 64K allocations.
-	World_IsValid :: proc(id: WorldId) -> c.bool ---
+	World_IsValid :: proc(id: WorldId) -> bool ---
 
 	/// Simulate a world for one time step. This performs collision detection, integration, and constraint solution.
 	/// @param worldId The world to simulate
 	/// @param timeStep The amount of time to simulate, this should be a fixed number. Usually 1/60.
 	/// @param subStepCount The number of sub-steps, increasing the sub-step count can increase accuracy. Usually 4.
-	World_Step :: proc(worldId: WorldId, timeStep: c.float, subStepCount: c.int) ---
+	World_Step :: proc(worldId: WorldId, timeStep: f32, subStepCount: c.int) ---
 
 	/// Call this to draw shapes and other debug draw data
 	World_Draw :: proc(worldId: WorldId, draw: ^DebugDraw) ---
@@ -86,35 +86,35 @@ foreign lib {
 	/// Enable/disable sleep. If your application does not need sleeping, you can gain some performance
 	/// by disabling sleep completely at the world level.
 	/// @see b2WorldDef
-	World_EnableSleeping :: proc(worldId: WorldId, flag: c.bool) ---
+	World_EnableSleeping :: proc(worldId: WorldId, flag: bool) ---
 
 	/// Is body sleeping enabled?
-	World_IsSleepingEnabled :: proc(worldId: WorldId) -> c.bool ---
+	World_IsSleepingEnabled :: proc(worldId: WorldId) -> bool ---
 
 	/// Enable/disable continuous collision between dynamic and static bodies. Generally you should keep continuous
 	/// collision enabled to prevent fast moving objects from going through static objects. The performance gain from
 	/// disabling continuous collision is minor.
 	/// @see b2WorldDef
-	World_EnableContinuous :: proc(worldId: WorldId, flag: c.bool) ---
+	World_EnableContinuous :: proc(worldId: WorldId, flag: bool) ---
 
 	/// Is continuous collision enabled?
-	World_IsContinuousEnabled :: proc(worldId: WorldId) -> c.bool ---
+	World_IsContinuousEnabled :: proc(worldId: WorldId) -> bool ---
 
 	/// Adjust the restitution threshold. It is recommended not to make this value very small
 	/// because it will prevent bodies from sleeping. Usually in meters per second.
 	/// @see b2WorldDef
-	World_SetRestitutionThreshold :: proc(worldId: WorldId, value: c.float) ---
+	World_SetRestitutionThreshold :: proc(worldId: WorldId, value: f32) ---
 
 	/// Get the the restitution speed threshold. Usually in meters per second.
-	World_GetRestitutionThreshold :: proc(worldId: WorldId) -> c.float ---
+	World_GetRestitutionThreshold :: proc(worldId: WorldId) -> f32 ---
 
 	/// Adjust the hit event threshold. This controls the collision speed needed to generate a b2ContactHitEvent.
 	/// Usually in meters per second.
 	/// @see b2WorldDef::hitEventThreshold
-	World_SetHitEventThreshold :: proc(worldId: WorldId, value: c.float) ---
+	World_SetHitEventThreshold :: proc(worldId: WorldId, value: f32) ---
 
 	/// Get the the hit event speed threshold. Usually in meters per second.
-	World_GetHitEventThreshold :: proc(worldId: WorldId) -> c.float ---
+	World_GetHitEventThreshold :: proc(worldId: WorldId) -> f32 ---
 
 	/// Register the custom filter callback. This is optional.
 	World_SetCustomFilterCallback :: proc(worldId: WorldId, fcn: ^CustomFilterFcn, _context: rawptr) ---
@@ -141,27 +141,27 @@ foreign lib {
 	/// @param dampingRatio The contact bounciness with 1 being critical damping (non-dimensional)
 	/// @param pushSpeed The maximum contact constraint push out speed (meters per second)
 	/// @note Advanced feature
-	World_SetContactTuning :: proc(worldId: WorldId, hertz: c.float, dampingRatio: c.float, pushSpeed: c.float) ---
+	World_SetContactTuning :: proc(worldId: WorldId, hertz: f32, dampingRatio: f32, pushSpeed: f32) ---
 
 	/// Adjust joint tuning parameters
 	/// @param worldId The world id
 	/// @param hertz The contact stiffness (cycles per second)
 	/// @param dampingRatio The contact bounciness with 1 being critical damping (non-dimensional)
 	/// @note Advanced feature
-	World_SetJointTuning :: proc(worldId: WorldId, hertz: c.float, dampingRatio: c.float) ---
+	World_SetJointTuning :: proc(worldId: WorldId, hertz: f32, dampingRatio: f32) ---
 
 	/// Set the maximum linear speed. Usually in m/s.
-	World_SetMaximumLinearSpeed :: proc(worldId: WorldId, maximumLinearSpeed: c.float) ---
+	World_SetMaximumLinearSpeed :: proc(worldId: WorldId, maximumLinearSpeed: f32) ---
 
 	/// Get the maximum linear speed. Usually in m/s.
-	World_GetMaximumLinearSpeed :: proc(worldId: WorldId) -> c.float ---
+	World_GetMaximumLinearSpeed :: proc(worldId: WorldId) -> f32 ---
 
 	/// Enable/disable constraint warm starting. Advanced feature for testing. Disabling
 	/// sleeping greatly reduces stability and provides no performance gain.
-	World_EnableWarmStarting :: proc(worldId: WorldId, flag: c.bool) ---
+	World_EnableWarmStarting :: proc(worldId: WorldId, flag: bool) ---
 
 	/// Is constraint warm starting enabled?
-	World_IsWarmStartingEnabled :: proc(worldId: WorldId) -> c.bool ---
+	World_IsWarmStartingEnabled :: proc(worldId: WorldId) -> bool ---
 
 	/// Get the number of awake bodies.
 	World_GetAwakeBodyCount :: proc(worldId: WorldId) -> c.int ---
@@ -191,7 +191,7 @@ foreign lib {
 	World_RebuildStaticTree :: proc(worldId: WorldId) ---
 
 	/// This is for internal testing
-	World_EnableSpeculative :: proc(worldId: WorldId, flag: c.bool) ---
+	World_EnableSpeculative :: proc(worldId: WorldId, flag: bool) ---
 
 	/// Create a rigid body given a definition. No reference to the definition is retained. So you can create the definition
 	/// on the stack and pass it as a pointer.
@@ -207,7 +207,7 @@ foreign lib {
 	DestroyBody :: proc(bodyId: BodyId) ---
 
 	/// Body identifier validation. Can be used to detect orphaned ids. Provides validation for up to 64K allocations.
-	Body_IsValid :: proc(id: BodyId) -> c.bool ---
+	Body_IsValid :: proc(id: BodyId) -> bool ---
 
 	/// Get the body type: static, kinematic, or dynamic
 	Body_GetType :: proc(bodyId: BodyId) -> BodyType ---
@@ -258,13 +258,13 @@ foreign lib {
 	Body_GetLinearVelocity :: proc(bodyId: BodyId) -> Vec2 ---
 
 	/// Get the angular velocity of a body in radians per second
-	Body_GetAngularVelocity :: proc(bodyId: BodyId) -> c.float ---
+	Body_GetAngularVelocity :: proc(bodyId: BodyId) -> f32 ---
 
 	/// Set the linear velocity of a body. Usually in meters per second.
 	Body_SetLinearVelocity :: proc(bodyId: BodyId, linearVelocity: Vec2) ---
 
 	/// Set the angular velocity of a body in radians per second
-	Body_SetAngularVelocity :: proc(bodyId: BodyId, angularVelocity: c.float) ---
+	Body_SetAngularVelocity :: proc(bodyId: BodyId, angularVelocity: f32) ---
 
 	/// Get the linear velocity of a local point attached to a body. Usually in meters per second.
 	Body_GetLocalPointVelocity :: proc(bodyId: BodyId, localPoint: Vec2) -> Vec2 ---
@@ -279,21 +279,21 @@ foreign lib {
 	/// @param force The world force vector, usually in newtons (N)
 	/// @param point The world position of the point of application
 	/// @param wake Option to wake up the body
-	Body_ApplyForce :: proc(bodyId: BodyId, force: Vec2, point: Vec2, wake: c.bool) ---
+	Body_ApplyForce :: proc(bodyId: BodyId, force: Vec2, point: Vec2, wake: bool) ---
 
 	/// Apply a force to the center of mass. This optionally wakes up the body.
 	/// The force is ignored if the body is not awake.
 	/// @param bodyId The body id
 	/// @param force the world force vector, usually in newtons (N).
 	/// @param wake also wake up the body
-	Body_ApplyForceToCenter :: proc(bodyId: BodyId, force: Vec2, wake: c.bool) ---
+	Body_ApplyForceToCenter :: proc(bodyId: BodyId, force: Vec2, wake: bool) ---
 
 	/// Apply a torque. This affects the angular velocity without affecting the linear velocity.
 	/// This optionally wakes the body. The torque is ignored if the body is not awake.
 	/// @param bodyId The body id
 	/// @param torque about the z-axis (out of the screen), usually in N*m.
 	/// @param wake also wake up the body
-	Body_ApplyTorque :: proc(bodyId: BodyId, torque: c.float, wake: c.bool) ---
+	Body_ApplyTorque :: proc(bodyId: BodyId, torque: f32, wake: bool) ---
 
 	/// Apply an impulse at a point. This immediately modifies the velocity.
 	/// It also modifies the angular velocity if the point of application
@@ -305,7 +305,7 @@ foreign lib {
 	/// @param wake also wake up the body
 	/// @warning This should be used for one-shot impulses. If you need a steady force,
 	/// use a force instead, which will work better with the sub-stepping solver.
-	Body_ApplyLinearImpulse :: proc(bodyId: BodyId, impulse: Vec2, point: Vec2, wake: c.bool) ---
+	Body_ApplyLinearImpulse :: proc(bodyId: BodyId, impulse: Vec2, point: Vec2, wake: bool) ---
 
 	/// Apply an impulse to the center of mass. This immediately modifies the velocity.
 	/// The impulse is ignored if the body is not awake. This optionally wakes the body.
@@ -314,7 +314,7 @@ foreign lib {
 	/// @param wake also wake up the body
 	/// @warning This should be used for one-shot impulses. If you need a steady force,
 	/// use a force instead, which will work better with the sub-stepping solver.
-	Body_ApplyLinearImpulseToCenter :: proc(bodyId: BodyId, impulse: Vec2, wake: c.bool) ---
+	Body_ApplyLinearImpulseToCenter :: proc(bodyId: BodyId, impulse: Vec2, wake: bool) ---
 
 	/// Apply an angular impulse. The impulse is ignored if the body is not awake.
 	/// This optionally wakes the body.
@@ -323,13 +323,13 @@ foreign lib {
 	/// @param wake also wake up the body
 	/// @warning This should be used for one-shot impulses. If you need a steady force,
 	/// use a force instead, which will work better with the sub-stepping solver.
-	Body_ApplyAngularImpulse :: proc(bodyId: BodyId, impulse: c.float, wake: c.bool) ---
+	Body_ApplyAngularImpulse :: proc(bodyId: BodyId, impulse: f32, wake: bool) ---
 
 	/// Get the mass of the body, usually in kilograms
-	Body_GetMass :: proc(bodyId: BodyId) -> c.float ---
+	Body_GetMass :: proc(bodyId: BodyId) -> f32 ---
 
 	/// Get the rotational inertia of the body, usually in kg*m^2
-	Body_GetRotationalInertia :: proc(bodyId: BodyId) -> c.float ---
+	Body_GetRotationalInertia :: proc(bodyId: BodyId) -> f32 ---
 
 	/// Get the center of mass position of the body in local space
 	Body_GetLocalCenterOfMass :: proc(bodyId: BodyId) -> Vec2 ---
@@ -353,46 +353,46 @@ foreign lib {
 	Body_ApplyMassFromShapes :: proc(bodyId: BodyId) ---
 
 	/// Adjust the linear damping. Normally this is set in b2BodyDef before creation.
-	Body_SetLinearDamping :: proc(bodyId: BodyId, linearDamping: c.float) ---
+	Body_SetLinearDamping :: proc(bodyId: BodyId, linearDamping: f32) ---
 
 	/// Get the current linear damping.
-	Body_GetLinearDamping :: proc(bodyId: BodyId) -> c.float ---
+	Body_GetLinearDamping :: proc(bodyId: BodyId) -> f32 ---
 
 	/// Adjust the angular damping. Normally this is set in b2BodyDef before creation.
-	Body_SetAngularDamping :: proc(bodyId: BodyId, angularDamping: c.float) ---
+	Body_SetAngularDamping :: proc(bodyId: BodyId, angularDamping: f32) ---
 
 	/// Get the current angular damping.
-	Body_GetAngularDamping :: proc(bodyId: BodyId) -> c.float ---
+	Body_GetAngularDamping :: proc(bodyId: BodyId) -> f32 ---
 
 	/// Adjust the gravity scale. Normally this is set in b2BodyDef before creation.
 	/// @see b2BodyDef::gravityScale
-	Body_SetGravityScale :: proc(bodyId: BodyId, gravityScale: c.float) ---
+	Body_SetGravityScale :: proc(bodyId: BodyId, gravityScale: f32) ---
 
 	/// Get the current gravity scale
-	Body_GetGravityScale :: proc(bodyId: BodyId) -> c.float ---
+	Body_GetGravityScale :: proc(bodyId: BodyId) -> f32 ---
 
 	/// @return true if this body is awake
-	Body_IsAwake :: proc(bodyId: BodyId) -> c.bool ---
+	Body_IsAwake :: proc(bodyId: BodyId) -> bool ---
 
 	/// Wake a body from sleep. This wakes the entire island the body is touching.
 	/// @warning Putting a body to sleep will put the entire island of bodies touching this body to sleep,
 	/// which can be expensive and possibly unintuitive.
-	Body_SetAwake :: proc(bodyId: BodyId, awake: c.bool) ---
+	Body_SetAwake :: proc(bodyId: BodyId, awake: bool) ---
 
 	/// Enable or disable sleeping for this body. If sleeping is disabled the body will wake.
-	Body_EnableSleep :: proc(bodyId: BodyId, enableSleep: c.bool) ---
+	Body_EnableSleep :: proc(bodyId: BodyId, enableSleep: bool) ---
 
 	/// Returns true if sleeping is enabled for this body
-	Body_IsSleepEnabled :: proc(bodyId: BodyId) -> c.bool ---
+	Body_IsSleepEnabled :: proc(bodyId: BodyId) -> bool ---
 
 	/// Set the sleep threshold, usually in meters per second
-	Body_SetSleepThreshold :: proc(bodyId: BodyId, sleepThreshold: c.float) ---
+	Body_SetSleepThreshold :: proc(bodyId: BodyId, sleepThreshold: f32) ---
 
 	/// Get the sleep threshold, usually in meters per second.
-	Body_GetSleepThreshold :: proc(bodyId: BodyId) -> c.float ---
+	Body_GetSleepThreshold :: proc(bodyId: BodyId) -> f32 ---
 
 	/// Returns true if this body is enabled
-	Body_IsEnabled :: proc(bodyId: BodyId) -> c.bool ---
+	Body_IsEnabled :: proc(bodyId: BodyId) -> bool ---
 
 	/// Disable a body by removing it completely from the simulation. This is expensive.
 	Body_Disable :: proc(bodyId: BodyId) ---
@@ -401,26 +401,26 @@ foreign lib {
 	Body_Enable :: proc(bodyId: BodyId) ---
 
 	/// Set this body to have fixed rotation. This causes the mass to be reset in all cases.
-	Body_SetFixedRotation :: proc(bodyId: BodyId, flag: c.bool) ---
+	Body_SetFixedRotation :: proc(bodyId: BodyId, flag: bool) ---
 
 	/// Does this body have fixed rotation?
-	Body_IsFixedRotation :: proc(bodyId: BodyId) -> c.bool ---
+	Body_IsFixedRotation :: proc(bodyId: BodyId) -> bool ---
 
 	/// Set this body to be a bullet. A bullet does continuous collision detection
 	/// against dynamic bodies (but not other bullets).
-	Body_SetBullet :: proc(bodyId: BodyId, flag: c.bool) ---
+	Body_SetBullet :: proc(bodyId: BodyId, flag: bool) ---
 
 	/// Is this body a bullet?
-	Body_IsBullet :: proc(bodyId: BodyId) -> c.bool ---
+	Body_IsBullet :: proc(bodyId: BodyId) -> bool ---
 
 	/// Enable/disable contact events on all shapes.
 	/// @see b2ShapeDef::enableContactEvents
 	/// @warning changing this at runtime may cause mismatched begin/end touch events
-	Body_EnableContactEvents :: proc(bodyId: BodyId, flag: c.bool) ---
+	Body_EnableContactEvents :: proc(bodyId: BodyId, flag: bool) ---
 
 	/// Enable/disable hit events on all shapes
 	/// @see b2ShapeDef::enableHitEvents
-	Body_EnableHitEvents :: proc(bodyId: BodyId, flag: c.bool) ---
+	Body_EnableHitEvents :: proc(bodyId: BodyId, flag: bool) ---
 
 	/// Get the world that owns this body
 	Body_GetWorld :: proc(bodyId: BodyId) -> WorldId ---
@@ -475,10 +475,10 @@ foreign lib {
 	/// Destroy a shape. You may defer the body mass update which can improve performance if several shapes on a
 	///	body are destroyed at once.
 	///	@see b2Body_ApplyMassFromShapes
-	DestroyShape :: proc(shapeId: ShapeId, updateBodyMass: c.bool) ---
+	DestroyShape :: proc(shapeId: ShapeId, updateBodyMass: bool) ---
 
 	/// Shape identifier validation. Provides validation for up to 64K allocations.
-	Shape_IsValid :: proc(id: ShapeId) -> c.bool ---
+	Shape_IsValid :: proc(id: ShapeId) -> bool ---
 
 	/// Get the type of a shape
 	Shape_GetType :: proc(shapeId: ShapeId) -> ShapeType ---
@@ -490,7 +490,7 @@ foreign lib {
 	Shape_GetWorld :: proc(shapeId: ShapeId) -> WorldId ---
 
 	/// Returns true If the shape is a sensor
-	Shape_IsSensor :: proc(shapeId: ShapeId) -> c.bool ---
+	Shape_IsSensor :: proc(shapeId: ShapeId) -> bool ---
 
 	/// Set the user data for a shape
 	Shape_SetUserData :: proc(shapeId: ShapeId, userData: rawptr) ---
@@ -502,24 +502,24 @@ foreign lib {
 	/// Set the mass density of a shape, usually in kg/m^2.
 	/// This will optionally update the mass properties on the parent body.
 	/// @see b2ShapeDef::density, b2Body_ApplyMassFromShapes
-	Shape_SetDensity :: proc(shapeId: ShapeId, density: c.float, updateBodyMass: c.bool) ---
+	Shape_SetDensity :: proc(shapeId: ShapeId, density: f32, updateBodyMass: bool) ---
 
 	/// Get the density of a shape, usually in kg/m^2
-	Shape_GetDensity :: proc(shapeId: ShapeId) -> c.float ---
+	Shape_GetDensity :: proc(shapeId: ShapeId) -> f32 ---
 
 	/// Set the friction on a shape
 	/// @see b2ShapeDef::friction
-	Shape_SetFriction :: proc(shapeId: ShapeId, friction: c.float) ---
+	Shape_SetFriction :: proc(shapeId: ShapeId, friction: f32) ---
 
 	/// Get the friction of a shape
-	Shape_GetFriction :: proc(shapeId: ShapeId) -> c.float ---
+	Shape_GetFriction :: proc(shapeId: ShapeId) -> f32 ---
 
 	/// Set the shape restitution (bounciness)
 	/// @see b2ShapeDef::restitution
-	Shape_SetRestitution :: proc(shapeId: ShapeId, restitution: c.float) ---
+	Shape_SetRestitution :: proc(shapeId: ShapeId, restitution: f32) ---
 
 	/// Get the shape restitution
-	Shape_GetRestitution :: proc(shapeId: ShapeId) -> c.float ---
+	Shape_GetRestitution :: proc(shapeId: ShapeId) -> f32 ---
 
 	/// Set the shape material identifier
 	/// @see b2ShapeDef::material
@@ -540,28 +540,28 @@ foreign lib {
 	/// Enable contact events for this shape. Only applies to kinematic and dynamic bodies. Ignored for sensors.
 	/// @see b2ShapeDef::enableContactEvents
 	/// @warning changing this at run-time may lead to lost begin/end events
-	Shape_EnableContactEvents :: proc(shapeId: ShapeId, flag: c.bool) ---
+	Shape_EnableContactEvents :: proc(shapeId: ShapeId, flag: bool) ---
 
 	/// Returns true if contact events are enabled
-	Shape_AreContactEventsEnabled :: proc(shapeId: ShapeId) -> c.bool ---
+	Shape_AreContactEventsEnabled :: proc(shapeId: ShapeId) -> bool ---
 
 	/// Enable pre-solve contact events for this shape. Only applies to dynamic bodies. These are expensive
 	/// and must be carefully handled due to multithreading. Ignored for sensors.
 	/// @see b2PreSolveFcn
-	Shape_EnablePreSolveEvents :: proc(shapeId: ShapeId, flag: c.bool) ---
+	Shape_EnablePreSolveEvents :: proc(shapeId: ShapeId, flag: bool) ---
 
 	/// Returns true if pre-solve events are enabled
-	Shape_ArePreSolveEventsEnabled :: proc(shapeId: ShapeId) -> c.bool ---
+	Shape_ArePreSolveEventsEnabled :: proc(shapeId: ShapeId) -> bool ---
 
 	/// Enable contact hit events for this shape. Ignored for sensors.
 	/// @see b2WorldDef.hitEventThreshold
-	Shape_EnableHitEvents :: proc(shapeId: ShapeId, flag: c.bool) ---
+	Shape_EnableHitEvents :: proc(shapeId: ShapeId, flag: bool) ---
 
 	/// Returns true if hit events are enabled
-	Shape_AreHitEventsEnabled :: proc(shapeId: ShapeId) -> c.bool ---
+	Shape_AreHitEventsEnabled :: proc(shapeId: ShapeId) -> bool ---
 
 	/// Test a point for overlap with a shape
-	Shape_TestPoint :: proc(shapeId: ShapeId, point: Vec2) -> c.bool ---
+	Shape_TestPoint :: proc(shapeId: ShapeId, point: Vec2) -> bool ---
 
 	/// Ray cast a shape directly
 	Shape_RayCast :: proc(shapeId: ShapeId, input: ^RayCastInput) -> CastOutput ---
@@ -657,17 +657,17 @@ foreign lib {
 
 	/// Set the chain friction
 	/// @see b2ChainDef::friction
-	Chain_SetFriction :: proc(chainId: ChainId, friction: c.float) ---
+	Chain_SetFriction :: proc(chainId: ChainId, friction: f32) ---
 
 	/// Get the chain friction
-	Chain_GetFriction :: proc(chainId: ChainId) -> c.float ---
+	Chain_GetFriction :: proc(chainId: ChainId) -> f32 ---
 
 	/// Set the chain restitution (bounciness)
 	/// @see b2ChainDef::restitution
-	Chain_SetRestitution :: proc(chainId: ChainId, restitution: c.float) ---
+	Chain_SetRestitution :: proc(chainId: ChainId, restitution: f32) ---
 
 	/// Get the chain restitution
-	Chain_GetRestitution :: proc(chainId: ChainId) -> c.float ---
+	Chain_GetRestitution :: proc(chainId: ChainId) -> f32 ---
 
 	/// Set the chain material
 	/// @see b2ChainDef::material
@@ -677,13 +677,13 @@ foreign lib {
 	Chain_GetMaterial :: proc(chainId: ChainId) -> c.int ---
 
 	/// Chain identifier validation. Provides validation for up to 64K allocations.
-	Chain_IsValid :: proc(id: ChainId) -> c.bool ---
+	Chain_IsValid :: proc(id: ChainId) -> bool ---
 
 	/// Destroy a joint
 	DestroyJoint :: proc(jointId: JointId) ---
 
 	/// Joint identifier validation. Provides validation for up to 64K allocations.
-	Joint_IsValid :: proc(id: JointId) -> c.bool ---
+	Joint_IsValid :: proc(id: JointId) -> bool ---
 
 	/// Get the joint type
 	Joint_GetType :: proc(jointId: JointId) -> JointType ---
@@ -704,10 +704,10 @@ foreign lib {
 	Joint_GetLocalAnchorB :: proc(jointId: JointId) -> Vec2 ---
 
 	/// Toggle collision between connected bodies
-	Joint_SetCollideConnected :: proc(jointId: JointId, shouldCollide: c.bool) ---
+	Joint_SetCollideConnected :: proc(jointId: JointId, shouldCollide: bool) ---
 
 	/// Is collision allowed between connected bodies?
-	Joint_GetCollideConnected :: proc(jointId: JointId) -> c.bool ---
+	Joint_GetCollideConnected :: proc(jointId: JointId) -> bool ---
 
 	/// Set the user data on a joint
 	Joint_SetUserData :: proc(jointId: JointId, userData: rawptr) ---
@@ -722,7 +722,7 @@ foreign lib {
 	Joint_GetConstraintForce :: proc(jointId: JointId) -> Vec2 ---
 
 	/// Get the current constraint torque for this joint. Usually in Newton * meters.
-	Joint_GetConstraintTorque :: proc(jointId: JointId) -> c.float ---
+	Joint_GetConstraintTorque :: proc(jointId: JointId) -> f32 ---
 
 	/// Create a distance joint
 	/// @see b2DistanceJointDef for details
@@ -731,68 +731,68 @@ foreign lib {
 	/// Set the rest length of a distance joint
 	/// @param jointId The id for a distance joint
 	/// @param length The new distance joint length
-	DistanceJoint_SetLength :: proc(jointId: JointId, length: c.float) ---
+	DistanceJoint_SetLength :: proc(jointId: JointId, length: f32) ---
 
 	/// Get the rest length of a distance joint
-	DistanceJoint_GetLength :: proc(jointId: JointId) -> c.float ---
+	DistanceJoint_GetLength :: proc(jointId: JointId) -> f32 ---
 
 	/// Enable/disable the distance joint spring. When disabled the distance joint is rigid.
-	DistanceJoint_EnableSpring :: proc(jointId: JointId, enableSpring: c.bool) ---
+	DistanceJoint_EnableSpring :: proc(jointId: JointId, enableSpring: bool) ---
 
 	/// Is the distance joint spring enabled?
-	DistanceJoint_IsSpringEnabled :: proc(jointId: JointId) -> c.bool ---
+	DistanceJoint_IsSpringEnabled :: proc(jointId: JointId) -> bool ---
 
 	/// Set the spring stiffness in Hertz
-	DistanceJoint_SetSpringHertz :: proc(jointId: JointId, hertz: c.float) ---
+	DistanceJoint_SetSpringHertz :: proc(jointId: JointId, hertz: f32) ---
 
 	/// Set the spring damping ratio, non-dimensional
-	DistanceJoint_SetSpringDampingRatio :: proc(jointId: JointId, dampingRatio: c.float) ---
+	DistanceJoint_SetSpringDampingRatio :: proc(jointId: JointId, dampingRatio: f32) ---
 
 	/// Get the spring Hertz
-	DistanceJoint_GetSpringHertz :: proc(jointId: JointId) -> c.float ---
+	DistanceJoint_GetSpringHertz :: proc(jointId: JointId) -> f32 ---
 
 	/// Get the spring damping ratio
-	DistanceJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> c.float ---
+	DistanceJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> f32 ---
 
 	/// Enable joint limit. The limit only works if the joint spring is enabled. Otherwise the joint is rigid
 	/// and the limit has no effect.
-	DistanceJoint_EnableLimit :: proc(jointId: JointId, enableLimit: c.bool) ---
+	DistanceJoint_EnableLimit :: proc(jointId: JointId, enableLimit: bool) ---
 
 	/// Is the distance joint limit enabled?
-	DistanceJoint_IsLimitEnabled :: proc(jointId: JointId) -> c.bool ---
+	DistanceJoint_IsLimitEnabled :: proc(jointId: JointId) -> bool ---
 
 	/// Set the minimum and maximum length parameters of a distance joint
-	DistanceJoint_SetLengthRange :: proc(jointId: JointId, minLength: c.float, maxLength: c.float) ---
+	DistanceJoint_SetLengthRange :: proc(jointId: JointId, minLength: f32, maxLength: f32) ---
 
 	/// Get the distance joint minimum length
-	DistanceJoint_GetMinLength :: proc(jointId: JointId) -> c.float ---
+	DistanceJoint_GetMinLength :: proc(jointId: JointId) -> f32 ---
 
 	/// Get the distance joint maximum length
-	DistanceJoint_GetMaxLength :: proc(jointId: JointId) -> c.float ---
+	DistanceJoint_GetMaxLength :: proc(jointId: JointId) -> f32 ---
 
 	/// Get the current length of a distance joint
-	DistanceJoint_GetCurrentLength :: proc(jointId: JointId) -> c.float ---
+	DistanceJoint_GetCurrentLength :: proc(jointId: JointId) -> f32 ---
 
 	/// Enable/disable the distance joint motor
-	DistanceJoint_EnableMotor :: proc(jointId: JointId, enableMotor: c.bool) ---
+	DistanceJoint_EnableMotor :: proc(jointId: JointId, enableMotor: bool) ---
 
 	/// Is the distance joint motor enabled?
-	DistanceJoint_IsMotorEnabled :: proc(jointId: JointId) -> c.bool ---
+	DistanceJoint_IsMotorEnabled :: proc(jointId: JointId) -> bool ---
 
 	/// Set the distance joint motor speed, usually in meters per second
-	DistanceJoint_SetMotorSpeed :: proc(jointId: JointId, motorSpeed: c.float) ---
+	DistanceJoint_SetMotorSpeed :: proc(jointId: JointId, motorSpeed: f32) ---
 
 	/// Get the distance joint motor speed, usually in meters per second
-	DistanceJoint_GetMotorSpeed :: proc(jointId: JointId) -> c.float ---
+	DistanceJoint_GetMotorSpeed :: proc(jointId: JointId) -> f32 ---
 
 	/// Set the distance joint maximum motor force, usually in newtons
-	DistanceJoint_SetMaxMotorForce :: proc(jointId: JointId, force: c.float) ---
+	DistanceJoint_SetMaxMotorForce :: proc(jointId: JointId, force: f32) ---
 
 	/// Get the distance joint maximum motor force, usually in newtons
-	DistanceJoint_GetMaxMotorForce :: proc(jointId: JointId) -> c.float ---
+	DistanceJoint_GetMaxMotorForce :: proc(jointId: JointId) -> f32 ---
 
 	/// Get the distance joint current motor force, usually in newtons
-	DistanceJoint_GetMotorForce :: proc(jointId: JointId) -> c.float ---
+	DistanceJoint_GetMotorForce :: proc(jointId: JointId) -> f32 ---
 
 	/// Create a motor joint
 	/// @see b2MotorJointDef for details
@@ -805,28 +805,28 @@ foreign lib {
 	MotorJoint_GetLinearOffset :: proc(jointId: JointId) -> Vec2 ---
 
 	/// Set the motor joint angular offset target in radians
-	MotorJoint_SetAngularOffset :: proc(jointId: JointId, angularOffset: c.float) ---
+	MotorJoint_SetAngularOffset :: proc(jointId: JointId, angularOffset: f32) ---
 
 	/// Get the motor joint angular offset target in radians
-	MotorJoint_GetAngularOffset :: proc(jointId: JointId) -> c.float ---
+	MotorJoint_GetAngularOffset :: proc(jointId: JointId) -> f32 ---
 
 	/// Set the motor joint maximum force, usually in newtons
-	MotorJoint_SetMaxForce :: proc(jointId: JointId, maxForce: c.float) ---
+	MotorJoint_SetMaxForce :: proc(jointId: JointId, maxForce: f32) ---
 
 	/// Get the motor joint maximum force, usually in newtons
-	MotorJoint_GetMaxForce :: proc(jointId: JointId) -> c.float ---
+	MotorJoint_GetMaxForce :: proc(jointId: JointId) -> f32 ---
 
 	/// Set the motor joint maximum torque, usually in newton-meters
-	MotorJoint_SetMaxTorque :: proc(jointId: JointId, maxTorque: c.float) ---
+	MotorJoint_SetMaxTorque :: proc(jointId: JointId, maxTorque: f32) ---
 
 	/// Get the motor joint maximum torque, usually in newton-meters
-	MotorJoint_GetMaxTorque :: proc(jointId: JointId) -> c.float ---
+	MotorJoint_GetMaxTorque :: proc(jointId: JointId) -> f32 ---
 
 	/// Set the motor joint correction factor, usually in [0, 1]
-	MotorJoint_SetCorrectionFactor :: proc(jointId: JointId, correctionFactor: c.float) ---
+	MotorJoint_SetCorrectionFactor :: proc(jointId: JointId, correctionFactor: f32) ---
 
 	/// Get the motor joint correction factor, usually in [0, 1]
-	MotorJoint_GetCorrectionFactor :: proc(jointId: JointId) -> c.float ---
+	MotorJoint_GetCorrectionFactor :: proc(jointId: JointId) -> f32 ---
 
 	/// Create a mouse joint
 	/// @see b2MouseJointDef for details
@@ -839,22 +839,22 @@ foreign lib {
 	MouseJoint_GetTarget :: proc(jointId: JointId) -> Vec2 ---
 
 	/// Set the mouse joint spring stiffness in Hertz
-	MouseJoint_SetSpringHertz :: proc(jointId: JointId, hertz: c.float) ---
+	MouseJoint_SetSpringHertz :: proc(jointId: JointId, hertz: f32) ---
 
 	/// Get the mouse joint spring stiffness in Hertz
-	MouseJoint_GetSpringHertz :: proc(jointId: JointId) -> c.float ---
+	MouseJoint_GetSpringHertz :: proc(jointId: JointId) -> f32 ---
 
 	/// Set the mouse joint spring damping ratio, non-dimensional
-	MouseJoint_SetSpringDampingRatio :: proc(jointId: JointId, dampingRatio: c.float) ---
+	MouseJoint_SetSpringDampingRatio :: proc(jointId: JointId, dampingRatio: f32) ---
 
 	/// Get the mouse joint damping ratio, non-dimensional
-	MouseJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> c.float ---
+	MouseJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> f32 ---
 
 	/// Set the mouse joint maximum force, usually in newtons
-	MouseJoint_SetMaxForce :: proc(jointId: JointId, maxForce: c.float) ---
+	MouseJoint_SetMaxForce :: proc(jointId: JointId, maxForce: f32) ---
 
 	/// Get the mouse joint maximum force, usually in newtons
-	MouseJoint_GetMaxForce :: proc(jointId: JointId) -> c.float ---
+	MouseJoint_GetMaxForce :: proc(jointId: JointId) -> f32 ---
 
 	/// Create a null joint.
 	/// @see b2NullJointDef for details
@@ -865,218 +865,218 @@ foreign lib {
 	CreatePrismaticJoint :: proc(worldId: WorldId, def: ^PrismaticJointDef) -> JointId ---
 
 	/// Enable/disable the joint spring.
-	PrismaticJoint_EnableSpring :: proc(jointId: JointId, enableSpring: c.bool) ---
+	PrismaticJoint_EnableSpring :: proc(jointId: JointId, enableSpring: bool) ---
 
 	/// Is the prismatic joint spring enabled or not?
-	PrismaticJoint_IsSpringEnabled :: proc(jointId: JointId) -> c.bool ---
+	PrismaticJoint_IsSpringEnabled :: proc(jointId: JointId) -> bool ---
 
 	/// Set the prismatic joint stiffness in Hertz.
 	/// This should usually be less than a quarter of the simulation rate. For example, if the simulation
 	/// runs at 60Hz then the joint stiffness should be 15Hz or less.
-	PrismaticJoint_SetSpringHertz :: proc(jointId: JointId, hertz: c.float) ---
+	PrismaticJoint_SetSpringHertz :: proc(jointId: JointId, hertz: f32) ---
 
 	/// Get the prismatic joint stiffness in Hertz
-	PrismaticJoint_GetSpringHertz :: proc(jointId: JointId) -> c.float ---
+	PrismaticJoint_GetSpringHertz :: proc(jointId: JointId) -> f32 ---
 
 	/// Set the prismatic joint damping ratio (non-dimensional)
-	PrismaticJoint_SetSpringDampingRatio :: proc(jointId: JointId, dampingRatio: c.float) ---
+	PrismaticJoint_SetSpringDampingRatio :: proc(jointId: JointId, dampingRatio: f32) ---
 
 	/// Get the prismatic spring damping ratio (non-dimensional)
-	PrismaticJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> c.float ---
+	PrismaticJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> f32 ---
 
 	/// Enable/disable a prismatic joint limit
-	PrismaticJoint_EnableLimit :: proc(jointId: JointId, enableLimit: c.bool) ---
+	PrismaticJoint_EnableLimit :: proc(jointId: JointId, enableLimit: bool) ---
 
 	/// Is the prismatic joint limit enabled?
-	PrismaticJoint_IsLimitEnabled :: proc(jointId: JointId) -> c.bool ---
+	PrismaticJoint_IsLimitEnabled :: proc(jointId: JointId) -> bool ---
 
 	/// Get the prismatic joint lower limit
-	PrismaticJoint_GetLowerLimit :: proc(jointId: JointId) -> c.float ---
+	PrismaticJoint_GetLowerLimit :: proc(jointId: JointId) -> f32 ---
 
 	/// Get the prismatic joint upper limit
-	PrismaticJoint_GetUpperLimit :: proc(jointId: JointId) -> c.float ---
+	PrismaticJoint_GetUpperLimit :: proc(jointId: JointId) -> f32 ---
 
 	/// Set the prismatic joint limits
-	PrismaticJoint_SetLimits :: proc(jointId: JointId, lower: c.float, upper: c.float) ---
+	PrismaticJoint_SetLimits :: proc(jointId: JointId, lower: f32, upper: f32) ---
 
 	/// Enable/disable a prismatic joint motor
-	PrismaticJoint_EnableMotor :: proc(jointId: JointId, enableMotor: c.bool) ---
+	PrismaticJoint_EnableMotor :: proc(jointId: JointId, enableMotor: bool) ---
 
 	/// Is the prismatic joint motor enabled?
-	PrismaticJoint_IsMotorEnabled :: proc(jointId: JointId) -> c.bool ---
+	PrismaticJoint_IsMotorEnabled :: proc(jointId: JointId) -> bool ---
 
 	/// Set the prismatic joint motor speed, usually in meters per second
-	PrismaticJoint_SetMotorSpeed :: proc(jointId: JointId, motorSpeed: c.float) ---
+	PrismaticJoint_SetMotorSpeed :: proc(jointId: JointId, motorSpeed: f32) ---
 
 	/// Get the prismatic joint motor speed, usually in meters per second
-	PrismaticJoint_GetMotorSpeed :: proc(jointId: JointId) -> c.float ---
+	PrismaticJoint_GetMotorSpeed :: proc(jointId: JointId) -> f32 ---
 
 	/// Set the prismatic joint maximum motor force, usually in newtons
-	PrismaticJoint_SetMaxMotorForce :: proc(jointId: JointId, force: c.float) ---
+	PrismaticJoint_SetMaxMotorForce :: proc(jointId: JointId, force: f32) ---
 
 	/// Get the prismatic joint maximum motor force, usually in newtons
-	PrismaticJoint_GetMaxMotorForce :: proc(jointId: JointId) -> c.float ---
+	PrismaticJoint_GetMaxMotorForce :: proc(jointId: JointId) -> f32 ---
 
 	/// Get the prismatic joint current motor force, usually in newtons
-	PrismaticJoint_GetMotorForce :: proc(jointId: JointId) -> c.float ---
+	PrismaticJoint_GetMotorForce :: proc(jointId: JointId) -> f32 ---
 
 	/// Get the current joint translation, usually in meters.
-	PrismaticJoint_GetTranslation :: proc(jointId: JointId) -> c.float ---
+	PrismaticJoint_GetTranslation :: proc(jointId: JointId) -> f32 ---
 
 	/// Get the current joint translation speed, usually in meters per second.
-	PrismaticJoint_GetSpeed :: proc(jointId: JointId) -> c.float ---
+	PrismaticJoint_GetSpeed :: proc(jointId: JointId) -> f32 ---
 
 	/// Create a revolute joint
 	/// @see b2RevoluteJointDef for details
 	CreateRevoluteJoint :: proc(worldId: WorldId, def: ^RevoluteJointDef) -> JointId ---
 
 	/// Enable/disable the revolute joint spring
-	RevoluteJoint_EnableSpring :: proc(jointId: JointId, enableSpring: c.bool) ---
+	RevoluteJoint_EnableSpring :: proc(jointId: JointId, enableSpring: bool) ---
 
 	/// It the revolute angular spring enabled?
-	RevoluteJoint_IsSpringEnabled :: proc(jointId: JointId) -> c.bool ---
+	RevoluteJoint_IsSpringEnabled :: proc(jointId: JointId) -> bool ---
 
 	/// Set the revolute joint spring stiffness in Hertz
-	RevoluteJoint_SetSpringHertz :: proc(jointId: JointId, hertz: c.float) ---
+	RevoluteJoint_SetSpringHertz :: proc(jointId: JointId, hertz: f32) ---
 
 	/// Get the revolute joint spring stiffness in Hertz
-	RevoluteJoint_GetSpringHertz :: proc(jointId: JointId) -> c.float ---
+	RevoluteJoint_GetSpringHertz :: proc(jointId: JointId) -> f32 ---
 
 	/// Set the revolute joint spring damping ratio, non-dimensional
-	RevoluteJoint_SetSpringDampingRatio :: proc(jointId: JointId, dampingRatio: c.float) ---
+	RevoluteJoint_SetSpringDampingRatio :: proc(jointId: JointId, dampingRatio: f32) ---
 
 	/// Get the revolute joint spring damping ratio, non-dimensional
-	RevoluteJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> c.float ---
+	RevoluteJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> f32 ---
 
 	/// Get the revolute joint current angle in radians relative to the reference angle
 	/// @see b2RevoluteJointDef::referenceAngle
-	RevoluteJoint_GetAngle :: proc(jointId: JointId) -> c.float ---
+	RevoluteJoint_GetAngle :: proc(jointId: JointId) -> f32 ---
 
 	/// Enable/disable the revolute joint limit
-	RevoluteJoint_EnableLimit :: proc(jointId: JointId, enableLimit: c.bool) ---
+	RevoluteJoint_EnableLimit :: proc(jointId: JointId, enableLimit: bool) ---
 
 	/// Is the revolute joint limit enabled?
-	RevoluteJoint_IsLimitEnabled :: proc(jointId: JointId) -> c.bool ---
+	RevoluteJoint_IsLimitEnabled :: proc(jointId: JointId) -> bool ---
 
 	/// Get the revolute joint lower limit in radians
-	RevoluteJoint_GetLowerLimit :: proc(jointId: JointId) -> c.float ---
+	RevoluteJoint_GetLowerLimit :: proc(jointId: JointId) -> f32 ---
 
 	/// Get the revolute joint upper limit in radians
-	RevoluteJoint_GetUpperLimit :: proc(jointId: JointId) -> c.float ---
+	RevoluteJoint_GetUpperLimit :: proc(jointId: JointId) -> f32 ---
 
 	/// Set the revolute joint limits in radians
-	RevoluteJoint_SetLimits :: proc(jointId: JointId, lower: c.float, upper: c.float) ---
+	RevoluteJoint_SetLimits :: proc(jointId: JointId, lower: f32, upper: f32) ---
 
 	/// Enable/disable a revolute joint motor
-	RevoluteJoint_EnableMotor :: proc(jointId: JointId, enableMotor: c.bool) ---
+	RevoluteJoint_EnableMotor :: proc(jointId: JointId, enableMotor: bool) ---
 
 	/// Is the revolute joint motor enabled?
-	RevoluteJoint_IsMotorEnabled :: proc(jointId: JointId) -> c.bool ---
+	RevoluteJoint_IsMotorEnabled :: proc(jointId: JointId) -> bool ---
 
 	/// Set the revolute joint motor speed in radians per second
-	RevoluteJoint_SetMotorSpeed :: proc(jointId: JointId, motorSpeed: c.float) ---
+	RevoluteJoint_SetMotorSpeed :: proc(jointId: JointId, motorSpeed: f32) ---
 
 	/// Get the revolute joint motor speed in radians per second
-	RevoluteJoint_GetMotorSpeed :: proc(jointId: JointId) -> c.float ---
+	RevoluteJoint_GetMotorSpeed :: proc(jointId: JointId) -> f32 ---
 
 	/// Get the revolute joint current motor torque, usually in newton-meters
-	RevoluteJoint_GetMotorTorque :: proc(jointId: JointId) -> c.float ---
+	RevoluteJoint_GetMotorTorque :: proc(jointId: JointId) -> f32 ---
 
 	/// Set the revolute joint maximum motor torque, usually in newton-meters
-	RevoluteJoint_SetMaxMotorTorque :: proc(jointId: JointId, torque: c.float) ---
+	RevoluteJoint_SetMaxMotorTorque :: proc(jointId: JointId, torque: f32) ---
 
 	/// Get the revolute joint maximum motor torque, usually in newton-meters
-	RevoluteJoint_GetMaxMotorTorque :: proc(jointId: JointId) -> c.float ---
+	RevoluteJoint_GetMaxMotorTorque :: proc(jointId: JointId) -> f32 ---
 
 	/// Create a weld joint
 	/// @see b2WeldJointDef for details
 	CreateWeldJoint :: proc(worldId: WorldId, def: ^WeldJointDef) -> JointId ---
 
 	/// Get the weld joint reference angle in radians
-	WeldJoint_GetReferenceAngle :: proc(jointId: JointId) -> c.float ---
+	WeldJoint_GetReferenceAngle :: proc(jointId: JointId) -> f32 ---
 
 	/// Set the weld joint reference angle in radians, must be in [-pi,pi].
-	WeldJoint_SetReferenceAngle :: proc(jointId: JointId, angleInRadians: c.float) ---
+	WeldJoint_SetReferenceAngle :: proc(jointId: JointId, angleInRadians: f32) ---
 
 	/// Set the weld joint linear stiffness in Hertz. 0 is rigid.
-	WeldJoint_SetLinearHertz :: proc(jointId: JointId, hertz: c.float) ---
+	WeldJoint_SetLinearHertz :: proc(jointId: JointId, hertz: f32) ---
 
 	/// Get the weld joint linear stiffness in Hertz
-	WeldJoint_GetLinearHertz :: proc(jointId: JointId) -> c.float ---
+	WeldJoint_GetLinearHertz :: proc(jointId: JointId) -> f32 ---
 
 	/// Set the weld joint linear damping ratio (non-dimensional)
-	WeldJoint_SetLinearDampingRatio :: proc(jointId: JointId, dampingRatio: c.float) ---
+	WeldJoint_SetLinearDampingRatio :: proc(jointId: JointId, dampingRatio: f32) ---
 
 	/// Get the weld joint linear damping ratio (non-dimensional)
-	WeldJoint_GetLinearDampingRatio :: proc(jointId: JointId) -> c.float ---
+	WeldJoint_GetLinearDampingRatio :: proc(jointId: JointId) -> f32 ---
 
 	/// Set the weld joint angular stiffness in Hertz. 0 is rigid.
-	WeldJoint_SetAngularHertz :: proc(jointId: JointId, hertz: c.float) ---
+	WeldJoint_SetAngularHertz :: proc(jointId: JointId, hertz: f32) ---
 
 	/// Get the weld joint angular stiffness in Hertz
-	WeldJoint_GetAngularHertz :: proc(jointId: JointId) -> c.float ---
+	WeldJoint_GetAngularHertz :: proc(jointId: JointId) -> f32 ---
 
 	/// Set weld joint angular damping ratio, non-dimensional
-	WeldJoint_SetAngularDampingRatio :: proc(jointId: JointId, dampingRatio: c.float) ---
+	WeldJoint_SetAngularDampingRatio :: proc(jointId: JointId, dampingRatio: f32) ---
 
 	/// Get the weld joint angular damping ratio, non-dimensional
-	WeldJoint_GetAngularDampingRatio :: proc(jointId: JointId) -> c.float ---
+	WeldJoint_GetAngularDampingRatio :: proc(jointId: JointId) -> f32 ---
 
 	/// Create a wheel joint
 	/// @see b2WheelJointDef for details
 	CreateWheelJoint :: proc(worldId: WorldId, def: ^WheelJointDef) -> JointId ---
 
 	/// Enable/disable the wheel joint spring
-	WheelJoint_EnableSpring :: proc(jointId: JointId, enableSpring: c.bool) ---
+	WheelJoint_EnableSpring :: proc(jointId: JointId, enableSpring: bool) ---
 
 	/// Is the wheel joint spring enabled?
-	WheelJoint_IsSpringEnabled :: proc(jointId: JointId) -> c.bool ---
+	WheelJoint_IsSpringEnabled :: proc(jointId: JointId) -> bool ---
 
 	/// Set the wheel joint stiffness in Hertz
-	WheelJoint_SetSpringHertz :: proc(jointId: JointId, hertz: c.float) ---
+	WheelJoint_SetSpringHertz :: proc(jointId: JointId, hertz: f32) ---
 
 	/// Get the wheel joint stiffness in Hertz
-	WheelJoint_GetSpringHertz :: proc(jointId: JointId) -> c.float ---
+	WheelJoint_GetSpringHertz :: proc(jointId: JointId) -> f32 ---
 
 	/// Set the wheel joint damping ratio, non-dimensional
-	WheelJoint_SetSpringDampingRatio :: proc(jointId: JointId, dampingRatio: c.float) ---
+	WheelJoint_SetSpringDampingRatio :: proc(jointId: JointId, dampingRatio: f32) ---
 
 	/// Get the wheel joint damping ratio, non-dimensional
-	WheelJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> c.float ---
+	WheelJoint_GetSpringDampingRatio :: proc(jointId: JointId) -> f32 ---
 
 	/// Enable/disable the wheel joint limit
-	WheelJoint_EnableLimit :: proc(jointId: JointId, enableLimit: c.bool) ---
+	WheelJoint_EnableLimit :: proc(jointId: JointId, enableLimit: bool) ---
 
 	/// Is the wheel joint limit enabled?
-	WheelJoint_IsLimitEnabled :: proc(jointId: JointId) -> c.bool ---
+	WheelJoint_IsLimitEnabled :: proc(jointId: JointId) -> bool ---
 
 	/// Get the wheel joint lower limit
-	WheelJoint_GetLowerLimit :: proc(jointId: JointId) -> c.float ---
+	WheelJoint_GetLowerLimit :: proc(jointId: JointId) -> f32 ---
 
 	/// Get the wheel joint upper limit
-	WheelJoint_GetUpperLimit :: proc(jointId: JointId) -> c.float ---
+	WheelJoint_GetUpperLimit :: proc(jointId: JointId) -> f32 ---
 
 	/// Set the wheel joint limits
-	WheelJoint_SetLimits :: proc(jointId: JointId, lower: c.float, upper: c.float) ---
+	WheelJoint_SetLimits :: proc(jointId: JointId, lower: f32, upper: f32) ---
 
 	/// Enable/disable the wheel joint motor
-	WheelJoint_EnableMotor :: proc(jointId: JointId, enableMotor: c.bool) ---
+	WheelJoint_EnableMotor :: proc(jointId: JointId, enableMotor: bool) ---
 
 	/// Is the wheel joint motor enabled?
-	WheelJoint_IsMotorEnabled :: proc(jointId: JointId) -> c.bool ---
+	WheelJoint_IsMotorEnabled :: proc(jointId: JointId) -> bool ---
 
 	/// Set the wheel joint motor speed in radians per second
-	WheelJoint_SetMotorSpeed :: proc(jointId: JointId, motorSpeed: c.float) ---
+	WheelJoint_SetMotorSpeed :: proc(jointId: JointId, motorSpeed: f32) ---
 
 	/// Get the wheel joint motor speed in radians per second
-	WheelJoint_GetMotorSpeed :: proc(jointId: JointId) -> c.float ---
+	WheelJoint_GetMotorSpeed :: proc(jointId: JointId) -> f32 ---
 
 	/// Set the wheel joint maximum motor torque, usually in newton-meters
-	WheelJoint_SetMaxMotorTorque :: proc(jointId: JointId, torque: c.float) ---
+	WheelJoint_SetMaxMotorTorque :: proc(jointId: JointId, torque: f32) ---
 
 	/// Get the wheel joint maximum motor torque, usually in newton-meters
-	WheelJoint_GetMaxMotorTorque :: proc(jointId: JointId) -> c.float ---
+	WheelJoint_GetMaxMotorTorque :: proc(jointId: JointId) -> f32 ---
 
 	/// Get the wheel joint current motor torque, usually in newton-meters
-	WheelJoint_GetMotorTorque :: proc(jointId: JointId) -> c.float ---
+	WheelJoint_GetMotorTorque :: proc(jointId: JointId) -> f32 ---
 }

--- a/examples/box2d/box2d/collision.odin
+++ b/examples/box2d/box2d/collision.odin
@@ -19,7 +19,7 @@ RayCastInput :: struct {
 	translation: Vec2,
 
 	/// The maximum fraction of the translation to consider, typically 1
-	maxFraction: c.float,
+	maxFraction: f32,
 }
 
 /// Low level shape cast input in generic form. This allows casting an arbitrary point
@@ -33,13 +33,13 @@ ShapeCastInput :: struct {
 	count: c.int,
 
 	/// The radius around the point cloud
-	radius: c.float,
+	radius: f32,
 
 	/// The translation of the shape cast
 	translation: Vec2,
 
 	/// The maximum fraction of the translation to consider, typically 1
-	maxFraction: c.float,
+	maxFraction: f32,
 }
 
 /// Low level ray cast or shape-cast output data
@@ -51,25 +51,25 @@ CastOutput :: struct {
 	point: Vec2,
 
 	/// The fraction of the input translation at collision
-	fraction: c.float,
+	fraction: f32,
 
 	/// The number of iterations used
 	iterations: c.int,
 
 	/// Did the cast hit?
-	hit: c.bool,
+	hit: bool,
 }
 
 /// This holds the mass data computed for a shape.
 MassData :: struct {
 	/// The mass of the shape, usually in kilograms.
-	mass: c.float,
+	mass: f32,
 
 	/// The position of the shape's centroid relative to the shape's origin.
 	center: Vec2,
 
 	/// The rotational inertia of the shape about the local origin.
-	rotationalInertia: c.float,
+	rotationalInertia: f32,
 }
 
 /// A solid circle
@@ -78,7 +78,7 @@ Circle :: struct {
 	center: Vec2,
 
 	/// The radius
-	radius: c.float,
+	radius: f32,
 }
 
 /// A solid capsule can be viewed as two semicircles connected
@@ -91,7 +91,7 @@ Capsule :: struct {
 	center2: Vec2,
 
 	/// The radius of the semicircles
-	radius: c.float,
+	radius: f32,
 }
 
 /// A solid convex polygon. It is assumed that the interior of the polygon is to
@@ -111,7 +111,7 @@ Polygon :: struct {
 	centroid: Vec2,
 
 	/// The external radius for rounded polygons
-	radius: c.float,
+	radius: f32,
 
 	/// The number of polygon vertices
 	count: c.int,
@@ -162,13 +162,13 @@ SegmentDistanceResult :: struct {
 	closest2: Vec2,
 
 	/// The barycentric coordinate on the first segment
-	fraction1: c.float,
+	fraction1: f32,
 
 	/// The barycentric coordinate on the second segment
-	fraction2: c.float,
+	fraction2: f32,
 
 	/// The squared distance between the closest points
-	distanceSquared: c.float,
+	distanceSquared: f32,
 }
 
 /// A distance proxy is used by the GJK algorithm. It encapsulates any shape.
@@ -180,7 +180,7 @@ ShapeProxy :: struct {
 	count: c.int,
 
 	/// The external radius of the point cloud
-	radius: c.float,
+	radius: f32,
 }
 
 /// Used to warm start the GJK simplex. If you call this function multiple times with nearby
@@ -189,13 +189,13 @@ ShapeProxy :: struct {
 /// Users should generally just zero initialize this structure for each call.
 SimplexCache :: struct {
 	/// The number of stored simplex points
-	count: c.uint16_t,
+	count: u16,
 
 	/// The cached simplex indices on shape A
-	indexA: [3]c.uint8_t,
+	indexA: [3]u8,
 
 	/// The cached simplex indices on shape B
-	indexB: [3]c.uint8_t,
+	indexB: [3]u8,
 }
 
 /// Input for b2ShapeDistance
@@ -213,26 +213,26 @@ DistanceInput :: struct {
 	transformB: Transform,
 
 	/// Should the proxy radius be considered?
-	useRadii: c.bool,
+	useRadii: bool,
 }
 
 /// Output for b2ShapeDistance
 DistanceOutput :: struct {
-	pointA:       Vec2,    ///< Closest point on shapeA
-	pointB:       Vec2,    ///< Closest point on shapeB
-	distance:     c.float, ///< The final distance, zero if overlapped
-	iterations:   c.int,   ///< Number of GJK iterations used
-	simplexCount: c.int,   ///< The number of simplexes stored in the simplex array
+	pointA:       Vec2,  ///< Closest point on shapeA
+	pointB:       Vec2,  ///< Closest point on shapeB
+	distance:     f32,   ///< The final distance, zero if overlapped
+	iterations:   c.int, ///< Number of GJK iterations used
+	simplexCount: c.int, ///< The number of simplexes stored in the simplex array
 }
 
 /// Simplex vertex for debugging the GJK algorithm
 SimplexVertex :: struct {
-	wA:     Vec2,    ///< support point in proxyA
-	wB:     Vec2,    ///< support point in proxyB
-	w:      Vec2,    ///< wB - wA
-	a:      c.float, ///< barycentric coordinate for closest point
-	indexA: c.int,   ///< wA index
-	indexB: c.int,   ///< wB index
+	wA:     Vec2,  ///< support point in proxyA
+	wB:     Vec2,  ///< support point in proxyB
+	w:      Vec2,  ///< wB - wA
+	a:      f32,   ///< barycentric coordinate for closest point
+	indexA: c.int, ///< wA index
+	indexB: c.int, ///< wB index
 }
 
 /// Simplex from the GJK algorithm
@@ -248,7 +248,7 @@ ShapeCastPairInput :: struct {
 	transformA:   Transform,  ///< The world transform for shape A
 	transformB:   Transform,  ///< The world transform for shape B
 	translationB: Vec2,       ///< The translation of shape B
-	maxFraction:  c.float,    ///< The fraction of the translation to consider, typically 1
+	maxFraction:  f32,        ///< The fraction of the translation to consider, typically 1
 }
 
 /// This describes the motion of a body/shape for TOI computation. Shapes are defined with respect to the body origin,
@@ -268,7 +268,7 @@ TOIInput :: struct {
 	proxyB:      ShapeProxy, ///< The proxy for shape B
 	sweepA:      Sweep,      ///< The movement of shape A
 	sweepB:      Sweep,      ///< The movement of shape B
-	maxFraction: c.float,    ///< Defines the sweep interval [0, maxFraction]
+	maxFraction: f32,        ///< Defines the sweep interval [0, maxFraction]
 }
 
 /// Describes the TOI output
@@ -283,7 +283,7 @@ TOIState :: enum c.int {
 /// Output parameters for b2TimeOfImpact.
 TOIOutput :: struct {
 	state:    TOIState, ///< The type of result
-	fraction: c.float,  ///< The sweep time of the collision
+	fraction: f32,      ///< The sweep time of the collision
 }
 
 /// A manifold point is a contact point belonging to a contact manifold.
@@ -305,27 +305,27 @@ ManifoldPoint :: struct {
 	anchorB: Vec2,
 
 	/// The separation of the contact point, negative if penetrating
-	separation: c.float,
+	separation: f32,
 
 	/// The impulse along the manifold normal vector.
-	normalImpulse: c.float,
+	normalImpulse: f32,
 
 	/// The friction impulse
-	tangentImpulse: c.float,
+	tangentImpulse: f32,
 
 	/// The maximum normal impulse applied during sub-stepping. This is important
 	/// to identify speculative contact points that had an interaction in the time step.
-	maxNormalImpulse: c.float,
+	maxNormalImpulse: f32,
 
 	/// Relative normal velocity pre-solve. Used for hit events. If the normal impulse is
 	/// zero then there was no hit. Negative means shapes are approaching.
-	normalVelocity: c.float,
+	normalVelocity: f32,
 
 	/// Uniquely identifies a contact point between two shapes
-	id: c.uint16_t,
+	id: u16,
 
 	/// Did this contact point exist the previous step?
-	persisted: c.bool,
+	persisted: bool,
 }
 
 /// A contact manifold describes the contact points between colliding shapes.
@@ -335,7 +335,7 @@ Manifold :: struct {
 	normal: Vec2,
 
 	/// Angular impulse applied for rolling resistance. N * m * s = kg * m^2 / s
-	rollingImpulse: c.float,
+	rollingImpulse: f32,
 
 	/// The manifold points, up to two are possible in 2D
 	points: [2]ManifoldPoint,
@@ -394,30 +394,30 @@ TreeStats :: struct {
 
 /// This function receives proxies found in the AABB query.
 /// @return true if the query should continue
-TreeQueryCallbackFcn :: proc "c" (c.int, c.int, rawptr) -> c.bool
+TreeQueryCallbackFcn :: proc "c" (c.int, c.int, rawptr) -> bool
 
 /// This function receives clipped ray cast input for a proxy. The function
 /// returns the new ray fraction.
 /// - return a value of 0 to terminate the ray cast
 /// - return a value less than input->maxFraction to clip the ray
 /// - return a value of input->maxFraction to continue the ray cast without clipping
-TreeRayCastCallbackFcn :: proc "c" (^RayCastInput, c.int, c.int, rawptr) -> c.float
+TreeRayCastCallbackFcn :: proc "c" (^RayCastInput, c.int, c.int, rawptr) -> f32
 
 /// This function receives clipped ray cast input for a proxy. The function
 /// returns the new ray fraction.
 /// - return a value of 0 to terminate the ray cast
 /// - return a value less than input->maxFraction to clip the ray
 /// - return a value of input->maxFraction to continue the ray cast without clipping
-TreeShapeCastCallbackFcn :: proc "c" (^ShapeCastInput, c.int, c.int, rawptr) -> c.float
+TreeShapeCastCallbackFcn :: proc "c" (^ShapeCastInput, c.int, c.int, rawptr) -> f32
 
 @(default_calling_convention="c", link_prefix="b2")
 foreign lib {
 	/// Validate ray cast input data (NaN, etc)
-	IsValidRay :: proc(input: ^RayCastInput) -> c.bool ---
+	IsValidRay :: proc(input: ^RayCastInput) -> bool ---
 
 	/// Make a convex polygon from a convex hull. This will assert if the hull is not valid.
 	/// @warning Do not manually fill in the hull data, it must come directly from b2ComputeHull
-	MakePolygon :: proc(hull: ^Hull, radius: c.float) -> Polygon ---
+	MakePolygon :: proc(hull: ^Hull, radius: f32) -> Polygon ---
 
 	/// Make an offset convex polygon from a convex hull. This will assert if the hull is not valid.
 	/// @warning Do not manually fill in the hull data, it must come directly from b2ComputeHull
@@ -425,29 +425,29 @@ foreign lib {
 
 	/// Make an offset convex polygon from a convex hull. This will assert if the hull is not valid.
 	/// @warning Do not manually fill in the hull data, it must come directly from b2ComputeHull
-	MakeOffsetRoundedPolygon :: proc(hull: ^Hull, position: Vec2, rotation: Rot, radius: c.float) -> Polygon ---
+	MakeOffsetRoundedPolygon :: proc(hull: ^Hull, position: Vec2, rotation: Rot, radius: f32) -> Polygon ---
 
 	/// Make a square polygon, bypassing the need for a convex hull.
 	/// @param halfWidth the half-width
-	MakeSquare :: proc(halfWidth: c.float) -> Polygon ---
+	MakeSquare :: proc(halfWidth: f32) -> Polygon ---
 
 	/// Make a box (rectangle) polygon, bypassing the need for a convex hull.
 	/// @param halfWidth the half-width (x-axis)
 	/// @param halfHeight the half-height (y-axis)
-	MakeBox :: proc(halfWidth: c.float, halfHeight: c.float) -> Polygon ---
+	MakeBox :: proc(halfWidth: f32, halfHeight: f32) -> Polygon ---
 
 	/// Make a rounded box, bypassing the need for a convex hull.
 	/// @param halfWidth the half-width (x-axis)
 	/// @param halfHeight the half-height (y-axis)
 	/// @param radius the radius of the rounded extension
-	MakeRoundedBox :: proc(halfWidth: c.float, halfHeight: c.float, radius: c.float) -> Polygon ---
+	MakeRoundedBox :: proc(halfWidth: f32, halfHeight: f32, radius: f32) -> Polygon ---
 
 	/// Make an offset box, bypassing the need for a convex hull.
 	/// @param halfWidth the half-width (x-axis)
 	/// @param halfHeight the half-height (y-axis)
 	/// @param center the local center of the box
 	/// @param rotation the local rotation of the box
-	MakeOffsetBox :: proc(halfWidth: c.float, halfHeight: c.float, center: Vec2, rotation: Rot) -> Polygon ---
+	MakeOffsetBox :: proc(halfWidth: f32, halfHeight: f32, center: Vec2, rotation: Rot) -> Polygon ---
 
 	/// Make an offset rounded box, bypassing the need for a convex hull.
 	/// @param halfWidth the half-width (x-axis)
@@ -455,19 +455,19 @@ foreign lib {
 	/// @param center the local center of the box
 	/// @param rotation the local rotation of the box
 	/// @param radius the radius of the rounded extension
-	MakeOffsetRoundedBox :: proc(halfWidth: c.float, halfHeight: c.float, center: Vec2, rotation: Rot, radius: c.float) -> Polygon ---
+	MakeOffsetRoundedBox :: proc(halfWidth: f32, halfHeight: f32, center: Vec2, rotation: Rot, radius: f32) -> Polygon ---
 
 	/// Transform a polygon. This is useful for transferring a shape from one body to another.
 	TransformPolygon :: proc(transform: Transform, polygon: ^Polygon) -> Polygon ---
 
 	/// Compute mass properties of a circle
-	ComputeCircleMass :: proc(shape: ^Circle, density: c.float) -> MassData ---
+	ComputeCircleMass :: proc(shape: ^Circle, density: f32) -> MassData ---
 
 	/// Compute mass properties of a capsule
-	ComputeCapsuleMass :: proc(shape: ^Capsule, density: c.float) -> MassData ---
+	ComputeCapsuleMass :: proc(shape: ^Capsule, density: f32) -> MassData ---
 
 	/// Compute mass properties of a polygon
-	ComputePolygonMass :: proc(shape: ^Polygon, density: c.float) -> MassData ---
+	ComputePolygonMass :: proc(shape: ^Polygon, density: f32) -> MassData ---
 
 	/// Compute the bounding box of a transformed circle
 	ComputeCircleAABB :: proc(shape: ^Circle, transform: Transform) -> AABB ---
@@ -482,13 +482,13 @@ foreign lib {
 	ComputeSegmentAABB :: proc(shape: ^Segment, transform: Transform) -> AABB ---
 
 	/// Test a point for overlap with a circle in local space
-	PointInCircle :: proc(point: Vec2, shape: ^Circle) -> c.bool ---
+	PointInCircle :: proc(point: Vec2, shape: ^Circle) -> bool ---
 
 	/// Test a point for overlap with a capsule in local space
-	PointInCapsule :: proc(point: Vec2, shape: ^Capsule) -> c.bool ---
+	PointInCapsule :: proc(point: Vec2, shape: ^Capsule) -> bool ---
 
 	/// Test a point for overlap with a convex polygon in local space
-	PointInPolygon :: proc(point: Vec2, shape: ^Polygon) -> c.bool ---
+	PointInPolygon :: proc(point: Vec2, shape: ^Polygon) -> bool ---
 
 	/// Ray cast versus circle shape in local space. Initial overlap is treated as a miss.
 	RayCastCircle :: proc(input: ^RayCastInput, shape: ^Circle) -> CastOutput ---
@@ -498,7 +498,7 @@ foreign lib {
 
 	/// Ray cast versus segment shape in local space. Optionally treat the segment as one-sided with hits from
 	/// the left side being treated as a miss.
-	RayCastSegment :: proc(input: ^RayCastInput, shape: ^Segment, oneSided: c.bool) -> CastOutput ---
+	RayCastSegment :: proc(input: ^RayCastInput, shape: ^Segment, oneSided: bool) -> CastOutput ---
 
 	/// Ray cast versus polygon shape in local space. Initial overlap is treated as a miss.
 	RayCastPolygon :: proc(input: ^RayCastInput, shape: ^Polygon) -> CastOutput ---
@@ -529,7 +529,7 @@ foreign lib {
 	/// - convexity
 	/// - collinear points
 	/// This is expensive and should not be called at runtime.
-	ValidateHull :: proc(hull: ^Hull) -> c.bool ---
+	ValidateHull :: proc(hull: ^Hull) -> bool ---
 
 	/// Compute the distance between two line segments, clamping at the end points if needed.
 	SegmentDistance :: proc(p1: Vec2, q1: Vec2, p2: Vec2, q2: Vec2) -> SegmentDistanceResult ---
@@ -543,10 +543,10 @@ foreign lib {
 	ShapeCast :: proc(input: ^ShapeCastPairInput) -> CastOutput ---
 
 	/// Make a proxy for use in GJK and related functions.
-	MakeProxy :: proc(vertices: ^Vec2, count: c.int, radius: c.float) -> ShapeProxy ---
+	MakeProxy :: proc(vertices: ^Vec2, count: c.int, radius: f32) -> ShapeProxy ---
 
 	/// Evaluate the transform sweep at a specific time.
-	GetSweepTransform :: proc(sweep: ^Sweep, time: c.float) -> Transform ---
+	GetSweepTransform :: proc(sweep: ^Sweep, time: f32) -> Transform ---
 
 	/// Compute the upper bound on time before two shapes penetrate. Time is represented as
 	/// a fraction between [0,tMax]. This uses a swept separating axis and may miss some intermediate,
@@ -597,7 +597,7 @@ foreign lib {
 	DynamicTree_Destroy :: proc(tree: ^DynamicTree) ---
 
 	/// Create a proxy. Provide an AABB and a userData value.
-	DynamicTree_CreateProxy :: proc(tree: ^DynamicTree, aabb: AABB, categoryBits: c.uint64_t, userData: c.int) -> c.int ---
+	DynamicTree_CreateProxy :: proc(tree: ^DynamicTree, aabb: AABB, categoryBits: u64, userData: c.int) -> c.int ---
 
 	/// Destroy a proxy. This asserts if the id is invalid.
 	DynamicTree_DestroyProxy :: proc(tree: ^DynamicTree, proxyId: c.int) ---
@@ -610,7 +610,7 @@ foreign lib {
 
 	/// Query an AABB for overlapping proxies. The callback class is called for each proxy that overlaps the supplied AABB.
 	///	@return performance data
-	DynamicTree_Query :: proc(tree: ^DynamicTree, aabb: AABB, maskBits: c.uint64_t, callback: TreeQueryCallbackFcn, _context: rawptr) -> TreeStats ---
+	DynamicTree_Query :: proc(tree: ^DynamicTree, aabb: AABB, maskBits: u64, callback: TreeQueryCallbackFcn, _context: rawptr) -> TreeStats ---
 
 	/// Ray cast against the proxies in the tree. This relies on the callback
 	/// to perform a exact ray cast in the case were the proxy contains a shape.
@@ -625,7 +625,7 @@ foreign lib {
 	/// @param callback a callback class that is called for each proxy that is hit by the ray
 	/// @param context user context that is passed to the callback
 	///	@return performance data
-	DynamicTree_RayCast :: proc(tree: ^DynamicTree, input: ^RayCastInput, maskBits: c.uint64_t, callback: TreeRayCastCallbackFcn, _context: rawptr) -> TreeStats ---
+	DynamicTree_RayCast :: proc(tree: ^DynamicTree, input: ^RayCastInput, maskBits: u64, callback: TreeRayCastCallbackFcn, _context: rawptr) -> TreeStats ---
 
 	/// Ray cast against the proxies in the tree. This relies on the callback
 	/// to perform a exact ray cast in the case were the proxy contains a shape.
@@ -638,19 +638,19 @@ foreign lib {
 	/// @param callback a callback class that is called for each proxy that is hit by the shape
 	/// @param context user context that is passed to the callback
 	///	@return performance data
-	DynamicTree_ShapeCast :: proc(tree: ^DynamicTree, input: ^ShapeCastInput, maskBits: c.uint64_t, callback: TreeShapeCastCallbackFcn, _context: rawptr) -> TreeStats ---
+	DynamicTree_ShapeCast :: proc(tree: ^DynamicTree, input: ^ShapeCastInput, maskBits: u64, callback: TreeShapeCastCallbackFcn, _context: rawptr) -> TreeStats ---
 
 	/// Get the height of the binary tree.
 	DynamicTree_GetHeight :: proc(tree: ^DynamicTree) -> c.int ---
 
 	/// Get the ratio of the sum of the node areas to the root area.
-	DynamicTree_GetAreaRatio :: proc(tree: ^DynamicTree) -> c.float ---
+	DynamicTree_GetAreaRatio :: proc(tree: ^DynamicTree) -> f32 ---
 
 	/// Get the number of proxies created
 	DynamicTree_GetProxyCount :: proc(tree: ^DynamicTree) -> c.int ---
 
 	/// Rebuild the tree while retaining subtrees that haven't changed. Returns the number of boxes sorted.
-	DynamicTree_Rebuild :: proc(tree: ^DynamicTree, fullBuild: c.bool) -> c.int ---
+	DynamicTree_Rebuild :: proc(tree: ^DynamicTree, fullBuild: bool) -> c.int ---
 
 	/// Get the number of bytes used by this tree
 	DynamicTree_GetByteCount :: proc(tree: ^DynamicTree) -> c.int ---

--- a/examples/box2d/box2d/collision.odin
+++ b/examples/box2d/box2d/collision.odin
@@ -19,7 +19,7 @@ RayCastInput :: struct {
 	translation: Vec2,
 
 	/// The maximum fraction of the translation to consider, typically 1
-	maxFraction: f32,
+	maxFraction: c.float,
 }
 
 /// Low level shape cast input in generic form. This allows casting an arbitrary point
@@ -30,16 +30,16 @@ ShapeCastInput :: struct {
 	points: [8]Vec2,
 
 	/// The number of points
-	count: i32,
+	count: c.int,
 
 	/// The radius around the point cloud
-	radius: f32,
+	radius: c.float,
 
 	/// The translation of the shape cast
 	translation: Vec2,
 
 	/// The maximum fraction of the translation to consider, typically 1
-	maxFraction: f32,
+	maxFraction: c.float,
 }
 
 /// Low level ray cast or shape-cast output data
@@ -51,25 +51,25 @@ CastOutput :: struct {
 	point: Vec2,
 
 	/// The fraction of the input translation at collision
-	fraction: f32,
+	fraction: c.float,
 
 	/// The number of iterations used
-	iterations: i32,
+	iterations: c.int,
 
 	/// Did the cast hit?
-	hit: bool,
+	hit: c.bool,
 }
 
 /// This holds the mass data computed for a shape.
 MassData :: struct {
 	/// The mass of the shape, usually in kilograms.
-	mass: f32,
+	mass: c.float,
 
 	/// The position of the shape's centroid relative to the shape's origin.
 	center: Vec2,
 
 	/// The rotational inertia of the shape about the local origin.
-	rotationalInertia: f32,
+	rotationalInertia: c.float,
 }
 
 /// A solid circle
@@ -78,7 +78,7 @@ Circle :: struct {
 	center: Vec2,
 
 	/// The radius
-	radius: f32,
+	radius: c.float,
 }
 
 /// A solid capsule can be viewed as two semicircles connected
@@ -91,7 +91,7 @@ Capsule :: struct {
 	center2: Vec2,
 
 	/// The radius of the semicircles
-	radius: f32,
+	radius: c.float,
 }
 
 /// A solid convex polygon. It is assumed that the interior of the polygon is to
@@ -111,10 +111,10 @@ Polygon :: struct {
 	centroid: Vec2,
 
 	/// The external radius for rounded polygons
-	radius: f32,
+	radius: c.float,
 
 	/// The number of polygon vertices
-	count: i32,
+	count: c.int,
 }
 
 /// A line segment with two-sided collision.
@@ -140,7 +140,7 @@ ChainSegment :: struct {
 	ghost2: Vec2,
 
 	/// The owning chain shape index (internal usage only)
-	chainId: i32,
+	chainId: c.int,
 }
 
 /// A convex hull. Used to create convex polygons.
@@ -150,7 +150,7 @@ Hull :: struct {
 	points: [8]Vec2,
 
 	/// The number of points
-	count: i32,
+	count: c.int,
 }
 
 /// Result of computing the distance between two line segments
@@ -162,13 +162,13 @@ SegmentDistanceResult :: struct {
 	closest2: Vec2,
 
 	/// The barycentric coordinate on the first segment
-	fraction1: f32,
+	fraction1: c.float,
 
 	/// The barycentric coordinate on the second segment
-	fraction2: f32,
+	fraction2: c.float,
 
 	/// The squared distance between the closest points
-	distanceSquared: f32,
+	distanceSquared: c.float,
 }
 
 /// A distance proxy is used by the GJK algorithm. It encapsulates any shape.
@@ -177,10 +177,10 @@ ShapeProxy :: struct {
 	points: [8]Vec2,
 
 	/// The number of points
-	count: i32,
+	count: c.int,
 
 	/// The external radius of the point cloud
-	radius: f32,
+	radius: c.float,
 }
 
 /// Used to warm start the GJK simplex. If you call this function multiple times with nearby
@@ -189,13 +189,13 @@ ShapeProxy :: struct {
 /// Users should generally just zero initialize this structure for each call.
 SimplexCache :: struct {
 	/// The number of stored simplex points
-	count: u16,
+	count: c.uint16_t,
 
 	/// The cached simplex indices on shape A
-	indexA: [3]u8,
+	indexA: [3]c.uint8_t,
 
 	/// The cached simplex indices on shape B
-	indexB: [3]u8,
+	indexB: [3]c.uint8_t,
 }
 
 /// Input for b2ShapeDistance
@@ -213,32 +213,32 @@ DistanceInput :: struct {
 	transformB: Transform,
 
 	/// Should the proxy radius be considered?
-	useRadii: bool,
+	useRadii: c.bool,
 }
 
 /// Output for b2ShapeDistance
 DistanceOutput :: struct {
-	pointA:       Vec2, ///< Closest point on shapeA
-	pointB:       Vec2, ///< Closest point on shapeB
-	distance:     f32,  ///< The final distance, zero if overlapped
-	iterations:   i32,  ///< Number of GJK iterations used
-	simplexCount: i32,  ///< The number of simplexes stored in the simplex array
+	pointA:       Vec2,    ///< Closest point on shapeA
+	pointB:       Vec2,    ///< Closest point on shapeB
+	distance:     c.float, ///< The final distance, zero if overlapped
+	iterations:   c.int,   ///< Number of GJK iterations used
+	simplexCount: c.int,   ///< The number of simplexes stored in the simplex array
 }
 
 /// Simplex vertex for debugging the GJK algorithm
 SimplexVertex :: struct {
-	wA:     Vec2, ///< support point in proxyA
-	wB:     Vec2, ///< support point in proxyB
-	w:      Vec2, ///< wB - wA
-	a:      f32,  ///< barycentric coordinate for closest point
-	indexA: i32,  ///< wA index
-	indexB: i32,  ///< wB index
+	wA:     Vec2,    ///< support point in proxyA
+	wB:     Vec2,    ///< support point in proxyB
+	w:      Vec2,    ///< wB - wA
+	a:      c.float, ///< barycentric coordinate for closest point
+	indexA: c.int,   ///< wA index
+	indexB: c.int,   ///< wB index
 }
 
 /// Simplex from the GJK algorithm
 Simplex :: struct {
 	v1, v2, v3: SimplexVertex, ///< vertices
-	count:      i32,           ///< number of valid vertices
+	count:      c.int,         ///< number of valid vertices
 }
 
 /// Input parameters for b2ShapeCast
@@ -248,7 +248,7 @@ ShapeCastPairInput :: struct {
 	transformA:   Transform,  ///< The world transform for shape A
 	transformB:   Transform,  ///< The world transform for shape B
 	translationB: Vec2,       ///< The translation of shape B
-	maxFraction:  f32,        ///< The fraction of the translation to consider, typically 1
+	maxFraction:  c.float,    ///< The fraction of the translation to consider, typically 1
 }
 
 /// This describes the motion of a body/shape for TOI computation. Shapes are defined with respect to the body origin,
@@ -268,7 +268,7 @@ TOIInput :: struct {
 	proxyB:      ShapeProxy, ///< The proxy for shape B
 	sweepA:      Sweep,      ///< The movement of shape A
 	sweepB:      Sweep,      ///< The movement of shape B
-	maxFraction: f32,        ///< Defines the sweep interval [0, maxFraction]
+	maxFraction: c.float,    ///< Defines the sweep interval [0, maxFraction]
 }
 
 /// Describes the TOI output
@@ -283,7 +283,7 @@ TOIState :: enum c.int {
 /// Output parameters for b2TimeOfImpact.
 TOIOutput :: struct {
 	state:    TOIState, ///< The type of result
-	fraction: f32,      ///< The sweep time of the collision
+	fraction: c.float,  ///< The sweep time of the collision
 }
 
 /// A manifold point is a contact point belonging to a contact manifold.
@@ -305,27 +305,27 @@ ManifoldPoint :: struct {
 	anchorB: Vec2,
 
 	/// The separation of the contact point, negative if penetrating
-	separation: f32,
+	separation: c.float,
 
 	/// The impulse along the manifold normal vector.
-	normalImpulse: f32,
+	normalImpulse: c.float,
 
 	/// The friction impulse
-	tangentImpulse: f32,
+	tangentImpulse: c.float,
 
 	/// The maximum normal impulse applied during sub-stepping. This is important
 	/// to identify speculative contact points that had an interaction in the time step.
-	maxNormalImpulse: f32,
+	maxNormalImpulse: c.float,
 
 	/// Relative normal velocity pre-solve. Used for hit events. If the normal impulse is
 	/// zero then there was no hit. Negative means shapes are approaching.
-	normalVelocity: f32,
+	normalVelocity: c.float,
 
 	/// Uniquely identifies a contact point between two shapes
-	id: u16,
+	id: c.uint16_t,
 
 	/// Did this contact point exist the previous step?
-	persisted: bool,
+	persisted: c.bool,
 }
 
 /// A contact manifold describes the contact points between colliding shapes.
@@ -335,13 +335,13 @@ Manifold :: struct {
 	normal: Vec2,
 
 	/// Angular impulse applied for rolling resistance. N * m * s = kg * m^2 / s
-	rollingImpulse: f32,
+	rollingImpulse: c.float,
 
 	/// The manifold points, up to two are possible in 2D
 	points: [2]ManifoldPoint,
 
 	/// The number of contacts points, will be 0, 1, or 2
-	pointCount: i32,
+	pointCount: c.int,
 }
 
 /// The dynamic tree structure. This should be considered private data.
@@ -353,22 +353,22 @@ DynamicTree :: struct {
 	nodes: [^]TreeNode,
 
 	/// The root index
-	root: i32,
+	root: c.int,
 
 	/// The number of nodes
-	nodeCount: i32,
+	nodeCount: c.int,
 
 	/// The allocated node space
-	nodeCapacity: i32,
+	nodeCapacity: c.int,
 
 	/// Node free list
-	freeList: i32,
+	freeList: c.int,
 
 	/// Number of proxies created
-	proxyCount: i32,
+	proxyCount: c.int,
 
 	/// Leaf indices for rebuild
-	leafIndices: ^i32,
+	leafIndices: ^c.int,
 
 	/// Leaf bounding boxes for rebuild
 	leafBoxes: ^AABB,
@@ -377,47 +377,47 @@ DynamicTree :: struct {
 	leafCenters: ^Vec2,
 
 	/// Bins for sorting during rebuild
-	binIndices: ^i32,
+	binIndices: ^c.int,
 
 	/// Allocated space for rebuilding
-	rebuildCapacity: i32,
+	rebuildCapacity: c.int,
 }
 
 /// These are performance results returned by dynamic tree queries.
 TreeStats :: struct {
 	/// Number of internal nodes visited during the query
-	nodeVisits: i32,
+	nodeVisits: c.int,
 
 	/// Number of leaf nodes visited during the query
-	leafVisits: i32,
+	leafVisits: c.int,
 }
 
 /// This function receives proxies found in the AABB query.
 /// @return true if the query should continue
-TreeQueryCallbackFcn :: proc "c" (i32, i32, rawptr) -> bool
+TreeQueryCallbackFcn :: proc "c" (c.int, c.int, rawptr) -> c.bool
 
 /// This function receives clipped ray cast input for a proxy. The function
 /// returns the new ray fraction.
 /// - return a value of 0 to terminate the ray cast
 /// - return a value less than input->maxFraction to clip the ray
 /// - return a value of input->maxFraction to continue the ray cast without clipping
-TreeRayCastCallbackFcn :: proc "c" (^RayCastInput, i32, i32, rawptr) -> f32
+TreeRayCastCallbackFcn :: proc "c" (^RayCastInput, c.int, c.int, rawptr) -> c.float
 
 /// This function receives clipped ray cast input for a proxy. The function
 /// returns the new ray fraction.
 /// - return a value of 0 to terminate the ray cast
 /// - return a value less than input->maxFraction to clip the ray
 /// - return a value of input->maxFraction to continue the ray cast without clipping
-TreeShapeCastCallbackFcn :: proc "c" (^ShapeCastInput, i32, i32, rawptr) -> f32
+TreeShapeCastCallbackFcn :: proc "c" (^ShapeCastInput, c.int, c.int, rawptr) -> c.float
 
 @(default_calling_convention="c", link_prefix="b2")
 foreign lib {
 	/// Validate ray cast input data (NaN, etc)
-	IsValidRay :: proc(input: ^RayCastInput) -> bool ---
+	IsValidRay :: proc(input: ^RayCastInput) -> c.bool ---
 
 	/// Make a convex polygon from a convex hull. This will assert if the hull is not valid.
 	/// @warning Do not manually fill in the hull data, it must come directly from b2ComputeHull
-	MakePolygon :: proc(hull: ^Hull, radius: f32) -> Polygon ---
+	MakePolygon :: proc(hull: ^Hull, radius: c.float) -> Polygon ---
 
 	/// Make an offset convex polygon from a convex hull. This will assert if the hull is not valid.
 	/// @warning Do not manually fill in the hull data, it must come directly from b2ComputeHull
@@ -425,29 +425,29 @@ foreign lib {
 
 	/// Make an offset convex polygon from a convex hull. This will assert if the hull is not valid.
 	/// @warning Do not manually fill in the hull data, it must come directly from b2ComputeHull
-	MakeOffsetRoundedPolygon :: proc(hull: ^Hull, position: Vec2, rotation: Rot, radius: f32) -> Polygon ---
+	MakeOffsetRoundedPolygon :: proc(hull: ^Hull, position: Vec2, rotation: Rot, radius: c.float) -> Polygon ---
 
 	/// Make a square polygon, bypassing the need for a convex hull.
 	/// @param halfWidth the half-width
-	MakeSquare :: proc(halfWidth: f32) -> Polygon ---
+	MakeSquare :: proc(halfWidth: c.float) -> Polygon ---
 
 	/// Make a box (rectangle) polygon, bypassing the need for a convex hull.
 	/// @param halfWidth the half-width (x-axis)
 	/// @param halfHeight the half-height (y-axis)
-	MakeBox :: proc(halfWidth: f32, halfHeight: f32) -> Polygon ---
+	MakeBox :: proc(halfWidth: c.float, halfHeight: c.float) -> Polygon ---
 
 	/// Make a rounded box, bypassing the need for a convex hull.
 	/// @param halfWidth the half-width (x-axis)
 	/// @param halfHeight the half-height (y-axis)
 	/// @param radius the radius of the rounded extension
-	MakeRoundedBox :: proc(halfWidth: f32, halfHeight: f32, radius: f32) -> Polygon ---
+	MakeRoundedBox :: proc(halfWidth: c.float, halfHeight: c.float, radius: c.float) -> Polygon ---
 
 	/// Make an offset box, bypassing the need for a convex hull.
 	/// @param halfWidth the half-width (x-axis)
 	/// @param halfHeight the half-height (y-axis)
 	/// @param center the local center of the box
 	/// @param rotation the local rotation of the box
-	MakeOffsetBox :: proc(halfWidth: f32, halfHeight: f32, center: Vec2, rotation: Rot) -> Polygon ---
+	MakeOffsetBox :: proc(halfWidth: c.float, halfHeight: c.float, center: Vec2, rotation: Rot) -> Polygon ---
 
 	/// Make an offset rounded box, bypassing the need for a convex hull.
 	/// @param halfWidth the half-width (x-axis)
@@ -455,19 +455,19 @@ foreign lib {
 	/// @param center the local center of the box
 	/// @param rotation the local rotation of the box
 	/// @param radius the radius of the rounded extension
-	MakeOffsetRoundedBox :: proc(halfWidth: f32, halfHeight: f32, center: Vec2, rotation: Rot, radius: f32) -> Polygon ---
+	MakeOffsetRoundedBox :: proc(halfWidth: c.float, halfHeight: c.float, center: Vec2, rotation: Rot, radius: c.float) -> Polygon ---
 
 	/// Transform a polygon. This is useful for transferring a shape from one body to another.
 	TransformPolygon :: proc(transform: Transform, polygon: ^Polygon) -> Polygon ---
 
 	/// Compute mass properties of a circle
-	ComputeCircleMass :: proc(shape: ^Circle, density: f32) -> MassData ---
+	ComputeCircleMass :: proc(shape: ^Circle, density: c.float) -> MassData ---
 
 	/// Compute mass properties of a capsule
-	ComputeCapsuleMass :: proc(shape: ^Capsule, density: f32) -> MassData ---
+	ComputeCapsuleMass :: proc(shape: ^Capsule, density: c.float) -> MassData ---
 
 	/// Compute mass properties of a polygon
-	ComputePolygonMass :: proc(shape: ^Polygon, density: f32) -> MassData ---
+	ComputePolygonMass :: proc(shape: ^Polygon, density: c.float) -> MassData ---
 
 	/// Compute the bounding box of a transformed circle
 	ComputeCircleAABB :: proc(shape: ^Circle, transform: Transform) -> AABB ---
@@ -482,13 +482,13 @@ foreign lib {
 	ComputeSegmentAABB :: proc(shape: ^Segment, transform: Transform) -> AABB ---
 
 	/// Test a point for overlap with a circle in local space
-	PointInCircle :: proc(point: Vec2, shape: ^Circle) -> bool ---
+	PointInCircle :: proc(point: Vec2, shape: ^Circle) -> c.bool ---
 
 	/// Test a point for overlap with a capsule in local space
-	PointInCapsule :: proc(point: Vec2, shape: ^Capsule) -> bool ---
+	PointInCapsule :: proc(point: Vec2, shape: ^Capsule) -> c.bool ---
 
 	/// Test a point for overlap with a convex polygon in local space
-	PointInPolygon :: proc(point: Vec2, shape: ^Polygon) -> bool ---
+	PointInPolygon :: proc(point: Vec2, shape: ^Polygon) -> c.bool ---
 
 	/// Ray cast versus circle shape in local space. Initial overlap is treated as a miss.
 	RayCastCircle :: proc(input: ^RayCastInput, shape: ^Circle) -> CastOutput ---
@@ -498,7 +498,7 @@ foreign lib {
 
 	/// Ray cast versus segment shape in local space. Optionally treat the segment as one-sided with hits from
 	/// the left side being treated as a miss.
-	RayCastSegment :: proc(input: ^RayCastInput, shape: ^Segment, oneSided: bool) -> CastOutput ---
+	RayCastSegment :: proc(input: ^RayCastInput, shape: ^Segment, oneSided: c.bool) -> CastOutput ---
 
 	/// Ray cast versus polygon shape in local space. Initial overlap is treated as a miss.
 	RayCastPolygon :: proc(input: ^RayCastInput, shape: ^Polygon) -> CastOutput ---
@@ -523,13 +523,13 @@ foreign lib {
 	/// - more than B2_MAX_POLYGON_VERTICES points
 	/// This welds close points and removes collinear points.
 	/// @warning Do not modify a hull once it has been computed
-	ComputeHull :: proc(points: ^Vec2, count: i32) -> Hull ---
+	ComputeHull :: proc(points: ^Vec2, count: c.int) -> Hull ---
 
 	/// This determines if a hull is valid. Checks for:
 	/// - convexity
 	/// - collinear points
 	/// This is expensive and should not be called at runtime.
-	ValidateHull :: proc(hull: ^Hull) -> bool ---
+	ValidateHull :: proc(hull: ^Hull) -> c.bool ---
 
 	/// Compute the distance between two line segments, clamping at the end points if needed.
 	SegmentDistance :: proc(p1: Vec2, q1: Vec2, p2: Vec2, q2: Vec2) -> SegmentDistanceResult ---
@@ -537,16 +537,16 @@ foreign lib {
 	/// Compute the closest points between two shapes represented as point clouds.
 	/// b2SimplexCache cache is input/output. On the first call set b2SimplexCache.count to zero.
 	/// The underlying GJK algorithm may be debugged by passing in debug simplexes and capacity. You may pass in NULL and 0 for these.
-	ShapeDistance :: proc(cache: ^SimplexCache, input: ^DistanceInput, simplexes: ^Simplex, simplexCapacity: i32) -> DistanceOutput ---
+	ShapeDistance :: proc(cache: ^SimplexCache, input: ^DistanceInput, simplexes: ^Simplex, simplexCapacity: c.int) -> DistanceOutput ---
 
 	/// Perform a linear shape cast of shape B moving and shape A fixed. Determines the hit point, normal, and translation fraction.
 	ShapeCast :: proc(input: ^ShapeCastPairInput) -> CastOutput ---
 
 	/// Make a proxy for use in GJK and related functions.
-	MakeProxy :: proc(vertices: ^Vec2, count: i32, radius: f32) -> ShapeProxy ---
+	MakeProxy :: proc(vertices: ^Vec2, count: c.int, radius: c.float) -> ShapeProxy ---
 
 	/// Evaluate the transform sweep at a specific time.
-	GetSweepTransform :: proc(sweep: ^Sweep, time: f32) -> Transform ---
+	GetSweepTransform :: proc(sweep: ^Sweep, time: c.float) -> Transform ---
 
 	/// Compute the upper bound on time before two shapes penetrate. Time is represented as
 	/// a fraction between [0,tMax]. This uses a swept separating axis and may miss some intermediate,
@@ -597,20 +597,20 @@ foreign lib {
 	DynamicTree_Destroy :: proc(tree: ^DynamicTree) ---
 
 	/// Create a proxy. Provide an AABB and a userData value.
-	DynamicTree_CreateProxy :: proc(tree: ^DynamicTree, aabb: AABB, categoryBits: u64, userData: i32) -> i32 ---
+	DynamicTree_CreateProxy :: proc(tree: ^DynamicTree, aabb: AABB, categoryBits: c.uint64_t, userData: c.int) -> c.int ---
 
 	/// Destroy a proxy. This asserts if the id is invalid.
-	DynamicTree_DestroyProxy :: proc(tree: ^DynamicTree, proxyId: i32) ---
+	DynamicTree_DestroyProxy :: proc(tree: ^DynamicTree, proxyId: c.int) ---
 
 	/// Move a proxy to a new AABB by removing and reinserting into the tree.
-	DynamicTree_MoveProxy :: proc(tree: ^DynamicTree, proxyId: i32, aabb: AABB) ---
+	DynamicTree_MoveProxy :: proc(tree: ^DynamicTree, proxyId: c.int, aabb: AABB) ---
 
 	/// Enlarge a proxy and enlarge ancestors as necessary.
-	DynamicTree_EnlargeProxy :: proc(tree: ^DynamicTree, proxyId: i32, aabb: AABB) ---
+	DynamicTree_EnlargeProxy :: proc(tree: ^DynamicTree, proxyId: c.int, aabb: AABB) ---
 
 	/// Query an AABB for overlapping proxies. The callback class is called for each proxy that overlaps the supplied AABB.
 	///	@return performance data
-	DynamicTree_Query :: proc(tree: ^DynamicTree, aabb: AABB, maskBits: u64, callback: TreeQueryCallbackFcn, _context: rawptr) -> TreeStats ---
+	DynamicTree_Query :: proc(tree: ^DynamicTree, aabb: AABB, maskBits: c.uint64_t, callback: TreeQueryCallbackFcn, _context: rawptr) -> TreeStats ---
 
 	/// Ray cast against the proxies in the tree. This relies on the callback
 	/// to perform a exact ray cast in the case were the proxy contains a shape.
@@ -625,7 +625,7 @@ foreign lib {
 	/// @param callback a callback class that is called for each proxy that is hit by the ray
 	/// @param context user context that is passed to the callback
 	///	@return performance data
-	DynamicTree_RayCast :: proc(tree: ^DynamicTree, input: ^RayCastInput, maskBits: u64, callback: TreeRayCastCallbackFcn, _context: rawptr) -> TreeStats ---
+	DynamicTree_RayCast :: proc(tree: ^DynamicTree, input: ^RayCastInput, maskBits: c.uint64_t, callback: TreeRayCastCallbackFcn, _context: rawptr) -> TreeStats ---
 
 	/// Ray cast against the proxies in the tree. This relies on the callback
 	/// to perform a exact ray cast in the case were the proxy contains a shape.
@@ -638,28 +638,28 @@ foreign lib {
 	/// @param callback a callback class that is called for each proxy that is hit by the shape
 	/// @param context user context that is passed to the callback
 	///	@return performance data
-	DynamicTree_ShapeCast :: proc(tree: ^DynamicTree, input: ^ShapeCastInput, maskBits: u64, callback: TreeShapeCastCallbackFcn, _context: rawptr) -> TreeStats ---
+	DynamicTree_ShapeCast :: proc(tree: ^DynamicTree, input: ^ShapeCastInput, maskBits: c.uint64_t, callback: TreeShapeCastCallbackFcn, _context: rawptr) -> TreeStats ---
 
 	/// Get the height of the binary tree.
-	DynamicTree_GetHeight :: proc(tree: ^DynamicTree) -> i32 ---
+	DynamicTree_GetHeight :: proc(tree: ^DynamicTree) -> c.int ---
 
 	/// Get the ratio of the sum of the node areas to the root area.
-	DynamicTree_GetAreaRatio :: proc(tree: ^DynamicTree) -> f32 ---
+	DynamicTree_GetAreaRatio :: proc(tree: ^DynamicTree) -> c.float ---
 
 	/// Get the number of proxies created
-	DynamicTree_GetProxyCount :: proc(tree: ^DynamicTree) -> i32 ---
+	DynamicTree_GetProxyCount :: proc(tree: ^DynamicTree) -> c.int ---
 
 	/// Rebuild the tree while retaining subtrees that haven't changed. Returns the number of boxes sorted.
-	DynamicTree_Rebuild :: proc(tree: ^DynamicTree, fullBuild: bool) -> i32 ---
+	DynamicTree_Rebuild :: proc(tree: ^DynamicTree, fullBuild: c.bool) -> c.int ---
 
 	/// Get the number of bytes used by this tree
-	DynamicTree_GetByteCount :: proc(tree: ^DynamicTree) -> i32 ---
+	DynamicTree_GetByteCount :: proc(tree: ^DynamicTree) -> c.int ---
 
 	/// Get proxy user data
-	DynamicTree_GetUserData :: proc(tree: ^DynamicTree, proxyId: i32) -> i32 ---
+	DynamicTree_GetUserData :: proc(tree: ^DynamicTree, proxyId: c.int) -> c.int ---
 
 	/// Get the AABB of a proxy
-	DynamicTree_GetAABB :: proc(tree: ^DynamicTree, proxyId: i32) -> AABB ---
+	DynamicTree_GetAABB :: proc(tree: ^DynamicTree, proxyId: c.int) -> AABB ---
 
 	/// Validate this tree. For testing.
 	DynamicTree_Validate :: proc(tree: ^DynamicTree) ---

--- a/examples/box2d/box2d/id.odin
+++ b/examples/box2d/box2d/id.odin
@@ -10,61 +10,61 @@ foreign import lib "box2d.lib"
 
 /// World id references a world instance. This should be treated as an opaque handle.
 WorldId :: struct {
-	index1:     c.uint16_t,
-	generation: c.uint16_t,
+	index1:     u16,
+	generation: u16,
 }
 
 /// Body id references a body instance. This should be treated as an opaque handle.
 BodyId :: struct {
-	index1:     c.int32_t,
-	world0:     c.uint16_t,
-	generation: c.uint16_t,
+	index1:     i32,
+	world0:     u16,
+	generation: u16,
 }
 
 /// Shape id references a shape instance. This should be treated as an opaque handle.
 ShapeId :: struct {
-	index1:     c.int32_t,
-	world0:     c.uint16_t,
-	generation: c.uint16_t,
+	index1:     i32,
+	world0:     u16,
+	generation: u16,
 }
 
 /// Chain id references a chain instances. This should be treated as an opaque handle.
 ChainId :: struct {
-	index1:     c.int32_t,
-	world0:     c.uint16_t,
-	generation: c.uint16_t,
+	index1:     i32,
+	world0:     u16,
+	generation: u16,
 }
 
 /// Joint id references a joint instance. This should be treated as an opaque handle.
 JointId :: struct {
-	index1:     c.int32_t,
-	world0:     c.uint16_t,
-	generation: c.uint16_t,
+	index1:     i32,
+	world0:     u16,
+	generation: u16,
 }
 
 @(default_calling_convention="c", link_prefix="b2")
 foreign lib {
 	/// Store a body id into a uint64_t.
-	StoreBodyId :: proc(id: BodyId) -> c.uint64_t ---
+	StoreBodyId :: proc(id: BodyId) -> u64 ---
 
 	/// Load a uint64_t into a body id.
-	LoadBodyId :: proc(x: c.uint64_t) -> BodyId ---
+	LoadBodyId :: proc(x: u64) -> BodyId ---
 
 	/// Store a shape id into a uint64_t.
-	StoreShapeId :: proc(id: ShapeId) -> c.uint64_t ---
+	StoreShapeId :: proc(id: ShapeId) -> u64 ---
 
 	/// Load a uint64_t into a shape id.
-	LoadShapeId :: proc(x: c.uint64_t) -> ShapeId ---
+	LoadShapeId :: proc(x: u64) -> ShapeId ---
 
 	/// Store a chain id into a uint64_t.
-	StoreChainId :: proc(id: ChainId) -> c.uint64_t ---
+	StoreChainId :: proc(id: ChainId) -> u64 ---
 
 	/// Load a uint64_t into a chain id.
-	LoadChainId :: proc(x: c.uint64_t) -> ChainId ---
+	LoadChainId :: proc(x: u64) -> ChainId ---
 
 	/// Store a joint id into a uint64_t.
-	StoreJointId :: proc(id: JointId) -> c.uint64_t ---
+	StoreJointId :: proc(id: JointId) -> u64 ---
 
 	/// Load a uint64_t into a joint id.
-	LoadJointId :: proc(x: c.uint64_t) -> JointId ---
+	LoadJointId :: proc(x: u64) -> JointId ---
 }

--- a/examples/box2d/box2d/id.odin
+++ b/examples/box2d/box2d/id.odin
@@ -10,61 +10,61 @@ foreign import lib "box2d.lib"
 
 /// World id references a world instance. This should be treated as an opaque handle.
 WorldId :: struct {
-	index1:     u16,
-	generation: u16,
+	index1:     c.uint16_t,
+	generation: c.uint16_t,
 }
 
 /// Body id references a body instance. This should be treated as an opaque handle.
 BodyId :: struct {
-	index1:     i32,
-	world0:     u16,
-	generation: u16,
+	index1:     c.int32_t,
+	world0:     c.uint16_t,
+	generation: c.uint16_t,
 }
 
 /// Shape id references a shape instance. This should be treated as an opaque handle.
 ShapeId :: struct {
-	index1:     i32,
-	world0:     u16,
-	generation: u16,
+	index1:     c.int32_t,
+	world0:     c.uint16_t,
+	generation: c.uint16_t,
 }
 
 /// Chain id references a chain instances. This should be treated as an opaque handle.
 ChainId :: struct {
-	index1:     i32,
-	world0:     u16,
-	generation: u16,
+	index1:     c.int32_t,
+	world0:     c.uint16_t,
+	generation: c.uint16_t,
 }
 
 /// Joint id references a joint instance. This should be treated as an opaque handle.
 JointId :: struct {
-	index1:     i32,
-	world0:     u16,
-	generation: u16,
+	index1:     c.int32_t,
+	world0:     c.uint16_t,
+	generation: c.uint16_t,
 }
 
 @(default_calling_convention="c", link_prefix="b2")
 foreign lib {
 	/// Store a body id into a uint64_t.
-	StoreBodyId :: proc(id: BodyId) -> u64 ---
+	StoreBodyId :: proc(id: BodyId) -> c.uint64_t ---
 
 	/// Load a uint64_t into a body id.
-	LoadBodyId :: proc(x: u64) -> BodyId ---
+	LoadBodyId :: proc(x: c.uint64_t) -> BodyId ---
 
 	/// Store a shape id into a uint64_t.
-	StoreShapeId :: proc(id: ShapeId) -> u64 ---
+	StoreShapeId :: proc(id: ShapeId) -> c.uint64_t ---
 
 	/// Load a uint64_t into a shape id.
-	LoadShapeId :: proc(x: u64) -> ShapeId ---
+	LoadShapeId :: proc(x: c.uint64_t) -> ShapeId ---
 
 	/// Store a chain id into a uint64_t.
-	StoreChainId :: proc(id: ChainId) -> u64 ---
+	StoreChainId :: proc(id: ChainId) -> c.uint64_t ---
 
 	/// Load a uint64_t into a chain id.
-	LoadChainId :: proc(x: u64) -> ChainId ---
+	LoadChainId :: proc(x: c.uint64_t) -> ChainId ---
 
 	/// Store a joint id into a uint64_t.
-	StoreJointId :: proc(id: JointId) -> u64 ---
+	StoreJointId :: proc(id: JointId) -> c.uint64_t ---
 
 	/// Load a uint64_t into a joint id.
-	LoadJointId :: proc(x: u64) -> JointId ---
+	LoadJointId :: proc(x: c.uint64_t) -> JointId ---
 }

--- a/examples/box2d/box2d/math_functions.odin
+++ b/examples/box2d/box2d/math_functions.odin
@@ -12,22 +12,22 @@ foreign import lib "box2d.lib"
 /// This can be used to represent a point or free vector
 Vec2 :: struct {
 	/// coordinates
-	x, y: c.float,
+	x, y: f32,
 }
 
 /// Cosine and sine pair
 /// This uses a custom implementation designed for cross-platform determinism
 CosSin :: struct {
 	/// cosine and sine
-	cosine: c.float,
-	sine: c.float,
+	cosine: f32,
+	sine: f32,
 }
 
 /// 2D rotation
 /// This is similar to using a complex number for rotation
 Rot :: struct {
 	/// cosine and sine
-	_c, s: c.float,
+	_c, s: f32,
 }
 
 /// A 2D rigid transform
@@ -65,38 +65,38 @@ foreign lib {
 	ClampInt :: proc(a: c.int, lower: c.int, upper: c.int) -> c.int ---
 
 	/// @return the minimum of two floats
-	MinFloat :: proc(a: c.float, b: c.float) -> c.float ---
+	MinFloat :: proc(a: f32, b: f32) -> f32 ---
 
 	/// @return the maximum of two floats
-	MaxFloat :: proc(a: c.float, b: c.float) -> c.float ---
+	MaxFloat :: proc(a: f32, b: f32) -> f32 ---
 
 	/// @return the absolute value of a float
-	AbsFloat :: proc(a: c.float) -> c.float ---
+	AbsFloat :: proc(a: f32) -> f32 ---
 
 	/// @return a float clamped between a lower and upper bound
-	ClampFloat :: proc(a: c.float, lower: c.float, upper: c.float) -> c.float ---
+	ClampFloat :: proc(a: f32, lower: f32, upper: f32) -> f32 ---
 
 	/// Compute an approximate arctangent in the range [-pi, pi]
 	/// This is hand coded for cross-platform determinism. The atan2f
 	/// function in the standard library is not cross-platform deterministic.
 	///	Accurate to around 0.0023 degrees
-	Atan2 :: proc(y: c.float, x: c.float) -> c.float ---
+	Atan2 :: proc(y: f32, x: f32) -> f32 ---
 
 	/// Compute the cosine and sine of an angle in radians. Implemented
 	/// for cross-platform determinism.
-	ComputeCosSin :: proc(radians: c.float) -> CosSin ---
+	ComputeCosSin :: proc(radians: f32) -> CosSin ---
 
 	/// Vector dot product
-	Dot :: proc(a: Vec2, b: Vec2) -> c.float ---
+	Dot :: proc(a: Vec2, b: Vec2) -> f32 ---
 
 	/// Vector cross product. In 2D this yields a scalar.
-	Cross :: proc(a: Vec2, b: Vec2) -> c.float ---
+	Cross :: proc(a: Vec2, b: Vec2) -> f32 ---
 
 	/// Perform the cross product on a vector and a scalar. In 2D this produces a vector.
-	CrossVS :: proc(v: Vec2, s: c.float) -> Vec2 ---
+	CrossVS :: proc(v: Vec2, s: f32) -> Vec2 ---
 
 	/// Perform the cross product on a scalar and a vector. In 2D this produces a vector.
-	CrossSV :: proc(s: c.float, v: Vec2) -> Vec2 ---
+	CrossSV :: proc(s: f32, v: Vec2) -> Vec2 ---
 
 	/// Get a left pointing perpendicular vector. Equivalent to b2CrossSV(1.0f, v)
 	LeftPerp :: proc(v: Vec2) -> Vec2 ---
@@ -115,19 +115,19 @@ foreign lib {
 
 	/// Vector linear interpolation
 	/// https://fgiesen.wordpress.com/2012/08/15/linear-interpolation-past-present-and-future/
-	Lerp :: proc(a: Vec2, b: Vec2, t: c.float) -> Vec2 ---
+	Lerp :: proc(a: Vec2, b: Vec2, t: f32) -> Vec2 ---
 
 	/// Component-wise multiplication
 	Mul :: proc(a: Vec2, b: Vec2) -> Vec2 ---
 
 	/// Multiply a scalar and vector
-	MulSV :: proc(s: c.float, v: Vec2) -> Vec2 ---
+	MulSV :: proc(s: f32, v: Vec2) -> Vec2 ---
 
 	/// a + s * b
-	MulAdd :: proc(a: Vec2, s: c.float, b: Vec2) -> Vec2 ---
+	MulAdd :: proc(a: Vec2, s: f32, b: Vec2) -> Vec2 ---
 
 	/// a - s * b
-	MulSub :: proc(a: Vec2, s: c.float, b: Vec2) -> Vec2 ---
+	MulSub :: proc(a: Vec2, s: f32, b: Vec2) -> Vec2 ---
 
 	/// Component-wise absolute vector
 	Abs :: proc(a: Vec2) -> Vec2 ---
@@ -142,17 +142,17 @@ foreign lib {
 	Clamp :: proc(v: Vec2, a: Vec2, b: Vec2) -> Vec2 ---
 
 	/// Get the length of this vector (the norm)
-	Length :: proc(v: Vec2) -> c.float ---
+	Length :: proc(v: Vec2) -> f32 ---
 
 	/// Get the distance between two points
-	Distance :: proc(a: Vec2, b: Vec2) -> c.float ---
+	Distance :: proc(a: Vec2, b: Vec2) -> f32 ---
 
 	/// Convert a vector into a unit vector if possible, otherwise returns the zero vector.
 	Normalize :: proc(v: Vec2) -> Vec2 ---
 
 	/// Convert a vector into a unit vector if possible, otherwise returns the zero vector. Also
 	/// outputs the length.
-	GetLengthAndNormalize :: proc(length: ^c.float, v: Vec2) -> Vec2 ---
+	GetLengthAndNormalize :: proc(length: ^f32, v: Vec2) -> Vec2 ---
 
 	/// Normalize rotation
 	NormalizeRot :: proc(q: Rot) -> Rot ---
@@ -160,36 +160,36 @@ foreign lib {
 	/// Integrate rotation from angular velocity
 	/// @param q1 initial rotation
 	/// @param deltaAngle the angular displacement in radians
-	IntegrateRotation :: proc(q1: Rot, deltaAngle: c.float) -> Rot ---
+	IntegrateRotation :: proc(q1: Rot, deltaAngle: f32) -> Rot ---
 
 	/// Get the length squared of this vector
-	LengthSquared :: proc(v: Vec2) -> c.float ---
+	LengthSquared :: proc(v: Vec2) -> f32 ---
 
 	/// Get the distance squared between points
-	DistanceSquared :: proc(a: Vec2, b: Vec2) -> c.float ---
+	DistanceSquared :: proc(a: Vec2, b: Vec2) -> f32 ---
 
 	/// Make a rotation using an angle in radians
-	MakeRot :: proc(radians: c.float) -> Rot ---
+	MakeRot :: proc(radians: f32) -> Rot ---
 
 	/// Compute the rotation between two unit vectors
 	ComputeRotationBetweenUnitVectors :: proc(v1: Vec2, v2: Vec2) -> Rot ---
 
 	/// Is this rotation normalized?
-	IsNormalized :: proc(q: Rot) -> c.bool ---
+	IsNormalized :: proc(q: Rot) -> bool ---
 
 	/// Normalized linear interpolation
 	/// https://fgiesen.wordpress.com/2012/08/15/linear-interpolation-past-present-and-future/
 	///	https://web.archive.org/web/20170825184056/http://number-none.com/product/Understanding%20Slerp,%20Then%20Not%20Using%20It/
-	NLerp :: proc(q1: Rot, q2: Rot, t: c.float) -> Rot ---
+	NLerp :: proc(q1: Rot, q2: Rot, t: f32) -> Rot ---
 
 	/// Compute the angular velocity necessary to rotate between two rotations over a give time
 	/// @param q1 initial rotation
 	/// @param q2 final rotation
 	/// @param inv_h inverse time step
-	ComputeAngularVelocity :: proc(q1: Rot, q2: Rot, inv_h: c.float) -> c.float ---
+	ComputeAngularVelocity :: proc(q1: Rot, q2: Rot, inv_h: f32) -> f32 ---
 
 	/// Get the angle in radians in the range [-pi, pi]
-	Rot_GetAngle :: proc(q: Rot) -> c.float ---
+	Rot_GetAngle :: proc(q: Rot) -> f32 ---
 
 	/// Get the x-axis
 	Rot_GetXAxis :: proc(q: Rot) -> Vec2 ---
@@ -204,13 +204,13 @@ foreign lib {
 	InvMulRot :: proc(q: Rot, r: Rot) -> Rot ---
 
 	/// relative angle between b and a (rot_b * inv(rot_a))
-	RelativeAngle :: proc(b: Rot, a: Rot) -> c.float ---
+	RelativeAngle :: proc(b: Rot, a: Rot) -> f32 ---
 
 	/// Convert an angle in the range [-2*pi, 2*pi] into the range [-pi, pi]
-	UnwindAngle :: proc(radians: c.float) -> c.float ---
+	UnwindAngle :: proc(radians: f32) -> f32 ---
 
 	/// Convert any into the range [-pi, pi] (slow)
-	UnwindLargeAngle :: proc(radians: c.float) -> c.float ---
+	UnwindLargeAngle :: proc(radians: f32) -> f32 ---
 
 	/// Rotate a vector
 	RotateVector :: proc(q: Rot, v: Vec2) -> Vec2 ---
@@ -247,7 +247,7 @@ foreign lib {
 	Solve22 :: proc(A: Mat22, b: Vec2) -> Vec2 ---
 
 	/// Does a fully contain b
-	AABB_Contains :: proc(a: AABB, b: AABB) -> c.bool ---
+	AABB_Contains :: proc(a: AABB, b: AABB) -> bool ---
 
 	/// Get the center of the AABB.
 	AABB_Center :: proc(a: AABB) -> Vec2 ---
@@ -259,16 +259,16 @@ foreign lib {
 	AABB_Union :: proc(a: AABB, b: AABB) -> AABB ---
 
 	/// Is this a valid number? Not NaN or infinity.
-	IsValidFloat :: proc(a: c.float) -> c.bool ---
+	IsValidFloat :: proc(a: f32) -> bool ---
 
 	/// Is this a valid vector? Not NaN or infinity.
-	IsValidVec2 :: proc(v: Vec2) -> c.bool ---
+	IsValidVec2 :: proc(v: Vec2) -> bool ---
 
 	/// Is this a valid rotation? Not NaN or infinity. Is normalized.
-	IsValidRotation :: proc(q: Rot) -> c.bool ---
+	IsValidRotation :: proc(q: Rot) -> bool ---
 
 	/// Is this a valid bounding box? Not Nan or infinity. Upper bound greater than or equal to lower bound.
-	IsValidAABB :: proc(aabb: AABB) -> c.bool ---
+	IsValidAABB :: proc(aabb: AABB) -> bool ---
 
 	/// Box2D bases all length units on meters, but you may need different units for your game.
 	/// You can set this value to use different units. This should be done at application startup
@@ -284,8 +284,8 @@ foreign lib {
 	/// However, you are now on the hook for coming up with good values for gravity, density, and
 	/// forces.
 	/// @warning This must be modified before any calls to Box2D
-	SetLengthUnitsPerMeter :: proc(lengthUnits: c.float) ---
+	SetLengthUnitsPerMeter :: proc(lengthUnits: f32) ---
 
 	/// Get the current length units per meter.
-	GetLengthUnitsPerMeter :: proc() -> c.float ---
+	GetLengthUnitsPerMeter :: proc() -> f32 ---
 }

--- a/examples/box2d/box2d/math_functions.odin
+++ b/examples/box2d/box2d/math_functions.odin
@@ -12,22 +12,22 @@ foreign import lib "box2d.lib"
 /// This can be used to represent a point or free vector
 Vec2 :: struct {
 	/// coordinates
-	x, y: f32,
+	x, y: c.float,
 }
 
 /// Cosine and sine pair
 /// This uses a custom implementation designed for cross-platform determinism
 CosSin :: struct {
 	/// cosine and sine
-	cosine: f32,
-	sine: f32,
+	cosine: c.float,
+	sine: c.float,
 }
 
 /// 2D rotation
 /// This is similar to using a complex number for rotation
 Rot :: struct {
 	/// cosine and sine
-	_c, s: f32,
+	_c, s: c.float,
 }
 
 /// A 2D rigid transform
@@ -53,50 +53,50 @@ PI :: 3.14159265359
 @(default_calling_convention="c", link_prefix="b2")
 foreign lib {
 	/// @return the minimum of two integers
-	MinInt :: proc(a: i32, b: i32) -> i32 ---
+	MinInt :: proc(a: c.int, b: c.int) -> c.int ---
 
 	/// @return the maximum of two integers
-	MaxInt :: proc(a: i32, b: i32) -> i32 ---
+	MaxInt :: proc(a: c.int, b: c.int) -> c.int ---
 
 	/// @return the absolute value of an integer
-	AbsInt :: proc(a: i32) -> i32 ---
+	AbsInt :: proc(a: c.int) -> c.int ---
 
 	/// @return an integer clamped between a lower and upper bound
-	ClampInt :: proc(a: i32, lower: i32, upper: i32) -> i32 ---
+	ClampInt :: proc(a: c.int, lower: c.int, upper: c.int) -> c.int ---
 
 	/// @return the minimum of two floats
-	MinFloat :: proc(a: f32, b: f32) -> f32 ---
+	MinFloat :: proc(a: c.float, b: c.float) -> c.float ---
 
 	/// @return the maximum of two floats
-	MaxFloat :: proc(a: f32, b: f32) -> f32 ---
+	MaxFloat :: proc(a: c.float, b: c.float) -> c.float ---
 
 	/// @return the absolute value of a float
-	AbsFloat :: proc(a: f32) -> f32 ---
+	AbsFloat :: proc(a: c.float) -> c.float ---
 
 	/// @return a float clamped between a lower and upper bound
-	ClampFloat :: proc(a: f32, lower: f32, upper: f32) -> f32 ---
+	ClampFloat :: proc(a: c.float, lower: c.float, upper: c.float) -> c.float ---
 
 	/// Compute an approximate arctangent in the range [-pi, pi]
 	/// This is hand coded for cross-platform determinism. The atan2f
 	/// function in the standard library is not cross-platform deterministic.
 	///	Accurate to around 0.0023 degrees
-	Atan2 :: proc(y: f32, x: f32) -> f32 ---
+	Atan2 :: proc(y: c.float, x: c.float) -> c.float ---
 
 	/// Compute the cosine and sine of an angle in radians. Implemented
 	/// for cross-platform determinism.
-	ComputeCosSin :: proc(radians: f32) -> CosSin ---
+	ComputeCosSin :: proc(radians: c.float) -> CosSin ---
 
 	/// Vector dot product
-	Dot :: proc(a: Vec2, b: Vec2) -> f32 ---
+	Dot :: proc(a: Vec2, b: Vec2) -> c.float ---
 
 	/// Vector cross product. In 2D this yields a scalar.
-	Cross :: proc(a: Vec2, b: Vec2) -> f32 ---
+	Cross :: proc(a: Vec2, b: Vec2) -> c.float ---
 
 	/// Perform the cross product on a vector and a scalar. In 2D this produces a vector.
-	CrossVS :: proc(v: Vec2, s: f32) -> Vec2 ---
+	CrossVS :: proc(v: Vec2, s: c.float) -> Vec2 ---
 
 	/// Perform the cross product on a scalar and a vector. In 2D this produces a vector.
-	CrossSV :: proc(s: f32, v: Vec2) -> Vec2 ---
+	CrossSV :: proc(s: c.float, v: Vec2) -> Vec2 ---
 
 	/// Get a left pointing perpendicular vector. Equivalent to b2CrossSV(1.0f, v)
 	LeftPerp :: proc(v: Vec2) -> Vec2 ---
@@ -115,19 +115,19 @@ foreign lib {
 
 	/// Vector linear interpolation
 	/// https://fgiesen.wordpress.com/2012/08/15/linear-interpolation-past-present-and-future/
-	Lerp :: proc(a: Vec2, b: Vec2, t: f32) -> Vec2 ---
+	Lerp :: proc(a: Vec2, b: Vec2, t: c.float) -> Vec2 ---
 
 	/// Component-wise multiplication
 	Mul :: proc(a: Vec2, b: Vec2) -> Vec2 ---
 
 	/// Multiply a scalar and vector
-	MulSV :: proc(s: f32, v: Vec2) -> Vec2 ---
+	MulSV :: proc(s: c.float, v: Vec2) -> Vec2 ---
 
 	/// a + s * b
-	MulAdd :: proc(a: Vec2, s: f32, b: Vec2) -> Vec2 ---
+	MulAdd :: proc(a: Vec2, s: c.float, b: Vec2) -> Vec2 ---
 
 	/// a - s * b
-	MulSub :: proc(a: Vec2, s: f32, b: Vec2) -> Vec2 ---
+	MulSub :: proc(a: Vec2, s: c.float, b: Vec2) -> Vec2 ---
 
 	/// Component-wise absolute vector
 	Abs :: proc(a: Vec2) -> Vec2 ---
@@ -142,17 +142,17 @@ foreign lib {
 	Clamp :: proc(v: Vec2, a: Vec2, b: Vec2) -> Vec2 ---
 
 	/// Get the length of this vector (the norm)
-	Length :: proc(v: Vec2) -> f32 ---
+	Length :: proc(v: Vec2) -> c.float ---
 
 	/// Get the distance between two points
-	Distance :: proc(a: Vec2, b: Vec2) -> f32 ---
+	Distance :: proc(a: Vec2, b: Vec2) -> c.float ---
 
 	/// Convert a vector into a unit vector if possible, otherwise returns the zero vector.
 	Normalize :: proc(v: Vec2) -> Vec2 ---
 
 	/// Convert a vector into a unit vector if possible, otherwise returns the zero vector. Also
 	/// outputs the length.
-	GetLengthAndNormalize :: proc(length: ^f32, v: Vec2) -> Vec2 ---
+	GetLengthAndNormalize :: proc(length: ^c.float, v: Vec2) -> Vec2 ---
 
 	/// Normalize rotation
 	NormalizeRot :: proc(q: Rot) -> Rot ---
@@ -160,36 +160,36 @@ foreign lib {
 	/// Integrate rotation from angular velocity
 	/// @param q1 initial rotation
 	/// @param deltaAngle the angular displacement in radians
-	IntegrateRotation :: proc(q1: Rot, deltaAngle: f32) -> Rot ---
+	IntegrateRotation :: proc(q1: Rot, deltaAngle: c.float) -> Rot ---
 
 	/// Get the length squared of this vector
-	LengthSquared :: proc(v: Vec2) -> f32 ---
+	LengthSquared :: proc(v: Vec2) -> c.float ---
 
 	/// Get the distance squared between points
-	DistanceSquared :: proc(a: Vec2, b: Vec2) -> f32 ---
+	DistanceSquared :: proc(a: Vec2, b: Vec2) -> c.float ---
 
 	/// Make a rotation using an angle in radians
-	MakeRot :: proc(radians: f32) -> Rot ---
+	MakeRot :: proc(radians: c.float) -> Rot ---
 
 	/// Compute the rotation between two unit vectors
 	ComputeRotationBetweenUnitVectors :: proc(v1: Vec2, v2: Vec2) -> Rot ---
 
 	/// Is this rotation normalized?
-	IsNormalized :: proc(q: Rot) -> bool ---
+	IsNormalized :: proc(q: Rot) -> c.bool ---
 
 	/// Normalized linear interpolation
 	/// https://fgiesen.wordpress.com/2012/08/15/linear-interpolation-past-present-and-future/
 	///	https://web.archive.org/web/20170825184056/http://number-none.com/product/Understanding%20Slerp,%20Then%20Not%20Using%20It/
-	NLerp :: proc(q1: Rot, q2: Rot, t: f32) -> Rot ---
+	NLerp :: proc(q1: Rot, q2: Rot, t: c.float) -> Rot ---
 
 	/// Compute the angular velocity necessary to rotate between two rotations over a give time
 	/// @param q1 initial rotation
 	/// @param q2 final rotation
 	/// @param inv_h inverse time step
-	ComputeAngularVelocity :: proc(q1: Rot, q2: Rot, inv_h: f32) -> f32 ---
+	ComputeAngularVelocity :: proc(q1: Rot, q2: Rot, inv_h: c.float) -> c.float ---
 
 	/// Get the angle in radians in the range [-pi, pi]
-	Rot_GetAngle :: proc(q: Rot) -> f32 ---
+	Rot_GetAngle :: proc(q: Rot) -> c.float ---
 
 	/// Get the x-axis
 	Rot_GetXAxis :: proc(q: Rot) -> Vec2 ---
@@ -204,13 +204,13 @@ foreign lib {
 	InvMulRot :: proc(q: Rot, r: Rot) -> Rot ---
 
 	/// relative angle between b and a (rot_b * inv(rot_a))
-	RelativeAngle :: proc(b: Rot, a: Rot) -> f32 ---
+	RelativeAngle :: proc(b: Rot, a: Rot) -> c.float ---
 
 	/// Convert an angle in the range [-2*pi, 2*pi] into the range [-pi, pi]
-	UnwindAngle :: proc(radians: f32) -> f32 ---
+	UnwindAngle :: proc(radians: c.float) -> c.float ---
 
 	/// Convert any into the range [-pi, pi] (slow)
-	UnwindLargeAngle :: proc(radians: f32) -> f32 ---
+	UnwindLargeAngle :: proc(radians: c.float) -> c.float ---
 
 	/// Rotate a vector
 	RotateVector :: proc(q: Rot, v: Vec2) -> Vec2 ---
@@ -247,7 +247,7 @@ foreign lib {
 	Solve22 :: proc(A: Mat22, b: Vec2) -> Vec2 ---
 
 	/// Does a fully contain b
-	AABB_Contains :: proc(a: AABB, b: AABB) -> bool ---
+	AABB_Contains :: proc(a: AABB, b: AABB) -> c.bool ---
 
 	/// Get the center of the AABB.
 	AABB_Center :: proc(a: AABB) -> Vec2 ---
@@ -259,16 +259,16 @@ foreign lib {
 	AABB_Union :: proc(a: AABB, b: AABB) -> AABB ---
 
 	/// Is this a valid number? Not NaN or infinity.
-	IsValidFloat :: proc(a: f32) -> bool ---
+	IsValidFloat :: proc(a: c.float) -> c.bool ---
 
 	/// Is this a valid vector? Not NaN or infinity.
-	IsValidVec2 :: proc(v: Vec2) -> bool ---
+	IsValidVec2 :: proc(v: Vec2) -> c.bool ---
 
 	/// Is this a valid rotation? Not NaN or infinity. Is normalized.
-	IsValidRotation :: proc(q: Rot) -> bool ---
+	IsValidRotation :: proc(q: Rot) -> c.bool ---
 
 	/// Is this a valid bounding box? Not Nan or infinity. Upper bound greater than or equal to lower bound.
-	IsValidAABB :: proc(aabb: AABB) -> bool ---
+	IsValidAABB :: proc(aabb: AABB) -> c.bool ---
 
 	/// Box2D bases all length units on meters, but you may need different units for your game.
 	/// You can set this value to use different units. This should be done at application startup
@@ -284,8 +284,8 @@ foreign lib {
 	/// However, you are now on the hook for coming up with good values for gravity, density, and
 	/// forces.
 	/// @warning This must be modified before any calls to Box2D
-	SetLengthUnitsPerMeter :: proc(lengthUnits: f32) ---
+	SetLengthUnitsPerMeter :: proc(lengthUnits: c.float) ---
 
 	/// Get the current length units per meter.
-	GetLengthUnitsPerMeter :: proc() -> f32 ---
+	GetLengthUnitsPerMeter :: proc() -> c.float ---
 }

--- a/examples/box2d/box2d/types.odin
+++ b/examples/box2d/box2d/types.odin
@@ -27,7 +27,7 @@ DEFAULT_CATEGORY_BITS :: 0
 /// }
 /// @endcode
 /// @ingroup world
-TaskCallback :: proc "c" (i32, i32, u32, rawptr)
+TaskCallback :: proc "c" (c.int, c.int, c.uint32_t, rawptr)
 
 /// These functions can be provided to Box2D to invoke a task system. These are designed to work well with enkiTS.
 /// Returns a pointer to the user's task object. May be nullptr. A nullptr indicates to Box2D that the work was executed
@@ -40,7 +40,7 @@ TaskCallback :: proc "c" (i32, i32, u32, rawptr)
 /// endIndex - startIndex >= minRange
 /// The exception of course is when itemCount < minRange.
 /// @ingroup world
-EnqueueTaskCallback :: proc "c" (TaskCallback, i32, i32, rawptr, rawptr) -> rawptr
+EnqueueTaskCallback :: proc "c" (TaskCallback, c.int, c.int, rawptr, rawptr) -> rawptr
 
 /// Finishes a user task object that wraps a Box2D task.
 /// @ingroup world
@@ -49,12 +49,12 @@ FinishTaskCallback :: proc "c" (rawptr, rawptr)
 /// Optional friction mixing callback. This intentionally provides no context objects because this is called
 /// from a worker thread.
 /// @warning This function should not attempt to modify Box2D state or user application state.
-FrictionCallback :: proc "c" (f32, i32, f32, i32) -> f32
+FrictionCallback :: proc "c" (c.float, c.int, c.float, c.int) -> c.float
 
 /// Optional restitution mixing callback. This intentionally provides no context objects because this is called
 /// from a worker thread.
 /// @warning This function should not attempt to modify Box2D state or user application state.
-RestitutionCallback :: proc "c" (f32, i32, f32, i32) -> f32
+RestitutionCallback :: proc "c" (c.float, c.int, c.float, c.int) -> c.float
 
 /// Result from b2World_RayCastClosest
 /// @ingroup world
@@ -62,10 +62,10 @@ RayResult :: struct {
 	shapeId:    ShapeId,
 	point:      Vec2,
 	normal:     Vec2,
-	fraction:   f32,
-	nodeVisits: i32,
-	leafVisits: i32,
-	hit:        bool,
+	fraction:   c.float,
+	nodeVisits: c.int,
+	leafVisits: c.int,
+	hit:        c.bool,
 }
 
 /// World definition used to create a simulation world.
@@ -77,31 +77,31 @@ WorldDef :: struct {
 
 	/// Restitution speed threshold, usually in m/s. Collisions above this
 	/// speed have restitution applied (will bounce).
-	restitutionThreshold: f32,
+	restitutionThreshold: c.float,
 
 	/// Threshold speed for hit events. Usually meters per second.
-	hitEventThreshold: f32,
+	hitEventThreshold: c.float,
 
 	/// Contact stiffness. Cycles per second. Increasing this increases the speed of overlap recovery, but can introduce jitter.
-	contactHertz: f32,
+	contactHertz: c.float,
 
 	/// Contact bounciness. Non-dimensional. You can speed up overlap recovery by decreasing this with
 	/// the trade-off that overlap resolution becomes more energetic.
-	contactDampingRatio: f32,
+	contactDampingRatio: c.float,
 
 	/// This parameter controls how fast overlap is resolved and usually has units of meters per second. This only
 	/// puts a cap on the resolution speed. The resolution speed is increased by increasing the hertz and/or
 	/// decreasing the damping ratio.
-	contactPushMaxSpeed: f32,
+	contactPushMaxSpeed: c.float,
 
 	/// Joint stiffness. Cycles per second.
-	jointHertz: f32,
+	jointHertz: c.float,
 
 	/// Joint bounciness. Non-dimensional.
-	jointDampingRatio: f32,
+	jointDampingRatio: c.float,
 
 	/// Maximum linear speed. Usually meters per second.
-	maximumLinearSpeed: f32,
+	maximumLinearSpeed: c.float,
 
 	/// Optional mixing callback for friction. The default uses sqrt(frictionA * frictionB).
 	frictionCallback: FrictionCallback,
@@ -110,10 +110,10 @@ WorldDef :: struct {
 	restitutionCallback: RestitutionCallback,
 
 	/// Can bodies go to sleep to improve performance
-	enableSleep: bool,
+	enableSleep: c.bool,
 
 	/// Enable continuous collision
-	enableContinuous: bool,
+	enableContinuous: c.bool,
 
 	/// Number of workers to use with the provided task system. Box2D performs best when using only
 	/// performance cores and accessing a single L2 cache. Efficiency cores and hyper-threading provide
@@ -122,7 +122,7 @@ WorldDef :: struct {
 	/// that you are allocating to b2World_Step.
 	/// @warning Do not modify the default value unless you are also providing a task system and providing
 	/// task callbacks (enqueueTask and finishTask).
-	workerCount: i32,
+	workerCount: c.int,
 
 	/// Function to spawn tasks
 	enqueueTask: EnqueueTaskCallback,
@@ -137,7 +137,7 @@ WorldDef :: struct {
 	userData: rawptr,
 
 	/// Used internally to detect a valid definition. DO NOT SET.
-	internalValue: i32,
+	internalValue: c.int,
 }
 
 /// The body simulation type.
@@ -178,26 +178,26 @@ BodyDef :: struct {
 	linearVelocity: Vec2,
 
 	/// The initial angular velocity of the body. Radians per second.
-	angularVelocity: f32,
+	angularVelocity: c.float,
 
 	/// Linear damping is used to reduce the linear velocity. The damping parameter
 	/// can be larger than 1 but the damping effect becomes sensitive to the
 	/// time step when the damping parameter is large.
 	/// Generally linear damping is undesirable because it makes objects move slowly
 	/// as if they are floating.
-	linearDamping: f32,
+	linearDamping: c.float,
 
 	/// Angular damping is used to reduce the angular velocity. The damping parameter
 	/// can be larger than 1.0f but the damping effect becomes sensitive to the
 	/// time step when the damping parameter is large.
 	/// Angular damping can be use slow down rotating bodies.
-	angularDamping: f32,
+	angularDamping: c.float,
 
 	/// Scale the gravity applied to this body. Non-dimensional.
-	gravityScale: f32,
+	gravityScale: c.float,
 
 	/// Sleep speed threshold, default is 0.05 meters per second
-	sleepThreshold: f32,
+	sleepThreshold: c.float,
 
 	/// Optional body name for debugging. Up to 31 characters (excluding null termination)
 	name: cstring,
@@ -206,29 +206,29 @@ BodyDef :: struct {
 	userData: rawptr,
 
 	/// Set this flag to false if this body should never fall asleep.
-	enableSleep: bool,
+	enableSleep: c.bool,
 
 	/// Is this body initially awake or sleeping?
-	isAwake: bool,
+	isAwake: c.bool,
 
 	/// Should this body be prevented from rotating? Useful for characters.
-	fixedRotation: bool,
+	fixedRotation: c.bool,
 
 	/// Treat this body as high speed object that performs continuous collision detection
 	/// against dynamic and kinematic bodies, but not other bullet bodies.
 	/// @warning Bullets should be used sparingly. They are not a solution for general dynamic-versus-dynamic
 	/// continuous collision. They may interfere with joint constraints.
-	isBullet: bool,
+	isBullet: c.bool,
 
 	/// Used to disable a body. A disabled body does not move or collide.
-	isEnabled: bool,
+	isEnabled: c.bool,
 
 	/// This allows this body to bypass rotational speed limits. Should only be used
 	/// for circular objects, like wheels.
-	allowFastRotation: bool,
+	allowFastRotation: c.bool,
 
 	/// Used internally to detect a valid definition. DO NOT SET.
-	internalValue: i32,
+	internalValue: c.int,
 }
 
 /// This is used to filter collision on shapes. It affects shape-vs-shape collision
@@ -238,14 +238,14 @@ Filter :: struct {
 	/// The collision category bits. Normally you would just set one bit. The category bits should
 	/// represent your application object types. For example:
 	/// @code{
-	categoryBits: u64,
+	categoryBits: c.uint64_t,
 
 	/// The collision mask bits. This states the categories that this
 	/// shape would accept for collision.
 	/// For example, you may want your player to only collide with static objects
 	/// and other players.
 	/// @code{
-	maskBits: u64,
+	maskBits: c.uint64_t,
 
 	/// Collision groups allow a certain group of objects to never collide (negative)
 	/// or always collide (positive). A group index of zero has no effect. Non-zero group filtering
@@ -253,7 +253,7 @@ Filter :: struct {
 	/// For example, you may want ragdolls to collide with other ragdolls but you don't want
 	/// ragdoll self-collision. In this case you would give each ragdoll a unique negative group index
 	/// and apply that group index to all shapes on the ragdoll.
-	groupIndex: i32,
+	groupIndex: c.int,
 }
 
 /// The query filter is used to filter collisions between queries and shapes. For example,
@@ -262,11 +262,11 @@ Filter :: struct {
 /// @ingroup shape
 QueryFilter :: struct {
 	/// The collision category bits of this query. Normally you would just set one bit.
-	categoryBits: u64,
+	categoryBits: c.uint64_t,
 
 	/// The collision mask bits. This states the shape categories that this
 	/// query would accept for collision.
-	maskBits: u64,
+	maskBits: c.uint64_t,
 }
 
 /// Shape type
@@ -301,81 +301,81 @@ ShapeDef :: struct {
 	userData: rawptr,
 
 	/// The Coulomb (dry) friction coefficient, usually in the range [0,1].
-	friction: f32,
+	friction: c.float,
 
 	/// The coefficient of restitution (bounce) usually in the range [0,1].
 	/// https://en.wikipedia.org/wiki/Coefficient_of_restitution
-	restitution: f32,
+	restitution: c.float,
 
 	/// The rolling resistance usually in the range [0,1].
-	rollingResistance: f32,
+	rollingResistance: c.float,
 
 	/// The tangent speed for conveyor belts
-	tangentSpeed: f32,
+	tangentSpeed: c.float,
 
 	/// User material identifier. This is passed with query results and to friction and restitution
 	/// combining functions. It is not used internally.
-	material: i32,
+	material: c.int,
 
 	/// The density, usually in kg/m^2.
-	density: f32,
+	density: c.float,
 
 	/// Collision filtering data.
 	filter: Filter,
 
 	/// Custom debug draw color.
-	customColor: u32,
+	customColor: c.uint32_t,
 
 	/// A sensor shape generates overlap events but never generates a collision response.
 	/// Sensors do not collide with other sensors and do not have continuous collision.
 	/// Instead, use a ray or shape cast for those scenarios.
-	isSensor: bool,
+	isSensor: c.bool,
 
 	/// Enable contact events for this shape. Only applies to kinematic and dynamic bodies. Ignored for sensors.
-	enableContactEvents: bool,
+	enableContactEvents: c.bool,
 
 	/// Enable hit events for this shape. Only applies to kinematic and dynamic bodies. Ignored for sensors.
-	enableHitEvents: bool,
+	enableHitEvents: c.bool,
 
 	/// Enable pre-solve contact events for this shape. Only applies to dynamic bodies. These are expensive
 	/// and must be carefully handled due to threading. Ignored for sensors.
-	enablePreSolveEvents: bool,
+	enablePreSolveEvents: c.bool,
 
 	/// Normally shapes on static bodies don't invoke contact creation when they are added to the world. This overrides
 	/// that behavior and causes contact creation. This significantly slows down static body creation which can be important
 	/// when there are many static shapes.
 	/// This is implicitly always true for sensors, dynamic bodies, and kinematic bodies.
-	invokeContactCreation: bool,
+	invokeContactCreation: c.bool,
 
 	/// Should the body update the mass properties when this shape is created. Default is true.
-	updateBodyMass: bool,
+	updateBodyMass: c.bool,
 
 	/// Used internally to detect a valid definition. DO NOT SET.
-	internalValue: i32,
+	internalValue: c.int,
 }
 
 /// Surface materials allow chain shapes to have per segment surface properties.
 /// @ingroup shape
 SurfaceMaterial :: struct {
 	/// The Coulomb (dry) friction coefficient, usually in the range [0,1].
-	friction: f32,
+	friction: c.float,
 
 	/// The coefficient of restitution (bounce) usually in the range [0,1].
 	/// https://en.wikipedia.org/wiki/Coefficient_of_restitution
-	restitution: f32,
+	restitution: c.float,
 
 	/// The rolling resistance usually in the range [0,1].
-	rollingResistance: f32,
+	rollingResistance: c.float,
 
 	/// The tangent speed for conveyor belts
-	tangentSpeed: f32,
+	tangentSpeed: c.float,
 
 	/// User material identifier. This is passed with query results and to friction and restitution
 	/// combining functions. It is not used internally.
-	material: i32,
+	material: c.int,
 
 	/// Custom debug draw color.
-	customColor: u32,
+	customColor: c.uint32_t,
 }
 
 /// Used to create a chain of line segments. This is designed to eliminate ghost collisions with some limitations.
@@ -401,65 +401,65 @@ ChainDef :: struct {
 	points: [^]Vec2,
 
 	/// The point count, must be 4 or more.
-	count: i32,
+	count: c.int,
 
 	/// Surface materials for each segment. These are cloned.
 	materials: [^]SurfaceMaterial,
 
 	/// The material count. Must be 1 or count. This allows you to provide one
 	/// material for all segments or a unique material per segment.
-	materialCount: i32,
+	materialCount: c.int,
 
 	/// Contact filtering data.
 	filter: Filter,
 
 	/// Indicates a closed chain formed by connecting the first and last points
-	isLoop: bool,
+	isLoop: c.bool,
 
 	/// Used internally to detect a valid definition. DO NOT SET.
-	internalValue: i32,
+	internalValue: c.int,
 }
 
 //! @cond
 /// Profiling data. Times are in milliseconds.
 Profile :: struct {
-	step:                f32,
-	pairs:               f32,
-	collide:             f32,
-	solve:               f32,
-	mergeIslands:        f32,
-	prepareStages:       f32,
-	solveConstraints:    f32,
-	prepareConstraints:  f32,
-	integrateVelocities: f32,
-	warmStart:           f32,
-	solveImpulses:       f32,
-	integratePositions:  f32,
-	relaxImpulses:       f32,
-	applyRestitution:    f32,
-	storeImpulses:       f32,
-	splitIslands:        f32,
-	transforms:          f32,
-	hitEvents:           f32,
-	refit:               f32,
-	bullets:             f32,
-	sleepIslands:        f32,
-	sensors:             f32,
+	step:                c.float,
+	pairs:               c.float,
+	collide:             c.float,
+	solve:               c.float,
+	mergeIslands:        c.float,
+	prepareStages:       c.float,
+	solveConstraints:    c.float,
+	prepareConstraints:  c.float,
+	integrateVelocities: c.float,
+	warmStart:           c.float,
+	solveImpulses:       c.float,
+	integratePositions:  c.float,
+	relaxImpulses:       c.float,
+	applyRestitution:    c.float,
+	storeImpulses:       c.float,
+	splitIslands:        c.float,
+	transforms:          c.float,
+	hitEvents:           c.float,
+	refit:               c.float,
+	bullets:             c.float,
+	sleepIslands:        c.float,
+	sensors:             c.float,
 }
 
 /// Counters that give details of the simulation size.
 Counters :: struct {
-	bodyCount:        i32,
-	shapeCount:       i32,
-	contactCount:     i32,
-	jointCount:       i32,
-	islandCount:      i32,
-	stackUsed:        i32,
-	staticTreeHeight: i32,
-	treeHeight:       i32,
-	byteCount:        i32,
-	taskCount:        i32,
-	colorCounts:      [12]i32,
+	bodyCount:        c.int,
+	shapeCount:       c.int,
+	contactCount:     c.int,
+	jointCount:       c.int,
+	islandCount:      c.int,
+	stackUsed:        c.int,
+	staticTreeHeight: c.int,
+	treeHeight:       c.int,
+	byteCount:        c.int,
+	taskCount:        c.int,
+	colorCounts:      [12]c.int,
 }
 
 /// Joint type enumeration
@@ -499,44 +499,44 @@ DistanceJointDef :: struct {
 	localAnchorB: Vec2,
 
 	/// The rest length of this joint. Clamped to a stable minimum value.
-	length: f32,
+	length: c.float,
 
 	/// Enable the distance constraint to behave like a spring. If false
 	/// then the distance joint will be rigid, overriding the limit and motor.
-	enableSpring: bool,
+	enableSpring: c.bool,
 
 	/// The spring linear stiffness Hertz, cycles per second
-	hertz: f32,
+	hertz: c.float,
 
 	/// The spring linear damping ratio, non-dimensional
-	dampingRatio: f32,
+	dampingRatio: c.float,
 
 	/// Enable/disable the joint limit
-	enableLimit: bool,
+	enableLimit: c.bool,
 
 	/// Minimum length. Clamped to a stable minimum value.
-	minLength: f32,
+	minLength: c.float,
 
 	/// Maximum length. Must be greater than or equal to the minimum length.
-	maxLength: f32,
+	maxLength: c.float,
 
 	/// Enable/disable the joint motor
-	enableMotor: bool,
+	enableMotor: c.bool,
 
 	/// The maximum motor force, usually in newtons
-	maxMotorForce: f32,
+	maxMotorForce: c.float,
 
 	/// The desired motor speed, usually in meters per second
-	motorSpeed: f32,
+	motorSpeed: c.float,
 
 	/// Set this flag to true if the attached bodies should collide
-	collideConnected: bool,
+	collideConnected: c.bool,
 
 	/// User data pointer
 	userData: rawptr,
 
 	/// Used internally to detect a valid definition. DO NOT SET.
-	internalValue: i32,
+	internalValue: c.int,
 }
 
 /// A motor joint is used to control the relative motion between two bodies
@@ -554,25 +554,25 @@ MotorJointDef :: struct {
 	linearOffset: Vec2,
 
 	/// The bodyB angle minus bodyA angle in radians
-	angularOffset: f32,
+	angularOffset: c.float,
 
 	/// The maximum motor force in newtons
-	maxForce: f32,
+	maxForce: c.float,
 
 	/// The maximum motor torque in newton-meters
-	maxTorque: f32,
+	maxTorque: c.float,
 
 	/// Position correction factor in the range [0,1]
-	correctionFactor: f32,
+	correctionFactor: c.float,
 
 	/// Set this flag to true if the attached bodies should collide
-	collideConnected: bool,
+	collideConnected: c.bool,
 
 	/// User data pointer
 	userData: rawptr,
 
 	/// Used internally to detect a valid definition. DO NOT SET.
-	internalValue: i32,
+	internalValue: c.int,
 }
 
 /// A mouse joint is used to make a point on a body track a specified world point.
@@ -591,22 +591,22 @@ MouseJointDef :: struct {
 	target: Vec2,
 
 	/// Stiffness in hertz
-	hertz: f32,
+	hertz: c.float,
 
 	/// Damping ratio, non-dimensional
-	dampingRatio: f32,
+	dampingRatio: c.float,
 
 	/// Maximum force, typically in newtons
-	maxForce: f32,
+	maxForce: c.float,
 
 	/// Set this flag to true if the attached bodies should collide.
-	collideConnected: bool,
+	collideConnected: c.bool,
 
 	/// User data pointer
 	userData: rawptr,
 
 	/// Used internally to detect a valid definition. DO NOT SET.
-	internalValue: i32,
+	internalValue: c.int,
 }
 
 /// A null joint is used to disable collision between two specific bodies.
@@ -623,7 +623,7 @@ NullJointDef :: struct {
 	userData: rawptr,
 
 	/// Used internally to detect a valid definition. DO NOT SET.
-	internalValue: i32,
+	internalValue: c.int,
 }
 
 /// Prismatic joint definition
@@ -650,43 +650,43 @@ PrismaticJointDef :: struct {
 	localAxisA: Vec2,
 
 	/// The constrained angle between the bodies: bodyB_angle - bodyA_angle
-	referenceAngle: f32,
+	referenceAngle: c.float,
 
 	/// Enable a linear spring along the prismatic joint axis
-	enableSpring: bool,
+	enableSpring: c.bool,
 
 	/// The spring stiffness Hertz, cycles per second
-	hertz: f32,
+	hertz: c.float,
 
 	/// The spring damping ratio, non-dimensional
-	dampingRatio: f32,
+	dampingRatio: c.float,
 
 	/// Enable/disable the joint limit
-	enableLimit: bool,
+	enableLimit: c.bool,
 
 	/// The lower translation limit
-	lowerTranslation: f32,
+	lowerTranslation: c.float,
 
 	/// The upper translation limit
-	upperTranslation: f32,
+	upperTranslation: c.float,
 
 	/// Enable/disable the joint motor
-	enableMotor: bool,
+	enableMotor: c.bool,
 
 	/// The maximum motor force, typically in newtons
-	maxMotorForce: f32,
+	maxMotorForce: c.float,
 
 	/// The desired motor speed, typically in meters per second
-	motorSpeed: f32,
+	motorSpeed: c.float,
 
 	/// Set this flag to true if the attached bodies should collide
-	collideConnected: bool,
+	collideConnected: c.bool,
 
 	/// User data pointer
 	userData: rawptr,
 
 	/// Used internally to detect a valid definition. DO NOT SET.
-	internalValue: i32,
+	internalValue: c.int,
 }
 
 /// Revolute joint definition
@@ -716,46 +716,46 @@ RevoluteJointDef :: struct {
 
 	/// The bodyB angle minus bodyA angle in the reference state (radians).
 	/// This defines the zero angle for the joint limit.
-	referenceAngle: f32,
+	referenceAngle: c.float,
 
 	/// Enable a rotational spring on the revolute hinge axis
-	enableSpring: bool,
+	enableSpring: c.bool,
 
 	/// The spring stiffness Hertz, cycles per second
-	hertz: f32,
+	hertz: c.float,
 
 	/// The spring damping ratio, non-dimensional
-	dampingRatio: f32,
+	dampingRatio: c.float,
 
 	/// A flag to enable joint limits
-	enableLimit: bool,
+	enableLimit: c.bool,
 
 	/// The lower angle for the joint limit in radians
-	lowerAngle: f32,
+	lowerAngle: c.float,
 
 	/// The upper angle for the joint limit in radians
-	upperAngle: f32,
+	upperAngle: c.float,
 
 	/// A flag to enable the joint motor
-	enableMotor: bool,
+	enableMotor: c.bool,
 
 	/// The maximum motor torque, typically in newton-meters
-	maxMotorTorque: f32,
+	maxMotorTorque: c.float,
 
 	/// The desired motor speed in radians per second
-	motorSpeed: f32,
+	motorSpeed: c.float,
 
 	/// Scale the debug draw
-	drawSize: f32,
+	drawSize: c.float,
 
 	/// Set this flag to true if the attached bodies should collide
-	collideConnected: bool,
+	collideConnected: c.bool,
 
 	/// User data pointer
 	userData: rawptr,
 
 	/// Used internally to detect a valid definition. DO NOT SET.
-	internalValue: i32,
+	internalValue: c.int,
 }
 
 /// Weld joint definition
@@ -778,28 +778,28 @@ WeldJointDef :: struct {
 	localAnchorB: Vec2,
 
 	/// The bodyB angle minus bodyA angle in the reference state (radians)
-	referenceAngle: f32,
+	referenceAngle: c.float,
 
 	/// Linear stiffness expressed as Hertz (cycles per second). Use zero for maximum stiffness.
-	linearHertz: f32,
+	linearHertz: c.float,
 
 	/// Angular stiffness as Hertz (cycles per second). Use zero for maximum stiffness.
-	angularHertz: f32,
+	angularHertz: c.float,
 
 	/// Linear damping ratio, non-dimensional. Use 1 for critical damping.
-	linearDampingRatio: f32,
+	linearDampingRatio: c.float,
 
 	/// Linear damping ratio, non-dimensional. Use 1 for critical damping.
-	angularDampingRatio: f32,
+	angularDampingRatio: c.float,
 
 	/// Set this flag to true if the attached bodies should collide
-	collideConnected: bool,
+	collideConnected: c.bool,
 
 	/// User data pointer
 	userData: rawptr,
 
 	/// Used internally to detect a valid definition. DO NOT SET.
-	internalValue: i32,
+	internalValue: c.int,
 }
 
 /// Wheel joint definition
@@ -826,40 +826,40 @@ WheelJointDef :: struct {
 	localAxisA: Vec2,
 
 	/// Enable a linear spring along the local axis
-	enableSpring: bool,
+	enableSpring: c.bool,
 
 	/// Spring stiffness in Hertz
-	hertz: f32,
+	hertz: c.float,
 
 	/// Spring damping ratio, non-dimensional
-	dampingRatio: f32,
+	dampingRatio: c.float,
 
 	/// Enable/disable the joint linear limit
-	enableLimit: bool,
+	enableLimit: c.bool,
 
 	/// The lower translation limit
-	lowerTranslation: f32,
+	lowerTranslation: c.float,
 
 	/// The upper translation limit
-	upperTranslation: f32,
+	upperTranslation: c.float,
 
 	/// Enable/disable the joint rotational motor
-	enableMotor: bool,
+	enableMotor: c.bool,
 
 	/// The maximum motor torque, typically in newton-meters
-	maxMotorTorque: f32,
+	maxMotorTorque: c.float,
 
 	/// The desired motor speed in radians per second
-	motorSpeed: f32,
+	motorSpeed: c.float,
 
 	/// Set this flag to true if the attached bodies should collide
-	collideConnected: bool,
+	collideConnected: c.bool,
 
 	/// User data pointer
 	userData: rawptr,
 
 	/// Used internally to detect a valid definition. DO NOT SET.
-	internalValue: i32,
+	internalValue: c.int,
 }
 
 /// The explosion definition is used to configure options for explosions. Explosions
@@ -867,21 +867,21 @@ WheelJointDef :: struct {
 /// @ingroup world
 ExplosionDef :: struct {
 	/// Mask bits to filter shapes
-	maskBits: u64,
+	maskBits: c.uint64_t,
 
 	/// The center of the explosion in world space
 	position: Vec2,
 
 	/// The radius of the explosion
-	radius: f32,
+	radius: c.float,
 
 	/// The falloff distance beyond the radius. Impulse is reduced to zero at this distance.
-	falloff: f32,
+	falloff: c.float,
 
 	/// Impulse per unit length. This applies an impulse according to the shape perimeter that
 	/// is facing the explosion. Explosions only apply to circles, capsules, and polygons. This
 	/// may be negative for implosions.
-	impulsePerLength: f32,
+	impulsePerLength: c.float,
 }
 
 /// A begin touch event is generated when a shape starts to overlap a sensor shape.
@@ -920,10 +920,10 @@ SensorEvents :: struct {
 	endEvents: ^SensorEndTouchEvent,
 
 	/// The number of begin touch events
-	beginCount: i32,
+	beginCount: c.int,
 
 	/// The number of end touch events
-	endCount: i32,
+	endCount: c.int,
 }
 
 /// A begin touch event is generated when two shapes begin touching.
@@ -970,7 +970,7 @@ ContactHitEvent :: struct {
 	normal: Vec2,
 
 	/// The speed the shapes are approaching. Always positive. Typically in meters per second.
-	approachSpeed: f32,
+	approachSpeed: c.float,
 }
 
 /// Contact events are buffered in the Box2D world and are available
@@ -987,13 +987,13 @@ ContactEvents :: struct {
 	hitEvents: ^ContactHitEvent,
 
 	/// Number of begin touch events
-	beginCount: i32,
+	beginCount: c.int,
 
 	/// Number of end touch events
-	endCount: i32,
+	endCount: c.int,
 
 	/// Number of hit events
-	hitCount: i32,
+	hitCount: c.int,
 }
 
 /// Body move events triggered when a body moves.
@@ -1010,7 +1010,7 @@ BodyMoveEvent :: struct {
 	transform:  Transform,
 	bodyId:     BodyId,
 	userData:   rawptr,
-	fellAsleep: bool,
+	fellAsleep: c.bool,
 }
 
 /// Body events are buffered in the Box2D world and are available
@@ -1021,7 +1021,7 @@ BodyEvents :: struct {
 	moveEvents: ^BodyMoveEvent,
 
 	/// Number of move events
-	moveCount: i32,
+	moveCount: c.int,
 }
 
 /// The contact data for two shapes. By convention the manifold normal points
@@ -1045,7 +1045,7 @@ ContactData :: struct {
 /// @see b2ShapeDef
 /// @warning Do not attempt to modify the world inside this callback
 /// @ingroup world
-CustomFilterFcn :: proc "c" (ShapeId, ShapeId, rawptr) -> bool
+CustomFilterFcn :: proc "c" (ShapeId, ShapeId, rawptr) -> c.bool
 
 /// Prototype for a pre-solve callback.
 /// This is called after a contact is updated. This allows you to inspect a
@@ -1060,14 +1060,14 @@ CustomFilterFcn :: proc "c" (ShapeId, ShapeId, rawptr) -> bool
 /// Return false if you want to disable the contact this step
 /// @warning Do not attempt to modify the world inside this callback
 /// @ingroup world
-PreSolveFcn :: proc "c" (ShapeId, ShapeId, ^Manifold, rawptr) -> bool
+PreSolveFcn :: proc "c" (ShapeId, ShapeId, ^Manifold, rawptr) -> c.bool
 
 /// Prototype callback for overlap queries.
 /// Called for each shape found in the query.
 /// @see b2World_OverlapABB
 /// @return false to terminate the query.
 /// @ingroup world
-OverlapResultFcn :: proc "c" (ShapeId, rawptr) -> bool
+OverlapResultFcn :: proc "c" (ShapeId, rawptr) -> c.bool
 
 /// Prototype callback for ray casts.
 /// Called for each shape found in the query. You control how the ray cast
@@ -1084,7 +1084,7 @@ OverlapResultFcn :: proc "c" (ShapeId, rawptr) -> bool
 /// @return -1 to filter, 0 to terminate, fraction to clip the ray for closest hit, 1 to continue
 /// @see b2World_CastRay
 /// @ingroup world
-CastResultFcn :: proc "c" (ShapeId, Vec2, Vec2, f32, rawptr) -> f32
+CastResultFcn :: proc "c" (ShapeId, Vec2, Vec2, c.float, rawptr) -> c.float
 
 /// These colors are used for debug draw and mostly match the named SVG colors.
 /// See https://www.rapidtables.com/web/color/index.html
@@ -1243,19 +1243,19 @@ HexColor :: enum c.int {
 /// @ingroup world
 DebugDraw :: struct {
 	/// Draw a closed polygon provided in CCW order.
-	DrawPolygon: proc "c" (^Vec2, i32, HexColor, rawptr),
+	DrawPolygon: proc "c" (^Vec2, c.int, HexColor, rawptr),
 
 	/// Draw a solid closed polygon provided in CCW order.
-	DrawSolidPolygon: proc "c" (Transform, ^Vec2, i32, f32, HexColor, rawptr),
+	DrawSolidPolygon: proc "c" (Transform, ^Vec2, c.int, c.float, HexColor, rawptr),
 
 	/// Draw a circle.
-	DrawCircle: proc "c" (Vec2, f32, HexColor, rawptr),
+	DrawCircle: proc "c" (Vec2, c.float, HexColor, rawptr),
 
 	/// Draw a solid circle.
-	DrawSolidCircle: proc "c" (Transform, f32, HexColor, rawptr),
+	DrawSolidCircle: proc "c" (Transform, c.float, HexColor, rawptr),
 
 	/// Draw a solid capsule.
-	DrawSolidCapsule: proc "c" (Vec2, Vec2, f32, HexColor, rawptr),
+	DrawSolidCapsule: proc "c" (Vec2, Vec2, c.float, HexColor, rawptr),
 
 	/// Draw a line segment.
 	DrawSegment: proc "c" (Vec2, Vec2, HexColor, rawptr),
@@ -1264,7 +1264,7 @@ DebugDraw :: struct {
 	DrawTransform: proc "c" (Transform, rawptr),
 
 	/// Draw a point.
-	DrawPoint: proc "c" (Vec2, f32, HexColor, rawptr),
+	DrawPoint: proc "c" (Vec2, c.float, HexColor, rawptr),
 
 	/// Draw a string in world space
 	DrawString: proc "c" (Vec2, cstring, HexColor, rawptr),
@@ -1273,40 +1273,40 @@ DebugDraw :: struct {
 	drawingBounds: AABB,
 
 	/// Option to restrict drawing to a rectangular region. May suffer from unstable depth sorting.
-	useDrawingBounds: bool,
+	useDrawingBounds: c.bool,
 
 	/// Option to draw shapes
-	drawShapes: bool,
+	drawShapes: c.bool,
 
 	/// Option to draw joints
-	drawJoints: bool,
+	drawJoints: c.bool,
 
 	/// Option to draw additional information for joints
-	drawJointExtras: bool,
+	drawJointExtras: c.bool,
 
 	/// Option to draw the bounding boxes for shapes
-	drawAABBs: bool,
+	drawAABBs: c.bool,
 
 	/// Option to draw the mass and center of mass of dynamic bodies
-	drawMass: bool,
+	drawMass: c.bool,
 
 	/// Option to draw body names
-	drawBodyNames: bool,
+	drawBodyNames: c.bool,
 
 	/// Option to draw contact points
-	drawContacts: bool,
+	drawContacts: c.bool,
 
 	/// Option to visualize the graph coloring used for contacts and joints
-	drawGraphColors: bool,
+	drawGraphColors: c.bool,
 
 	/// Option to draw contact normals
-	drawContactNormals: bool,
+	drawContactNormals: c.bool,
 
 	/// Option to draw contact normal impulses
-	drawContactImpulses: bool,
+	drawContactImpulses: c.bool,
 
 	/// Option to draw contact friction impulses
-	drawFrictionImpulses: bool,
+	drawFrictionImpulses: c.bool,
 
 	/// User context that is passed as an argument to drawing callback functions
 	_context: rawptr,

--- a/examples/box2d/box2d/types.odin
+++ b/examples/box2d/box2d/types.odin
@@ -27,7 +27,7 @@ DEFAULT_CATEGORY_BITS :: 0
 /// }
 /// @endcode
 /// @ingroup world
-TaskCallback :: proc "c" (c.int, c.int, c.uint32_t, rawptr)
+TaskCallback :: proc "c" (c.int, c.int, u32, rawptr)
 
 /// These functions can be provided to Box2D to invoke a task system. These are designed to work well with enkiTS.
 /// Returns a pointer to the user's task object. May be nullptr. A nullptr indicates to Box2D that the work was executed
@@ -49,12 +49,12 @@ FinishTaskCallback :: proc "c" (rawptr, rawptr)
 /// Optional friction mixing callback. This intentionally provides no context objects because this is called
 /// from a worker thread.
 /// @warning This function should not attempt to modify Box2D state or user application state.
-FrictionCallback :: proc "c" (c.float, c.int, c.float, c.int) -> c.float
+FrictionCallback :: proc "c" (f32, c.int, f32, c.int) -> f32
 
 /// Optional restitution mixing callback. This intentionally provides no context objects because this is called
 /// from a worker thread.
 /// @warning This function should not attempt to modify Box2D state or user application state.
-RestitutionCallback :: proc "c" (c.float, c.int, c.float, c.int) -> c.float
+RestitutionCallback :: proc "c" (f32, c.int, f32, c.int) -> f32
 
 /// Result from b2World_RayCastClosest
 /// @ingroup world
@@ -62,10 +62,10 @@ RayResult :: struct {
 	shapeId:    ShapeId,
 	point:      Vec2,
 	normal:     Vec2,
-	fraction:   c.float,
+	fraction:   f32,
 	nodeVisits: c.int,
 	leafVisits: c.int,
-	hit:        c.bool,
+	hit:        bool,
 }
 
 /// World definition used to create a simulation world.
@@ -77,31 +77,31 @@ WorldDef :: struct {
 
 	/// Restitution speed threshold, usually in m/s. Collisions above this
 	/// speed have restitution applied (will bounce).
-	restitutionThreshold: c.float,
+	restitutionThreshold: f32,
 
 	/// Threshold speed for hit events. Usually meters per second.
-	hitEventThreshold: c.float,
+	hitEventThreshold: f32,
 
 	/// Contact stiffness. Cycles per second. Increasing this increases the speed of overlap recovery, but can introduce jitter.
-	contactHertz: c.float,
+	contactHertz: f32,
 
 	/// Contact bounciness. Non-dimensional. You can speed up overlap recovery by decreasing this with
 	/// the trade-off that overlap resolution becomes more energetic.
-	contactDampingRatio: c.float,
+	contactDampingRatio: f32,
 
 	/// This parameter controls how fast overlap is resolved and usually has units of meters per second. This only
 	/// puts a cap on the resolution speed. The resolution speed is increased by increasing the hertz and/or
 	/// decreasing the damping ratio.
-	contactPushMaxSpeed: c.float,
+	contactPushMaxSpeed: f32,
 
 	/// Joint stiffness. Cycles per second.
-	jointHertz: c.float,
+	jointHertz: f32,
 
 	/// Joint bounciness. Non-dimensional.
-	jointDampingRatio: c.float,
+	jointDampingRatio: f32,
 
 	/// Maximum linear speed. Usually meters per second.
-	maximumLinearSpeed: c.float,
+	maximumLinearSpeed: f32,
 
 	/// Optional mixing callback for friction. The default uses sqrt(frictionA * frictionB).
 	frictionCallback: FrictionCallback,
@@ -110,10 +110,10 @@ WorldDef :: struct {
 	restitutionCallback: RestitutionCallback,
 
 	/// Can bodies go to sleep to improve performance
-	enableSleep: c.bool,
+	enableSleep: bool,
 
 	/// Enable continuous collision
-	enableContinuous: c.bool,
+	enableContinuous: bool,
 
 	/// Number of workers to use with the provided task system. Box2D performs best when using only
 	/// performance cores and accessing a single L2 cache. Efficiency cores and hyper-threading provide
@@ -178,26 +178,26 @@ BodyDef :: struct {
 	linearVelocity: Vec2,
 
 	/// The initial angular velocity of the body. Radians per second.
-	angularVelocity: c.float,
+	angularVelocity: f32,
 
 	/// Linear damping is used to reduce the linear velocity. The damping parameter
 	/// can be larger than 1 but the damping effect becomes sensitive to the
 	/// time step when the damping parameter is large.
 	/// Generally linear damping is undesirable because it makes objects move slowly
 	/// as if they are floating.
-	linearDamping: c.float,
+	linearDamping: f32,
 
 	/// Angular damping is used to reduce the angular velocity. The damping parameter
 	/// can be larger than 1.0f but the damping effect becomes sensitive to the
 	/// time step when the damping parameter is large.
 	/// Angular damping can be use slow down rotating bodies.
-	angularDamping: c.float,
+	angularDamping: f32,
 
 	/// Scale the gravity applied to this body. Non-dimensional.
-	gravityScale: c.float,
+	gravityScale: f32,
 
 	/// Sleep speed threshold, default is 0.05 meters per second
-	sleepThreshold: c.float,
+	sleepThreshold: f32,
 
 	/// Optional body name for debugging. Up to 31 characters (excluding null termination)
 	name: cstring,
@@ -206,26 +206,26 @@ BodyDef :: struct {
 	userData: rawptr,
 
 	/// Set this flag to false if this body should never fall asleep.
-	enableSleep: c.bool,
+	enableSleep: bool,
 
 	/// Is this body initially awake or sleeping?
-	isAwake: c.bool,
+	isAwake: bool,
 
 	/// Should this body be prevented from rotating? Useful for characters.
-	fixedRotation: c.bool,
+	fixedRotation: bool,
 
 	/// Treat this body as high speed object that performs continuous collision detection
 	/// against dynamic and kinematic bodies, but not other bullet bodies.
 	/// @warning Bullets should be used sparingly. They are not a solution for general dynamic-versus-dynamic
 	/// continuous collision. They may interfere with joint constraints.
-	isBullet: c.bool,
+	isBullet: bool,
 
 	/// Used to disable a body. A disabled body does not move or collide.
-	isEnabled: c.bool,
+	isEnabled: bool,
 
 	/// This allows this body to bypass rotational speed limits. Should only be used
 	/// for circular objects, like wheels.
-	allowFastRotation: c.bool,
+	allowFastRotation: bool,
 
 	/// Used internally to detect a valid definition. DO NOT SET.
 	internalValue: c.int,
@@ -238,14 +238,14 @@ Filter :: struct {
 	/// The collision category bits. Normally you would just set one bit. The category bits should
 	/// represent your application object types. For example:
 	/// @code{
-	categoryBits: c.uint64_t,
+	categoryBits: u64,
 
 	/// The collision mask bits. This states the categories that this
 	/// shape would accept for collision.
 	/// For example, you may want your player to only collide with static objects
 	/// and other players.
 	/// @code{
-	maskBits: c.uint64_t,
+	maskBits: u64,
 
 	/// Collision groups allow a certain group of objects to never collide (negative)
 	/// or always collide (positive). A group index of zero has no effect. Non-zero group filtering
@@ -262,11 +262,11 @@ Filter :: struct {
 /// @ingroup shape
 QueryFilter :: struct {
 	/// The collision category bits of this query. Normally you would just set one bit.
-	categoryBits: c.uint64_t,
+	categoryBits: u64,
 
 	/// The collision mask bits. This states the shape categories that this
 	/// query would accept for collision.
-	maskBits: c.uint64_t,
+	maskBits: u64,
 }
 
 /// Shape type
@@ -301,54 +301,54 @@ ShapeDef :: struct {
 	userData: rawptr,
 
 	/// The Coulomb (dry) friction coefficient, usually in the range [0,1].
-	friction: c.float,
+	friction: f32,
 
 	/// The coefficient of restitution (bounce) usually in the range [0,1].
 	/// https://en.wikipedia.org/wiki/Coefficient_of_restitution
-	restitution: c.float,
+	restitution: f32,
 
 	/// The rolling resistance usually in the range [0,1].
-	rollingResistance: c.float,
+	rollingResistance: f32,
 
 	/// The tangent speed for conveyor belts
-	tangentSpeed: c.float,
+	tangentSpeed: f32,
 
 	/// User material identifier. This is passed with query results and to friction and restitution
 	/// combining functions. It is not used internally.
 	material: c.int,
 
 	/// The density, usually in kg/m^2.
-	density: c.float,
+	density: f32,
 
 	/// Collision filtering data.
 	filter: Filter,
 
 	/// Custom debug draw color.
-	customColor: c.uint32_t,
+	customColor: u32,
 
 	/// A sensor shape generates overlap events but never generates a collision response.
 	/// Sensors do not collide with other sensors and do not have continuous collision.
 	/// Instead, use a ray or shape cast for those scenarios.
-	isSensor: c.bool,
+	isSensor: bool,
 
 	/// Enable contact events for this shape. Only applies to kinematic and dynamic bodies. Ignored for sensors.
-	enableContactEvents: c.bool,
+	enableContactEvents: bool,
 
 	/// Enable hit events for this shape. Only applies to kinematic and dynamic bodies. Ignored for sensors.
-	enableHitEvents: c.bool,
+	enableHitEvents: bool,
 
 	/// Enable pre-solve contact events for this shape. Only applies to dynamic bodies. These are expensive
 	/// and must be carefully handled due to threading. Ignored for sensors.
-	enablePreSolveEvents: c.bool,
+	enablePreSolveEvents: bool,
 
 	/// Normally shapes on static bodies don't invoke contact creation when they are added to the world. This overrides
 	/// that behavior and causes contact creation. This significantly slows down static body creation which can be important
 	/// when there are many static shapes.
 	/// This is implicitly always true for sensors, dynamic bodies, and kinematic bodies.
-	invokeContactCreation: c.bool,
+	invokeContactCreation: bool,
 
 	/// Should the body update the mass properties when this shape is created. Default is true.
-	updateBodyMass: c.bool,
+	updateBodyMass: bool,
 
 	/// Used internally to detect a valid definition. DO NOT SET.
 	internalValue: c.int,
@@ -358,24 +358,24 @@ ShapeDef :: struct {
 /// @ingroup shape
 SurfaceMaterial :: struct {
 	/// The Coulomb (dry) friction coefficient, usually in the range [0,1].
-	friction: c.float,
+	friction: f32,
 
 	/// The coefficient of restitution (bounce) usually in the range [0,1].
 	/// https://en.wikipedia.org/wiki/Coefficient_of_restitution
-	restitution: c.float,
+	restitution: f32,
 
 	/// The rolling resistance usually in the range [0,1].
-	rollingResistance: c.float,
+	rollingResistance: f32,
 
 	/// The tangent speed for conveyor belts
-	tangentSpeed: c.float,
+	tangentSpeed: f32,
 
 	/// User material identifier. This is passed with query results and to friction and restitution
 	/// combining functions. It is not used internally.
 	material: c.int,
 
 	/// Custom debug draw color.
-	customColor: c.uint32_t,
+	customColor: u32,
 }
 
 /// Used to create a chain of line segments. This is designed to eliminate ghost collisions with some limitations.
@@ -414,7 +414,7 @@ ChainDef :: struct {
 	filter: Filter,
 
 	/// Indicates a closed chain formed by connecting the first and last points
-	isLoop: c.bool,
+	isLoop: bool,
 
 	/// Used internally to detect a valid definition. DO NOT SET.
 	internalValue: c.int,
@@ -423,28 +423,28 @@ ChainDef :: struct {
 //! @cond
 /// Profiling data. Times are in milliseconds.
 Profile :: struct {
-	step:                c.float,
-	pairs:               c.float,
-	collide:             c.float,
-	solve:               c.float,
-	mergeIslands:        c.float,
-	prepareStages:       c.float,
-	solveConstraints:    c.float,
-	prepareConstraints:  c.float,
-	integrateVelocities: c.float,
-	warmStart:           c.float,
-	solveImpulses:       c.float,
-	integratePositions:  c.float,
-	relaxImpulses:       c.float,
-	applyRestitution:    c.float,
-	storeImpulses:       c.float,
-	splitIslands:        c.float,
-	transforms:          c.float,
-	hitEvents:           c.float,
-	refit:               c.float,
-	bullets:             c.float,
-	sleepIslands:        c.float,
-	sensors:             c.float,
+	step:                f32,
+	pairs:               f32,
+	collide:             f32,
+	solve:               f32,
+	mergeIslands:        f32,
+	prepareStages:       f32,
+	solveConstraints:    f32,
+	prepareConstraints:  f32,
+	integrateVelocities: f32,
+	warmStart:           f32,
+	solveImpulses:       f32,
+	integratePositions:  f32,
+	relaxImpulses:       f32,
+	applyRestitution:    f32,
+	storeImpulses:       f32,
+	splitIslands:        f32,
+	transforms:          f32,
+	hitEvents:           f32,
+	refit:               f32,
+	bullets:             f32,
+	sleepIslands:        f32,
+	sensors:             f32,
 }
 
 /// Counters that give details of the simulation size.
@@ -499,38 +499,38 @@ DistanceJointDef :: struct {
 	localAnchorB: Vec2,
 
 	/// The rest length of this joint. Clamped to a stable minimum value.
-	length: c.float,
+	length: f32,
 
 	/// Enable the distance constraint to behave like a spring. If false
 	/// then the distance joint will be rigid, overriding the limit and motor.
-	enableSpring: c.bool,
+	enableSpring: bool,
 
 	/// The spring linear stiffness Hertz, cycles per second
-	hertz: c.float,
+	hertz: f32,
 
 	/// The spring linear damping ratio, non-dimensional
-	dampingRatio: c.float,
+	dampingRatio: f32,
 
 	/// Enable/disable the joint limit
-	enableLimit: c.bool,
+	enableLimit: bool,
 
 	/// Minimum length. Clamped to a stable minimum value.
-	minLength: c.float,
+	minLength: f32,
 
 	/// Maximum length. Must be greater than or equal to the minimum length.
-	maxLength: c.float,
+	maxLength: f32,
 
 	/// Enable/disable the joint motor
-	enableMotor: c.bool,
+	enableMotor: bool,
 
 	/// The maximum motor force, usually in newtons
-	maxMotorForce: c.float,
+	maxMotorForce: f32,
 
 	/// The desired motor speed, usually in meters per second
-	motorSpeed: c.float,
+	motorSpeed: f32,
 
 	/// Set this flag to true if the attached bodies should collide
-	collideConnected: c.bool,
+	collideConnected: bool,
 
 	/// User data pointer
 	userData: rawptr,
@@ -554,19 +554,19 @@ MotorJointDef :: struct {
 	linearOffset: Vec2,
 
 	/// The bodyB angle minus bodyA angle in radians
-	angularOffset: c.float,
+	angularOffset: f32,
 
 	/// The maximum motor force in newtons
-	maxForce: c.float,
+	maxForce: f32,
 
 	/// The maximum motor torque in newton-meters
-	maxTorque: c.float,
+	maxTorque: f32,
 
 	/// Position correction factor in the range [0,1]
-	correctionFactor: c.float,
+	correctionFactor: f32,
 
 	/// Set this flag to true if the attached bodies should collide
-	collideConnected: c.bool,
+	collideConnected: bool,
 
 	/// User data pointer
 	userData: rawptr,
@@ -591,16 +591,16 @@ MouseJointDef :: struct {
 	target: Vec2,
 
 	/// Stiffness in hertz
-	hertz: c.float,
+	hertz: f32,
 
 	/// Damping ratio, non-dimensional
-	dampingRatio: c.float,
+	dampingRatio: f32,
 
 	/// Maximum force, typically in newtons
-	maxForce: c.float,
+	maxForce: f32,
 
 	/// Set this flag to true if the attached bodies should collide.
-	collideConnected: c.bool,
+	collideConnected: bool,
 
 	/// User data pointer
 	userData: rawptr,
@@ -650,37 +650,37 @@ PrismaticJointDef :: struct {
 	localAxisA: Vec2,
 
 	/// The constrained angle between the bodies: bodyB_angle - bodyA_angle
-	referenceAngle: c.float,
+	referenceAngle: f32,
 
 	/// Enable a linear spring along the prismatic joint axis
-	enableSpring: c.bool,
+	enableSpring: bool,
 
 	/// The spring stiffness Hertz, cycles per second
-	hertz: c.float,
+	hertz: f32,
 
 	/// The spring damping ratio, non-dimensional
-	dampingRatio: c.float,
+	dampingRatio: f32,
 
 	/// Enable/disable the joint limit
-	enableLimit: c.bool,
+	enableLimit: bool,
 
 	/// The lower translation limit
-	lowerTranslation: c.float,
+	lowerTranslation: f32,
 
 	/// The upper translation limit
-	upperTranslation: c.float,
+	upperTranslation: f32,
 
 	/// Enable/disable the joint motor
-	enableMotor: c.bool,
+	enableMotor: bool,
 
 	/// The maximum motor force, typically in newtons
-	maxMotorForce: c.float,
+	maxMotorForce: f32,
 
 	/// The desired motor speed, typically in meters per second
-	motorSpeed: c.float,
+	motorSpeed: f32,
 
 	/// Set this flag to true if the attached bodies should collide
-	collideConnected: c.bool,
+	collideConnected: bool,
 
 	/// User data pointer
 	userData: rawptr,
@@ -716,40 +716,40 @@ RevoluteJointDef :: struct {
 
 	/// The bodyB angle minus bodyA angle in the reference state (radians).
 	/// This defines the zero angle for the joint limit.
-	referenceAngle: c.float,
+	referenceAngle: f32,
 
 	/// Enable a rotational spring on the revolute hinge axis
-	enableSpring: c.bool,
+	enableSpring: bool,
 
 	/// The spring stiffness Hertz, cycles per second
-	hertz: c.float,
+	hertz: f32,
 
 	/// The spring damping ratio, non-dimensional
-	dampingRatio: c.float,
+	dampingRatio: f32,
 
 	/// A flag to enable joint limits
-	enableLimit: c.bool,
+	enableLimit: bool,
 
 	/// The lower angle for the joint limit in radians
-	lowerAngle: c.float,
+	lowerAngle: f32,
 
 	/// The upper angle for the joint limit in radians
-	upperAngle: c.float,
+	upperAngle: f32,
 
 	/// A flag to enable the joint motor
-	enableMotor: c.bool,
+	enableMotor: bool,
 
 	/// The maximum motor torque, typically in newton-meters
-	maxMotorTorque: c.float,
+	maxMotorTorque: f32,
 
 	/// The desired motor speed in radians per second
-	motorSpeed: c.float,
+	motorSpeed: f32,
 
 	/// Scale the debug draw
-	drawSize: c.float,
+	drawSize: f32,
 
 	/// Set this flag to true if the attached bodies should collide
-	collideConnected: c.bool,
+	collideConnected: bool,
 
 	/// User data pointer
 	userData: rawptr,
@@ -778,22 +778,22 @@ WeldJointDef :: struct {
 	localAnchorB: Vec2,
 
 	/// The bodyB angle minus bodyA angle in the reference state (radians)
-	referenceAngle: c.float,
+	referenceAngle: f32,
 
 	/// Linear stiffness expressed as Hertz (cycles per second). Use zero for maximum stiffness.
-	linearHertz: c.float,
+	linearHertz: f32,
 
 	/// Angular stiffness as Hertz (cycles per second). Use zero for maximum stiffness.
-	angularHertz: c.float,
+	angularHertz: f32,
 
 	/// Linear damping ratio, non-dimensional. Use 1 for critical damping.
-	linearDampingRatio: c.float,
+	linearDampingRatio: f32,
 
 	/// Linear damping ratio, non-dimensional. Use 1 for critical damping.
-	angularDampingRatio: c.float,
+	angularDampingRatio: f32,
 
 	/// Set this flag to true if the attached bodies should collide
-	collideConnected: c.bool,
+	collideConnected: bool,
 
 	/// User data pointer
 	userData: rawptr,
@@ -826,34 +826,34 @@ WheelJointDef :: struct {
 	localAxisA: Vec2,
 
 	/// Enable a linear spring along the local axis
-	enableSpring: c.bool,
+	enableSpring: bool,
 
 	/// Spring stiffness in Hertz
-	hertz: c.float,
+	hertz: f32,
 
 	/// Spring damping ratio, non-dimensional
-	dampingRatio: c.float,
+	dampingRatio: f32,
 
 	/// Enable/disable the joint linear limit
-	enableLimit: c.bool,
+	enableLimit: bool,
 
 	/// The lower translation limit
-	lowerTranslation: c.float,
+	lowerTranslation: f32,
 
 	/// The upper translation limit
-	upperTranslation: c.float,
+	upperTranslation: f32,
 
 	/// Enable/disable the joint rotational motor
-	enableMotor: c.bool,
+	enableMotor: bool,
 
 	/// The maximum motor torque, typically in newton-meters
-	maxMotorTorque: c.float,
+	maxMotorTorque: f32,
 
 	/// The desired motor speed in radians per second
-	motorSpeed: c.float,
+	motorSpeed: f32,
 
 	/// Set this flag to true if the attached bodies should collide
-	collideConnected: c.bool,
+	collideConnected: bool,
 
 	/// User data pointer
 	userData: rawptr,
@@ -867,21 +867,21 @@ WheelJointDef :: struct {
 /// @ingroup world
 ExplosionDef :: struct {
 	/// Mask bits to filter shapes
-	maskBits: c.uint64_t,
+	maskBits: u64,
 
 	/// The center of the explosion in world space
 	position: Vec2,
 
 	/// The radius of the explosion
-	radius: c.float,
+	radius: f32,
 
 	/// The falloff distance beyond the radius. Impulse is reduced to zero at this distance.
-	falloff: c.float,
+	falloff: f32,
 
 	/// Impulse per unit length. This applies an impulse according to the shape perimeter that
 	/// is facing the explosion. Explosions only apply to circles, capsules, and polygons. This
 	/// may be negative for implosions.
-	impulsePerLength: c.float,
+	impulsePerLength: f32,
 }
 
 /// A begin touch event is generated when a shape starts to overlap a sensor shape.
@@ -970,7 +970,7 @@ ContactHitEvent :: struct {
 	normal: Vec2,
 
 	/// The speed the shapes are approaching. Always positive. Typically in meters per second.
-	approachSpeed: c.float,
+	approachSpeed: f32,
 }
 
 /// Contact events are buffered in the Box2D world and are available
@@ -1010,7 +1010,7 @@ BodyMoveEvent :: struct {
 	transform:  Transform,
 	bodyId:     BodyId,
 	userData:   rawptr,
-	fellAsleep: c.bool,
+	fellAsleep: bool,
 }
 
 /// Body events are buffered in the Box2D world and are available
@@ -1045,7 +1045,7 @@ ContactData :: struct {
 /// @see b2ShapeDef
 /// @warning Do not attempt to modify the world inside this callback
 /// @ingroup world
-CustomFilterFcn :: proc "c" (ShapeId, ShapeId, rawptr) -> c.bool
+CustomFilterFcn :: proc "c" (ShapeId, ShapeId, rawptr) -> bool
 
 /// Prototype for a pre-solve callback.
 /// This is called after a contact is updated. This allows you to inspect a
@@ -1060,14 +1060,14 @@ CustomFilterFcn :: proc "c" (ShapeId, ShapeId, rawptr) -> c.bool
 /// Return false if you want to disable the contact this step
 /// @warning Do not attempt to modify the world inside this callback
 /// @ingroup world
-PreSolveFcn :: proc "c" (ShapeId, ShapeId, ^Manifold, rawptr) -> c.bool
+PreSolveFcn :: proc "c" (ShapeId, ShapeId, ^Manifold, rawptr) -> bool
 
 /// Prototype callback for overlap queries.
 /// Called for each shape found in the query.
 /// @see b2World_OverlapABB
 /// @return false to terminate the query.
 /// @ingroup world
-OverlapResultFcn :: proc "c" (ShapeId, rawptr) -> c.bool
+OverlapResultFcn :: proc "c" (ShapeId, rawptr) -> bool
 
 /// Prototype callback for ray casts.
 /// Called for each shape found in the query. You control how the ray cast
@@ -1084,7 +1084,7 @@ OverlapResultFcn :: proc "c" (ShapeId, rawptr) -> c.bool
 /// @return -1 to filter, 0 to terminate, fraction to clip the ray for closest hit, 1 to continue
 /// @see b2World_CastRay
 /// @ingroup world
-CastResultFcn :: proc "c" (ShapeId, Vec2, Vec2, c.float, rawptr) -> c.float
+CastResultFcn :: proc "c" (ShapeId, Vec2, Vec2, f32, rawptr) -> f32
 
 /// These colors are used for debug draw and mostly match the named SVG colors.
 /// See https://www.rapidtables.com/web/color/index.html
@@ -1246,16 +1246,16 @@ DebugDraw :: struct {
 	DrawPolygon: proc "c" (^Vec2, c.int, HexColor, rawptr),
 
 	/// Draw a solid closed polygon provided in CCW order.
-	DrawSolidPolygon: proc "c" (Transform, ^Vec2, c.int, c.float, HexColor, rawptr),
+	DrawSolidPolygon: proc "c" (Transform, ^Vec2, c.int, f32, HexColor, rawptr),
 
 	/// Draw a circle.
-	DrawCircle: proc "c" (Vec2, c.float, HexColor, rawptr),
+	DrawCircle: proc "c" (Vec2, f32, HexColor, rawptr),
 
 	/// Draw a solid circle.
-	DrawSolidCircle: proc "c" (Transform, c.float, HexColor, rawptr),
+	DrawSolidCircle: proc "c" (Transform, f32, HexColor, rawptr),
 
 	/// Draw a solid capsule.
-	DrawSolidCapsule: proc "c" (Vec2, Vec2, c.float, HexColor, rawptr),
+	DrawSolidCapsule: proc "c" (Vec2, Vec2, f32, HexColor, rawptr),
 
 	/// Draw a line segment.
 	DrawSegment: proc "c" (Vec2, Vec2, HexColor, rawptr),
@@ -1264,7 +1264,7 @@ DebugDraw :: struct {
 	DrawTransform: proc "c" (Transform, rawptr),
 
 	/// Draw a point.
-	DrawPoint: proc "c" (Vec2, c.float, HexColor, rawptr),
+	DrawPoint: proc "c" (Vec2, f32, HexColor, rawptr),
 
 	/// Draw a string in world space
 	DrawString: proc "c" (Vec2, cstring, HexColor, rawptr),
@@ -1273,40 +1273,40 @@ DebugDraw :: struct {
 	drawingBounds: AABB,
 
 	/// Option to restrict drawing to a rectangular region. May suffer from unstable depth sorting.
-	useDrawingBounds: c.bool,
+	useDrawingBounds: bool,
 
 	/// Option to draw shapes
-	drawShapes: c.bool,
+	drawShapes: bool,
 
 	/// Option to draw joints
-	drawJoints: c.bool,
+	drawJoints: bool,
 
 	/// Option to draw additional information for joints
-	drawJointExtras: c.bool,
+	drawJointExtras: bool,
 
 	/// Option to draw the bounding boxes for shapes
-	drawAABBs: c.bool,
+	drawAABBs: bool,
 
 	/// Option to draw the mass and center of mass of dynamic bodies
-	drawMass: c.bool,
+	drawMass: bool,
 
 	/// Option to draw body names
-	drawBodyNames: c.bool,
+	drawBodyNames: bool,
 
 	/// Option to draw contact points
-	drawContacts: c.bool,
+	drawContacts: bool,
 
 	/// Option to visualize the graph coloring used for contacts and joints
-	drawGraphColors: c.bool,
+	drawGraphColors: bool,
 
 	/// Option to draw contact normals
-	drawContactNormals: c.bool,
+	drawContactNormals: bool,
 
 	/// Option to draw contact normal impulses
-	drawContactImpulses: c.bool,
+	drawContactImpulses: bool,
 
 	/// Option to draw contact friction impulses
-	drawFrictionImpulses: c.bool,
+	drawFrictionImpulses: bool,
 
 	/// User context that is passed as an argument to drawing callback functions
 	_context: rawptr,

--- a/examples/pdfio/pdfio/pdfio-content.odin
+++ b/examples/pdfio/pdfio/pdfio-content.odin
@@ -33,7 +33,7 @@ linejoin_t :: enum c.int {
 	BEVEL, // Bevel joint
 }
 
-matrix_t :: [3][2]c.double // Transform matrix
+matrix_t :: [3][2]f64 // Transform matrix
 
 textrendering_t :: enum c.int {
 	FILL,            // Fill text
@@ -50,84 +50,84 @@ textrendering_t :: enum c.int {
 foreign lib {
 	// Color array functions...
 	ArrayCreateColorFromICCObj    :: proc(pdf: ^file_t, icc_object: ^obj_t) -> ^array_t ---
-	ArrayCreateColorFromMatrix    :: proc(pdf: ^file_t, num_colors: c.size_t, gamma: c.double, _matrix: [^][3]c.double, white_point: ^c.double) -> ^array_t ---
+	ArrayCreateColorFromMatrix    :: proc(pdf: ^file_t, num_colors: c.size_t, gamma: f64, _matrix: [^][3]f64, white_point: ^f64) -> ^array_t ---
 	ArrayCreateColorFromPalette   :: proc(pdf: ^file_t, num_colors: c.size_t, colors: ^c.uchar) -> ^array_t ---
-	ArrayCreateColorFromPrimaries :: proc(pdf: ^file_t, num_colors: c.size_t, gamma: c.double, wx: c.double, wy: c.double, rx: c.double, ry: c.double, gx: c.double, gy: c.double, bx: c.double, by: c.double) -> ^array_t ---
+	ArrayCreateColorFromPrimaries :: proc(pdf: ^file_t, num_colors: c.size_t, gamma: f64, wx: f64, wy: f64, rx: f64, ry: f64, gx: f64, gy: f64, bx: f64, by: f64) -> ^array_t ---
 	ArrayCreateColorFromStandard  :: proc(pdf: ^file_t, num_colors: c.size_t, cs: cs_t) -> ^array_t ---
 
 	// PDF content drawing functions...
-	ContentClip                     :: proc(st: ^stream_t, even_odd: c.bool) -> c.bool ---
-	ContentDrawImage                :: proc(st: ^stream_t, name: cstring, x: c.double, y: c.double, w: c.double, h: c.double) -> c.bool ---
-	ContentFill                     :: proc(st: ^stream_t, even_odd: c.bool) -> c.bool ---
-	ContentFillAndStroke            :: proc(st: ^stream_t, even_odd: c.bool) -> c.bool ---
-	ContentMatrixConcat             :: proc(st: ^stream_t, m: [^][2]c.double) -> c.bool ---
-	ContentMatrixRotate             :: proc(st: ^stream_t, degrees: c.double) -> c.bool ---
-	ContentMatrixScale              :: proc(st: ^stream_t, sx: c.double, sy: c.double) -> c.bool ---
-	ContentMatrixTranslate          :: proc(st: ^stream_t, tx: c.double, ty: c.double) -> c.bool ---
-	ContentPathClose                :: proc(st: ^stream_t) -> c.bool ---
-	ContentPathCurve                :: proc(st: ^stream_t, x1: c.double, y1: c.double, x2: c.double, y2: c.double, x3: c.double, y3: c.double) -> c.bool ---
-	ContentPathCurve13              :: proc(st: ^stream_t, x1: c.double, y1: c.double, x3: c.double, y3: c.double) -> c.bool ---
-	ContentPathCurve23              :: proc(st: ^stream_t, x2: c.double, y2: c.double, x3: c.double, y3: c.double) -> c.bool ---
-	ContentPathEnd                  :: proc(st: ^stream_t) -> c.bool ---
-	ContentPathLineTo               :: proc(st: ^stream_t, x: c.double, y: c.double) -> c.bool ---
-	ContentPathMoveTo               :: proc(st: ^stream_t, x: c.double, y: c.double) -> c.bool ---
-	ContentPathRect                 :: proc(st: ^stream_t, x: c.double, y: c.double, width: c.double, height: c.double) -> c.bool ---
-	ContentRestore                  :: proc(st: ^stream_t) -> c.bool ---
-	ContentSave                     :: proc(st: ^stream_t) -> c.bool ---
-	ContentSetDashPattern           :: proc(st: ^stream_t, phase: c.double, on: c.double, off: c.double) -> c.bool ---
-	ContentSetFillColorDeviceCMYK   :: proc(st: ^stream_t, _c: c.double, m: c.double, y: c.double, k: c.double) -> c.bool ---
-	ContentSetFillColorDeviceGray   :: proc(st: ^stream_t, g: c.double) -> c.bool ---
-	ContentSetFillColorDeviceRGB    :: proc(st: ^stream_t, r: c.double, g: c.double, b: c.double) -> c.bool ---
-	ContentSetFillColorGray         :: proc(st: ^stream_t, g: c.double) -> c.bool ---
-	ContentSetFillColorRGB          :: proc(st: ^stream_t, r: c.double, g: c.double, b: c.double) -> c.bool ---
-	ContentSetFillColorSpace        :: proc(st: ^stream_t, name: cstring) -> c.bool ---
-	ContentSetFlatness              :: proc(st: ^stream_t, f: c.double) -> c.bool ---
-	ContentSetLineCap               :: proc(st: ^stream_t, lc: linecap_t) -> c.bool ---
-	ContentSetLineJoin              :: proc(st: ^stream_t, lj: linejoin_t) -> c.bool ---
-	ContentSetLineWidth             :: proc(st: ^stream_t, width: c.double) -> c.bool ---
-	ContentSetMiterLimit            :: proc(st: ^stream_t, limit: c.double) -> c.bool ---
-	ContentSetStrokeColorDeviceCMYK :: proc(st: ^stream_t, _c: c.double, m: c.double, y: c.double, k: c.double) -> c.bool ---
-	ContentSetStrokeColorDeviceGray :: proc(st: ^stream_t, g: c.double) -> c.bool ---
-	ContentSetStrokeColorDeviceRGB  :: proc(st: ^stream_t, r: c.double, g: c.double, b: c.double) -> c.bool ---
-	ContentSetStrokeColorGray       :: proc(st: ^stream_t, g: c.double) -> c.bool ---
-	ContentSetStrokeColorRGB        :: proc(st: ^stream_t, r: c.double, g: c.double, b: c.double) -> c.bool ---
-	ContentSetStrokeColorSpace      :: proc(st: ^stream_t, name: cstring) -> c.bool ---
-	ContentSetTextCharacterSpacing  :: proc(st: ^stream_t, spacing: c.double) -> c.bool ---
-	ContentSetTextFont              :: proc(st: ^stream_t, name: cstring, size: c.double) -> c.bool ---
-	ContentSetTextLeading           :: proc(st: ^stream_t, leading: c.double) -> c.bool ---
-	ContentSetTextMatrix            :: proc(st: ^stream_t, m: [^][2]c.double) -> c.bool ---
-	ContentSetTextRenderingMode     :: proc(st: ^stream_t, mode: textrendering_t) -> c.bool ---
-	ContentSetTextRise              :: proc(st: ^stream_t, rise: c.double) -> c.bool ---
-	ContentSetTextWordSpacing       :: proc(st: ^stream_t, spacing: c.double) -> c.bool ---
-	ContentSetTextXScaling          :: proc(st: ^stream_t, percent: c.double) -> c.bool ---
-	ContentStroke                   :: proc(st: ^stream_t) -> c.bool ---
-	ContentTextBegin                :: proc(st: ^stream_t) -> c.bool ---
-	ContentTextEnd                  :: proc(st: ^stream_t) -> c.bool ---
-	ContentTextMeasure              :: proc(font: ^obj_t, s: cstring, size: c.double) -> c.double ---
-	ContentTextMoveLine             :: proc(st: ^stream_t, tx: c.double, ty: c.double) -> c.bool ---
-	ContentTextMoveTo               :: proc(st: ^stream_t, tx: c.double, ty: c.double) -> c.bool ---
-	ContentTextNewLine              :: proc(st: ^stream_t) -> c.bool ---
-	ContentTextNewLineShow          :: proc(st: ^stream_t, ws: c.double, cs: c.double, unicode: c.bool, s: cstring) -> c.bool ---
-	ContentTextNewLineShowf         :: proc(st: ^stream_t, ws: c.double, cs: c.double, unicode: c.bool, format: cstring) -> c.bool ---
-	ContentTextNextLine             :: proc(st: ^stream_t) -> c.bool ---
-	ContentTextShow                 :: proc(st: ^stream_t, unicode: c.bool, s: cstring) -> c.bool ---
-	ContentTextShowf                :: proc(st: ^stream_t, unicode: c.bool, format: cstring) -> c.bool ---
-	ContentTextShowJustified        :: proc(st: ^stream_t, unicode: c.bool, num_fragments: c.size_t, offsets: ^c.double, fragments: [^]cstring) -> c.bool ---
+	ContentClip                     :: proc(st: ^stream_t, even_odd: bool) -> bool ---
+	ContentDrawImage                :: proc(st: ^stream_t, name: cstring, x: f64, y: f64, w: f64, h: f64) -> bool ---
+	ContentFill                     :: proc(st: ^stream_t, even_odd: bool) -> bool ---
+	ContentFillAndStroke            :: proc(st: ^stream_t, even_odd: bool) -> bool ---
+	ContentMatrixConcat             :: proc(st: ^stream_t, m: [^][2]f64) -> bool ---
+	ContentMatrixRotate             :: proc(st: ^stream_t, degrees: f64) -> bool ---
+	ContentMatrixScale              :: proc(st: ^stream_t, sx: f64, sy: f64) -> bool ---
+	ContentMatrixTranslate          :: proc(st: ^stream_t, tx: f64, ty: f64) -> bool ---
+	ContentPathClose                :: proc(st: ^stream_t) -> bool ---
+	ContentPathCurve                :: proc(st: ^stream_t, x1: f64, y1: f64, x2: f64, y2: f64, x3: f64, y3: f64) -> bool ---
+	ContentPathCurve13              :: proc(st: ^stream_t, x1: f64, y1: f64, x3: f64, y3: f64) -> bool ---
+	ContentPathCurve23              :: proc(st: ^stream_t, x2: f64, y2: f64, x3: f64, y3: f64) -> bool ---
+	ContentPathEnd                  :: proc(st: ^stream_t) -> bool ---
+	ContentPathLineTo               :: proc(st: ^stream_t, x: f64, y: f64) -> bool ---
+	ContentPathMoveTo               :: proc(st: ^stream_t, x: f64, y: f64) -> bool ---
+	ContentPathRect                 :: proc(st: ^stream_t, x: f64, y: f64, width: f64, height: f64) -> bool ---
+	ContentRestore                  :: proc(st: ^stream_t) -> bool ---
+	ContentSave                     :: proc(st: ^stream_t) -> bool ---
+	ContentSetDashPattern           :: proc(st: ^stream_t, phase: f64, on: f64, off: f64) -> bool ---
+	ContentSetFillColorDeviceCMYK   :: proc(st: ^stream_t, _c: f64, m: f64, y: f64, k: f64) -> bool ---
+	ContentSetFillColorDeviceGray   :: proc(st: ^stream_t, g: f64) -> bool ---
+	ContentSetFillColorDeviceRGB    :: proc(st: ^stream_t, r: f64, g: f64, b: f64) -> bool ---
+	ContentSetFillColorGray         :: proc(st: ^stream_t, g: f64) -> bool ---
+	ContentSetFillColorRGB          :: proc(st: ^stream_t, r: f64, g: f64, b: f64) -> bool ---
+	ContentSetFillColorSpace        :: proc(st: ^stream_t, name: cstring) -> bool ---
+	ContentSetFlatness              :: proc(st: ^stream_t, f: f64) -> bool ---
+	ContentSetLineCap               :: proc(st: ^stream_t, lc: linecap_t) -> bool ---
+	ContentSetLineJoin              :: proc(st: ^stream_t, lj: linejoin_t) -> bool ---
+	ContentSetLineWidth             :: proc(st: ^stream_t, width: f64) -> bool ---
+	ContentSetMiterLimit            :: proc(st: ^stream_t, limit: f64) -> bool ---
+	ContentSetStrokeColorDeviceCMYK :: proc(st: ^stream_t, _c: f64, m: f64, y: f64, k: f64) -> bool ---
+	ContentSetStrokeColorDeviceGray :: proc(st: ^stream_t, g: f64) -> bool ---
+	ContentSetStrokeColorDeviceRGB  :: proc(st: ^stream_t, r: f64, g: f64, b: f64) -> bool ---
+	ContentSetStrokeColorGray       :: proc(st: ^stream_t, g: f64) -> bool ---
+	ContentSetStrokeColorRGB        :: proc(st: ^stream_t, r: f64, g: f64, b: f64) -> bool ---
+	ContentSetStrokeColorSpace      :: proc(st: ^stream_t, name: cstring) -> bool ---
+	ContentSetTextCharacterSpacing  :: proc(st: ^stream_t, spacing: f64) -> bool ---
+	ContentSetTextFont              :: proc(st: ^stream_t, name: cstring, size: f64) -> bool ---
+	ContentSetTextLeading           :: proc(st: ^stream_t, leading: f64) -> bool ---
+	ContentSetTextMatrix            :: proc(st: ^stream_t, m: [^][2]f64) -> bool ---
+	ContentSetTextRenderingMode     :: proc(st: ^stream_t, mode: textrendering_t) -> bool ---
+	ContentSetTextRise              :: proc(st: ^stream_t, rise: f64) -> bool ---
+	ContentSetTextWordSpacing       :: proc(st: ^stream_t, spacing: f64) -> bool ---
+	ContentSetTextXScaling          :: proc(st: ^stream_t, percent: f64) -> bool ---
+	ContentStroke                   :: proc(st: ^stream_t) -> bool ---
+	ContentTextBegin                :: proc(st: ^stream_t) -> bool ---
+	ContentTextEnd                  :: proc(st: ^stream_t) -> bool ---
+	ContentTextMeasure              :: proc(font: ^obj_t, s: cstring, size: f64) -> f64 ---
+	ContentTextMoveLine             :: proc(st: ^stream_t, tx: f64, ty: f64) -> bool ---
+	ContentTextMoveTo               :: proc(st: ^stream_t, tx: f64, ty: f64) -> bool ---
+	ContentTextNewLine              :: proc(st: ^stream_t) -> bool ---
+	ContentTextNewLineShow          :: proc(st: ^stream_t, ws: f64, cs: f64, unicode: bool, s: cstring) -> bool ---
+	ContentTextNewLineShowf         :: proc(st: ^stream_t, ws: f64, cs: f64, unicode: bool, format: cstring) -> bool ---
+	ContentTextNextLine             :: proc(st: ^stream_t) -> bool ---
+	ContentTextShow                 :: proc(st: ^stream_t, unicode: bool, s: cstring) -> bool ---
+	ContentTextShowf                :: proc(st: ^stream_t, unicode: bool, format: cstring) -> bool ---
+	ContentTextShowJustified        :: proc(st: ^stream_t, unicode: bool, num_fragments: c.size_t, offsets: ^f64, fragments: [^]cstring) -> bool ---
 
 	// Resource helpers...
 	FileCreateFontObjFromBase  :: proc(pdf: ^file_t, name: cstring) -> ^obj_t ---
-	FileCreateFontObjFromFile  :: proc(pdf: ^file_t, filename: cstring, unicode: c.bool) -> ^obj_t ---
+	FileCreateFontObjFromFile  :: proc(pdf: ^file_t, filename: cstring, unicode: bool) -> ^obj_t ---
 	FileCreateICCObjFromFile   :: proc(pdf: ^file_t, filename: cstring, num_colors: c.size_t) -> ^obj_t ---
-	FileCreateImageObjFromData :: proc(pdf: ^file_t, data: ^c.uchar, width: c.size_t, height: c.size_t, num_colors: c.size_t, color_data: ^array_t, alpha: c.bool, interpolate: c.bool) -> ^obj_t ---
-	FileCreateImageObjFromFile :: proc(pdf: ^file_t, filename: cstring, interpolate: c.bool) -> ^obj_t ---
+	FileCreateImageObjFromData :: proc(pdf: ^file_t, data: ^c.uchar, width: c.size_t, height: c.size_t, num_colors: c.size_t, color_data: ^array_t, alpha: bool, interpolate: bool) -> ^obj_t ---
+	FileCreateImageObjFromFile :: proc(pdf: ^file_t, filename: cstring, interpolate: bool) -> ^obj_t ---
 
 	// Image object helpers...
 	ImageGetBytesPerLine :: proc(obj: ^obj_t) -> c.size_t ---
-	ImageGetHeight       :: proc(obj: ^obj_t) -> c.double ---
-	ImageGetWidth        :: proc(obj: ^obj_t) -> c.double ---
+	ImageGetHeight       :: proc(obj: ^obj_t) -> f64 ---
+	ImageGetWidth        :: proc(obj: ^obj_t) -> f64 ---
 
 	// Page dictionary helpers...
-	PageDictAddColorSpace :: proc(dict: ^dict_t, name: cstring, data: ^array_t) -> c.bool ---
-	PageDictAddFont       :: proc(dict: ^dict_t, name: cstring, obj: ^obj_t) -> c.bool ---
-	PageDictAddImage      :: proc(dict: ^dict_t, name: cstring, obj: ^obj_t) -> c.bool ---
+	PageDictAddColorSpace :: proc(dict: ^dict_t, name: cstring, data: ^array_t) -> bool ---
+	PageDictAddFont       :: proc(dict: ^dict_t, name: cstring, obj: ^obj_t) -> bool ---
+	PageDictAddImage      :: proc(dict: ^dict_t, name: cstring, obj: ^obj_t) -> bool ---
 }

--- a/examples/pdfio/pdfio/pdfio-content.odin
+++ b/examples/pdfio/pdfio/pdfio-content.odin
@@ -33,7 +33,7 @@ linejoin_t :: enum c.int {
 	BEVEL, // Bevel joint
 }
 
-matrix_t :: [3][2]f64 // Transform matrix
+matrix_t :: [3][2]c.double // Transform matrix
 
 textrendering_t :: enum c.int {
 	FILL,            // Fill text
@@ -50,84 +50,84 @@ textrendering_t :: enum c.int {
 foreign lib {
 	// Color array functions...
 	ArrayCreateColorFromICCObj    :: proc(pdf: ^file_t, icc_object: ^obj_t) -> ^array_t ---
-	ArrayCreateColorFromMatrix    :: proc(pdf: ^file_t, num_colors: uint, gamma: f64, _matrix: [^][3]f64, white_point: ^f64) -> ^array_t ---
-	ArrayCreateColorFromPalette   :: proc(pdf: ^file_t, num_colors: uint, colors: ^u8) -> ^array_t ---
-	ArrayCreateColorFromPrimaries :: proc(pdf: ^file_t, num_colors: uint, gamma: f64, wx: f64, wy: f64, rx: f64, ry: f64, gx: f64, gy: f64, bx: f64, by: f64) -> ^array_t ---
-	ArrayCreateColorFromStandard  :: proc(pdf: ^file_t, num_colors: uint, cs: cs_t) -> ^array_t ---
+	ArrayCreateColorFromMatrix    :: proc(pdf: ^file_t, num_colors: c.size_t, gamma: c.double, _matrix: [^][3]c.double, white_point: ^c.double) -> ^array_t ---
+	ArrayCreateColorFromPalette   :: proc(pdf: ^file_t, num_colors: c.size_t, colors: ^c.uchar) -> ^array_t ---
+	ArrayCreateColorFromPrimaries :: proc(pdf: ^file_t, num_colors: c.size_t, gamma: c.double, wx: c.double, wy: c.double, rx: c.double, ry: c.double, gx: c.double, gy: c.double, bx: c.double, by: c.double) -> ^array_t ---
+	ArrayCreateColorFromStandard  :: proc(pdf: ^file_t, num_colors: c.size_t, cs: cs_t) -> ^array_t ---
 
 	// PDF content drawing functions...
-	ContentClip                     :: proc(st: ^stream_t, even_odd: bool) -> bool ---
-	ContentDrawImage                :: proc(st: ^stream_t, name: cstring, x: f64, y: f64, w: f64, h: f64) -> bool ---
-	ContentFill                     :: proc(st: ^stream_t, even_odd: bool) -> bool ---
-	ContentFillAndStroke            :: proc(st: ^stream_t, even_odd: bool) -> bool ---
-	ContentMatrixConcat             :: proc(st: ^stream_t, m: [^][2]f64) -> bool ---
-	ContentMatrixRotate             :: proc(st: ^stream_t, degrees: f64) -> bool ---
-	ContentMatrixScale              :: proc(st: ^stream_t, sx: f64, sy: f64) -> bool ---
-	ContentMatrixTranslate          :: proc(st: ^stream_t, tx: f64, ty: f64) -> bool ---
-	ContentPathClose                :: proc(st: ^stream_t) -> bool ---
-	ContentPathCurve                :: proc(st: ^stream_t, x1: f64, y1: f64, x2: f64, y2: f64, x3: f64, y3: f64) -> bool ---
-	ContentPathCurve13              :: proc(st: ^stream_t, x1: f64, y1: f64, x3: f64, y3: f64) -> bool ---
-	ContentPathCurve23              :: proc(st: ^stream_t, x2: f64, y2: f64, x3: f64, y3: f64) -> bool ---
-	ContentPathEnd                  :: proc(st: ^stream_t) -> bool ---
-	ContentPathLineTo               :: proc(st: ^stream_t, x: f64, y: f64) -> bool ---
-	ContentPathMoveTo               :: proc(st: ^stream_t, x: f64, y: f64) -> bool ---
-	ContentPathRect                 :: proc(st: ^stream_t, x: f64, y: f64, width: f64, height: f64) -> bool ---
-	ContentRestore                  :: proc(st: ^stream_t) -> bool ---
-	ContentSave                     :: proc(st: ^stream_t) -> bool ---
-	ContentSetDashPattern           :: proc(st: ^stream_t, phase: f64, on: f64, off: f64) -> bool ---
-	ContentSetFillColorDeviceCMYK   :: proc(st: ^stream_t, _c: f64, m: f64, y: f64, k: f64) -> bool ---
-	ContentSetFillColorDeviceGray   :: proc(st: ^stream_t, g: f64) -> bool ---
-	ContentSetFillColorDeviceRGB    :: proc(st: ^stream_t, r: f64, g: f64, b: f64) -> bool ---
-	ContentSetFillColorGray         :: proc(st: ^stream_t, g: f64) -> bool ---
-	ContentSetFillColorRGB          :: proc(st: ^stream_t, r: f64, g: f64, b: f64) -> bool ---
-	ContentSetFillColorSpace        :: proc(st: ^stream_t, name: cstring) -> bool ---
-	ContentSetFlatness              :: proc(st: ^stream_t, f: f64) -> bool ---
-	ContentSetLineCap               :: proc(st: ^stream_t, lc: linecap_t) -> bool ---
-	ContentSetLineJoin              :: proc(st: ^stream_t, lj: linejoin_t) -> bool ---
-	ContentSetLineWidth             :: proc(st: ^stream_t, width: f64) -> bool ---
-	ContentSetMiterLimit            :: proc(st: ^stream_t, limit: f64) -> bool ---
-	ContentSetStrokeColorDeviceCMYK :: proc(st: ^stream_t, _c: f64, m: f64, y: f64, k: f64) -> bool ---
-	ContentSetStrokeColorDeviceGray :: proc(st: ^stream_t, g: f64) -> bool ---
-	ContentSetStrokeColorDeviceRGB  :: proc(st: ^stream_t, r: f64, g: f64, b: f64) -> bool ---
-	ContentSetStrokeColorGray       :: proc(st: ^stream_t, g: f64) -> bool ---
-	ContentSetStrokeColorRGB        :: proc(st: ^stream_t, r: f64, g: f64, b: f64) -> bool ---
-	ContentSetStrokeColorSpace      :: proc(st: ^stream_t, name: cstring) -> bool ---
-	ContentSetTextCharacterSpacing  :: proc(st: ^stream_t, spacing: f64) -> bool ---
-	ContentSetTextFont              :: proc(st: ^stream_t, name: cstring, size: f64) -> bool ---
-	ContentSetTextLeading           :: proc(st: ^stream_t, leading: f64) -> bool ---
-	ContentSetTextMatrix            :: proc(st: ^stream_t, m: [^][2]f64) -> bool ---
-	ContentSetTextRenderingMode     :: proc(st: ^stream_t, mode: textrendering_t) -> bool ---
-	ContentSetTextRise              :: proc(st: ^stream_t, rise: f64) -> bool ---
-	ContentSetTextWordSpacing       :: proc(st: ^stream_t, spacing: f64) -> bool ---
-	ContentSetTextXScaling          :: proc(st: ^stream_t, percent: f64) -> bool ---
-	ContentStroke                   :: proc(st: ^stream_t) -> bool ---
-	ContentTextBegin                :: proc(st: ^stream_t) -> bool ---
-	ContentTextEnd                  :: proc(st: ^stream_t) -> bool ---
-	ContentTextMeasure              :: proc(font: ^obj_t, s: cstring, size: f64) -> f64 ---
-	ContentTextMoveLine             :: proc(st: ^stream_t, tx: f64, ty: f64) -> bool ---
-	ContentTextMoveTo               :: proc(st: ^stream_t, tx: f64, ty: f64) -> bool ---
-	ContentTextNewLine              :: proc(st: ^stream_t) -> bool ---
-	ContentTextNewLineShow          :: proc(st: ^stream_t, ws: f64, cs: f64, unicode: bool, s: cstring) -> bool ---
-	ContentTextNewLineShowf         :: proc(st: ^stream_t, ws: f64, cs: f64, unicode: bool, format: cstring) -> bool ---
-	ContentTextNextLine             :: proc(st: ^stream_t) -> bool ---
-	ContentTextShow                 :: proc(st: ^stream_t, unicode: bool, s: cstring) -> bool ---
-	ContentTextShowf                :: proc(st: ^stream_t, unicode: bool, format: cstring) -> bool ---
-	ContentTextShowJustified        :: proc(st: ^stream_t, unicode: bool, num_fragments: uint, offsets: ^f64, fragments: [^]cstring) -> bool ---
+	ContentClip                     :: proc(st: ^stream_t, even_odd: c.bool) -> c.bool ---
+	ContentDrawImage                :: proc(st: ^stream_t, name: cstring, x: c.double, y: c.double, w: c.double, h: c.double) -> c.bool ---
+	ContentFill                     :: proc(st: ^stream_t, even_odd: c.bool) -> c.bool ---
+	ContentFillAndStroke            :: proc(st: ^stream_t, even_odd: c.bool) -> c.bool ---
+	ContentMatrixConcat             :: proc(st: ^stream_t, m: [^][2]c.double) -> c.bool ---
+	ContentMatrixRotate             :: proc(st: ^stream_t, degrees: c.double) -> c.bool ---
+	ContentMatrixScale              :: proc(st: ^stream_t, sx: c.double, sy: c.double) -> c.bool ---
+	ContentMatrixTranslate          :: proc(st: ^stream_t, tx: c.double, ty: c.double) -> c.bool ---
+	ContentPathClose                :: proc(st: ^stream_t) -> c.bool ---
+	ContentPathCurve                :: proc(st: ^stream_t, x1: c.double, y1: c.double, x2: c.double, y2: c.double, x3: c.double, y3: c.double) -> c.bool ---
+	ContentPathCurve13              :: proc(st: ^stream_t, x1: c.double, y1: c.double, x3: c.double, y3: c.double) -> c.bool ---
+	ContentPathCurve23              :: proc(st: ^stream_t, x2: c.double, y2: c.double, x3: c.double, y3: c.double) -> c.bool ---
+	ContentPathEnd                  :: proc(st: ^stream_t) -> c.bool ---
+	ContentPathLineTo               :: proc(st: ^stream_t, x: c.double, y: c.double) -> c.bool ---
+	ContentPathMoveTo               :: proc(st: ^stream_t, x: c.double, y: c.double) -> c.bool ---
+	ContentPathRect                 :: proc(st: ^stream_t, x: c.double, y: c.double, width: c.double, height: c.double) -> c.bool ---
+	ContentRestore                  :: proc(st: ^stream_t) -> c.bool ---
+	ContentSave                     :: proc(st: ^stream_t) -> c.bool ---
+	ContentSetDashPattern           :: proc(st: ^stream_t, phase: c.double, on: c.double, off: c.double) -> c.bool ---
+	ContentSetFillColorDeviceCMYK   :: proc(st: ^stream_t, _c: c.double, m: c.double, y: c.double, k: c.double) -> c.bool ---
+	ContentSetFillColorDeviceGray   :: proc(st: ^stream_t, g: c.double) -> c.bool ---
+	ContentSetFillColorDeviceRGB    :: proc(st: ^stream_t, r: c.double, g: c.double, b: c.double) -> c.bool ---
+	ContentSetFillColorGray         :: proc(st: ^stream_t, g: c.double) -> c.bool ---
+	ContentSetFillColorRGB          :: proc(st: ^stream_t, r: c.double, g: c.double, b: c.double) -> c.bool ---
+	ContentSetFillColorSpace        :: proc(st: ^stream_t, name: cstring) -> c.bool ---
+	ContentSetFlatness              :: proc(st: ^stream_t, f: c.double) -> c.bool ---
+	ContentSetLineCap               :: proc(st: ^stream_t, lc: linecap_t) -> c.bool ---
+	ContentSetLineJoin              :: proc(st: ^stream_t, lj: linejoin_t) -> c.bool ---
+	ContentSetLineWidth             :: proc(st: ^stream_t, width: c.double) -> c.bool ---
+	ContentSetMiterLimit            :: proc(st: ^stream_t, limit: c.double) -> c.bool ---
+	ContentSetStrokeColorDeviceCMYK :: proc(st: ^stream_t, _c: c.double, m: c.double, y: c.double, k: c.double) -> c.bool ---
+	ContentSetStrokeColorDeviceGray :: proc(st: ^stream_t, g: c.double) -> c.bool ---
+	ContentSetStrokeColorDeviceRGB  :: proc(st: ^stream_t, r: c.double, g: c.double, b: c.double) -> c.bool ---
+	ContentSetStrokeColorGray       :: proc(st: ^stream_t, g: c.double) -> c.bool ---
+	ContentSetStrokeColorRGB        :: proc(st: ^stream_t, r: c.double, g: c.double, b: c.double) -> c.bool ---
+	ContentSetStrokeColorSpace      :: proc(st: ^stream_t, name: cstring) -> c.bool ---
+	ContentSetTextCharacterSpacing  :: proc(st: ^stream_t, spacing: c.double) -> c.bool ---
+	ContentSetTextFont              :: proc(st: ^stream_t, name: cstring, size: c.double) -> c.bool ---
+	ContentSetTextLeading           :: proc(st: ^stream_t, leading: c.double) -> c.bool ---
+	ContentSetTextMatrix            :: proc(st: ^stream_t, m: [^][2]c.double) -> c.bool ---
+	ContentSetTextRenderingMode     :: proc(st: ^stream_t, mode: textrendering_t) -> c.bool ---
+	ContentSetTextRise              :: proc(st: ^stream_t, rise: c.double) -> c.bool ---
+	ContentSetTextWordSpacing       :: proc(st: ^stream_t, spacing: c.double) -> c.bool ---
+	ContentSetTextXScaling          :: proc(st: ^stream_t, percent: c.double) -> c.bool ---
+	ContentStroke                   :: proc(st: ^stream_t) -> c.bool ---
+	ContentTextBegin                :: proc(st: ^stream_t) -> c.bool ---
+	ContentTextEnd                  :: proc(st: ^stream_t) -> c.bool ---
+	ContentTextMeasure              :: proc(font: ^obj_t, s: cstring, size: c.double) -> c.double ---
+	ContentTextMoveLine             :: proc(st: ^stream_t, tx: c.double, ty: c.double) -> c.bool ---
+	ContentTextMoveTo               :: proc(st: ^stream_t, tx: c.double, ty: c.double) -> c.bool ---
+	ContentTextNewLine              :: proc(st: ^stream_t) -> c.bool ---
+	ContentTextNewLineShow          :: proc(st: ^stream_t, ws: c.double, cs: c.double, unicode: c.bool, s: cstring) -> c.bool ---
+	ContentTextNewLineShowf         :: proc(st: ^stream_t, ws: c.double, cs: c.double, unicode: c.bool, format: cstring) -> c.bool ---
+	ContentTextNextLine             :: proc(st: ^stream_t) -> c.bool ---
+	ContentTextShow                 :: proc(st: ^stream_t, unicode: c.bool, s: cstring) -> c.bool ---
+	ContentTextShowf                :: proc(st: ^stream_t, unicode: c.bool, format: cstring) -> c.bool ---
+	ContentTextShowJustified        :: proc(st: ^stream_t, unicode: c.bool, num_fragments: c.size_t, offsets: ^c.double, fragments: [^]cstring) -> c.bool ---
 
 	// Resource helpers...
 	FileCreateFontObjFromBase  :: proc(pdf: ^file_t, name: cstring) -> ^obj_t ---
-	FileCreateFontObjFromFile  :: proc(pdf: ^file_t, filename: cstring, unicode: bool) -> ^obj_t ---
-	FileCreateICCObjFromFile   :: proc(pdf: ^file_t, filename: cstring, num_colors: uint) -> ^obj_t ---
-	FileCreateImageObjFromData :: proc(pdf: ^file_t, data: ^u8, width: uint, height: uint, num_colors: uint, color_data: ^array_t, alpha: bool, interpolate: bool) -> ^obj_t ---
-	FileCreateImageObjFromFile :: proc(pdf: ^file_t, filename: cstring, interpolate: bool) -> ^obj_t ---
+	FileCreateFontObjFromFile  :: proc(pdf: ^file_t, filename: cstring, unicode: c.bool) -> ^obj_t ---
+	FileCreateICCObjFromFile   :: proc(pdf: ^file_t, filename: cstring, num_colors: c.size_t) -> ^obj_t ---
+	FileCreateImageObjFromData :: proc(pdf: ^file_t, data: ^c.uchar, width: c.size_t, height: c.size_t, num_colors: c.size_t, color_data: ^array_t, alpha: c.bool, interpolate: c.bool) -> ^obj_t ---
+	FileCreateImageObjFromFile :: proc(pdf: ^file_t, filename: cstring, interpolate: c.bool) -> ^obj_t ---
 
 	// Image object helpers...
-	ImageGetBytesPerLine :: proc(obj: ^obj_t) -> uint ---
-	ImageGetHeight       :: proc(obj: ^obj_t) -> f64 ---
-	ImageGetWidth        :: proc(obj: ^obj_t) -> f64 ---
+	ImageGetBytesPerLine :: proc(obj: ^obj_t) -> c.size_t ---
+	ImageGetHeight       :: proc(obj: ^obj_t) -> c.double ---
+	ImageGetWidth        :: proc(obj: ^obj_t) -> c.double ---
 
 	// Page dictionary helpers...
-	PageDictAddColorSpace :: proc(dict: ^dict_t, name: cstring, data: ^array_t) -> bool ---
-	PageDictAddFont       :: proc(dict: ^dict_t, name: cstring, obj: ^obj_t) -> bool ---
-	PageDictAddImage      :: proc(dict: ^dict_t, name: cstring, obj: ^obj_t) -> bool ---
+	PageDictAddColorSpace :: proc(dict: ^dict_t, name: cstring, data: ^array_t) -> c.bool ---
+	PageDictAddFont       :: proc(dict: ^dict_t, name: cstring, obj: ^obj_t) -> c.bool ---
+	PageDictAddImage      :: proc(dict: ^dict_t, name: cstring, obj: ^obj_t) -> c.bool ---
 }

--- a/examples/pdfio/pdfio/pdfio.odin
+++ b/examples/pdfio/pdfio/pdfio.odin
@@ -22,13 +22,13 @@ array_t :: struct {}
 dict_t :: struct {}
 
 // Key/value dictionary
-dict_cb_t :: proc "c" (^dict_t, cstring, rawptr) -> bool
+dict_cb_t :: proc "c" (^dict_t, cstring, rawptr) -> c.bool
 
 // Dictionary iterator callback
 file_t :: struct {}
 
 // PDF file
-error_cb_t :: proc "c" (^file_t, cstring, rawptr) -> bool
+error_cb_t :: proc "c" (^file_t, cstring, rawptr) -> c.bool
 
 // Error callback
 encryption_t :: enum c.int {
@@ -55,7 +55,7 @@ filter_t :: enum c.int {
 
 obj_t :: struct {} // Numbered object in PDF file
 
-output_cb_t :: proc "c" (rawptr, rawptr, uint) -> int
+output_cb_t :: proc "c" (rawptr, rawptr, c.size_t) -> c.ssize_t
 
 // Output callback for pdfioFileCreateOutput
 password_cb_t :: proc "c" (rawptr, cstring) -> cstring
@@ -77,10 +77,10 @@ permission_t :: distinct bit_set[permission_e; c.int]
 PERMISSION_ALL :: permission_t { .PRINT, .MODIFY, .COPY, .ANNOTATE, .FORMS, .READING, .ASSEMBLE, .PRINT_HIGH }
 
 rect_t :: struct {
-	x1: f64, // Lower-left X coordinate
-	y1: f64, // Lower-left Y coordinate
-	x2: f64, // Upper-right X coordinate
-	y2: f64, // Upper-right Y coordinate
+	x1: c.double, // Lower-left X coordinate
+	y1: c.double, // Lower-left Y coordinate
+	x2: c.double, // Upper-right X coordinate
+	y2: c.double, // Upper-right Y coordinate
 }
 
 stream_t :: struct {}
@@ -103,71 +103,71 @@ valtype_t :: enum c.int {
 @(default_calling_convention="c", link_prefix="pdfio")
 foreign lib {
 	// Functions...
-	ArrayAppendArray    :: proc(a: ^array_t, value: ^array_t) -> bool ---
-	ArrayAppendBinary   :: proc(a: ^array_t, value: [^]u8, valuelen: uint) -> bool ---
-	ArrayAppendBoolean  :: proc(a: ^array_t, value: bool) -> bool ---
-	ArrayAppendDate     :: proc(a: ^array_t, value: libc.time_t) -> bool ---
-	ArrayAppendDict     :: proc(a: ^array_t, value: ^dict_t) -> bool ---
-	ArrayAppendName     :: proc(a: ^array_t, value: cstring) -> bool ---
-	ArrayAppendNumber   :: proc(a: ^array_t, value: f64) -> bool ---
-	ArrayAppendObj      :: proc(a: ^array_t, value: ^obj_t) -> bool ---
-	ArrayAppendString   :: proc(a: ^array_t, value: cstring) -> bool ---
+	ArrayAppendArray    :: proc(a: ^array_t, value: ^array_t) -> c.bool ---
+	ArrayAppendBinary   :: proc(a: ^array_t, value: [^]c.uchar, valuelen: c.size_t) -> c.bool ---
+	ArrayAppendBoolean  :: proc(a: ^array_t, value: c.bool) -> c.bool ---
+	ArrayAppendDate     :: proc(a: ^array_t, value: libc.time_t) -> c.bool ---
+	ArrayAppendDict     :: proc(a: ^array_t, value: ^dict_t) -> c.bool ---
+	ArrayAppendName     :: proc(a: ^array_t, value: cstring) -> c.bool ---
+	ArrayAppendNumber   :: proc(a: ^array_t, value: c.double) -> c.bool ---
+	ArrayAppendObj      :: proc(a: ^array_t, value: ^obj_t) -> c.bool ---
+	ArrayAppendString   :: proc(a: ^array_t, value: cstring) -> c.bool ---
 	ArrayCopy           :: proc(pdf: ^file_t, a: ^array_t) -> ^array_t ---
 	ArrayCreate         :: proc(pdf: ^file_t) -> ^array_t ---
-	ArrayGetArray       :: proc(a: ^array_t, n: uint) -> ^array_t ---
-	ArrayGetBinary      :: proc(a: ^array_t, n: uint, length: ^uint) -> [^]u8 ---
-	ArrayGetBoolean     :: proc(a: ^array_t, n: uint) -> bool ---
-	ArrayGetDate        :: proc(a: ^array_t, n: uint) -> libc.time_t ---
-	ArrayGetDict        :: proc(a: ^array_t, n: uint) -> ^dict_t ---
-	ArrayGetName        :: proc(a: ^array_t, n: uint) -> cstring ---
-	ArrayGetNumber      :: proc(a: ^array_t, n: uint) -> f64 ---
-	ArrayGetObj         :: proc(a: ^array_t, n: uint) -> ^obj_t ---
-	ArrayGetSize        :: proc(a: ^array_t) -> uint ---
-	ArrayGetString      :: proc(a: ^array_t, n: uint) -> cstring ---
-	ArrayGetType        :: proc(a: ^array_t, n: uint) -> valtype_t ---
-	ArrayRemove         :: proc(a: ^array_t, n: uint) -> bool ---
-	DictClear           :: proc(dict: ^dict_t, key: cstring) -> bool ---
+	ArrayGetArray       :: proc(a: ^array_t, n: c.size_t) -> ^array_t ---
+	ArrayGetBinary      :: proc(a: ^array_t, n: c.size_t, length: ^c.size_t) -> [^]c.uchar ---
+	ArrayGetBoolean     :: proc(a: ^array_t, n: c.size_t) -> c.bool ---
+	ArrayGetDate        :: proc(a: ^array_t, n: c.size_t) -> libc.time_t ---
+	ArrayGetDict        :: proc(a: ^array_t, n: c.size_t) -> ^dict_t ---
+	ArrayGetName        :: proc(a: ^array_t, n: c.size_t) -> cstring ---
+	ArrayGetNumber      :: proc(a: ^array_t, n: c.size_t) -> c.double ---
+	ArrayGetObj         :: proc(a: ^array_t, n: c.size_t) -> ^obj_t ---
+	ArrayGetSize        :: proc(a: ^array_t) -> c.size_t ---
+	ArrayGetString      :: proc(a: ^array_t, n: c.size_t) -> cstring ---
+	ArrayGetType        :: proc(a: ^array_t, n: c.size_t) -> valtype_t ---
+	ArrayRemove         :: proc(a: ^array_t, n: c.size_t) -> c.bool ---
+	DictClear           :: proc(dict: ^dict_t, key: cstring) -> c.bool ---
 	DictCopy            :: proc(pdf: ^file_t, dict: ^dict_t) -> ^dict_t ---
 	DictCreate          :: proc(pdf: ^file_t) -> ^dict_t ---
 	DictGetArray        :: proc(dict: ^dict_t, key: cstring) -> ^array_t ---
-	DictGetBinary       :: proc(dict: ^dict_t, key: cstring, length: ^uint) -> ^u8 ---
-	DictGetBoolean      :: proc(dict: ^dict_t, key: cstring) -> bool ---
+	DictGetBinary       :: proc(dict: ^dict_t, key: cstring, length: ^c.size_t) -> ^c.uchar ---
+	DictGetBoolean      :: proc(dict: ^dict_t, key: cstring) -> c.bool ---
 	DictGetDate         :: proc(dict: ^dict_t, key: cstring) -> libc.time_t ---
 	DictGetDict         :: proc(dict: ^dict_t, key: cstring) -> ^dict_t ---
-	DictGetKey          :: proc(dict: ^dict_t, n: uint) -> cstring ---
+	DictGetKey          :: proc(dict: ^dict_t, n: c.size_t) -> cstring ---
 	DictGetName         :: proc(dict: ^dict_t, key: cstring) -> cstring ---
-	DictGetNumPairs     :: proc(dict: ^dict_t) -> uint ---
-	DictGetNumber       :: proc(dict: ^dict_t, key: cstring) -> f64 ---
+	DictGetNumPairs     :: proc(dict: ^dict_t) -> c.size_t ---
+	DictGetNumber       :: proc(dict: ^dict_t, key: cstring) -> c.double ---
 	DictGetObj          :: proc(dict: ^dict_t, key: cstring) -> ^obj_t ---
 	DictGetRect         :: proc(dict: ^dict_t, key: cstring, rect: ^rect_t) -> ^rect_t ---
 	DictGetString       :: proc(dict: ^dict_t, key: cstring) -> cstring ---
 	DictGetType         :: proc(dict: ^dict_t, key: cstring) -> valtype_t ---
 	DictIterateKeys     :: proc(dict: ^dict_t, cb: dict_cb_t, cb_data: rawptr) ---
-	DictSetArray        :: proc(dict: ^dict_t, key: cstring, value: ^array_t) -> bool ---
-	DictSetBinary       :: proc(dict: ^dict_t, key: cstring, value: ^u8, valuelen: uint) -> bool ---
-	DictSetBoolean      :: proc(dict: ^dict_t, key: cstring, value: bool) -> bool ---
-	DictSetDate         :: proc(dict: ^dict_t, key: cstring, value: libc.time_t) -> bool ---
-	DictSetDict         :: proc(dict: ^dict_t, key: cstring, value: ^dict_t) -> bool ---
-	DictSetName         :: proc(dict: ^dict_t, key: cstring, value: cstring) -> bool ---
-	DictSetNull         :: proc(dict: ^dict_t, key: cstring) -> bool ---
-	DictSetNumber       :: proc(dict: ^dict_t, key: cstring, value: f64) -> bool ---
-	DictSetObj          :: proc(dict: ^dict_t, key: cstring, value: ^obj_t) -> bool ---
-	DictSetRect         :: proc(dict: ^dict_t, key: cstring, value: ^rect_t) -> bool ---
-	DictSetString       :: proc(dict: ^dict_t, key: cstring, value: cstring) -> bool ---
-	DictSetStringf      :: proc(dict: ^dict_t, key: cstring, format: cstring) -> bool ---
-	FileClose           :: proc(pdf: ^file_t) -> bool ---
+	DictSetArray        :: proc(dict: ^dict_t, key: cstring, value: ^array_t) -> c.bool ---
+	DictSetBinary       :: proc(dict: ^dict_t, key: cstring, value: ^c.uchar, valuelen: c.size_t) -> c.bool ---
+	DictSetBoolean      :: proc(dict: ^dict_t, key: cstring, value: c.bool) -> c.bool ---
+	DictSetDate         :: proc(dict: ^dict_t, key: cstring, value: libc.time_t) -> c.bool ---
+	DictSetDict         :: proc(dict: ^dict_t, key: cstring, value: ^dict_t) -> c.bool ---
+	DictSetName         :: proc(dict: ^dict_t, key: cstring, value: cstring) -> c.bool ---
+	DictSetNull         :: proc(dict: ^dict_t, key: cstring) -> c.bool ---
+	DictSetNumber       :: proc(dict: ^dict_t, key: cstring, value: c.double) -> c.bool ---
+	DictSetObj          :: proc(dict: ^dict_t, key: cstring, value: ^obj_t) -> c.bool ---
+	DictSetRect         :: proc(dict: ^dict_t, key: cstring, value: ^rect_t) -> c.bool ---
+	DictSetString       :: proc(dict: ^dict_t, key: cstring, value: cstring) -> c.bool ---
+	DictSetStringf      :: proc(dict: ^dict_t, key: cstring, format: cstring) -> c.bool ---
+	FileClose           :: proc(pdf: ^file_t) -> c.bool ---
 	FileCreate          :: proc(filename: cstring, version: cstring, media_box: ^rect_t, crop_box: ^rect_t, error_cb: error_cb_t, error_data: rawptr) -> ^file_t ---
 	FileCreateArrayObj  :: proc(pdf: ^file_t, array: ^array_t) -> ^obj_t ---
 	FileCreateNameObj   :: proc(pdf: ^file_t, name: cstring) -> ^obj_t ---
-	FileCreateNumberObj :: proc(pdf: ^file_t, number: f64) -> ^obj_t ---
+	FileCreateNumberObj :: proc(pdf: ^file_t, number: c.double) -> ^obj_t ---
 	FileCreateObj       :: proc(pdf: ^file_t, dict: ^dict_t) -> ^obj_t ---
 	FileCreateOutput    :: proc(output_cb: output_cb_t, output_ctx: rawptr, version: cstring, media_box: ^rect_t, crop_box: ^rect_t, error_cb: error_cb_t, error_data: rawptr) -> ^file_t ---
 
 	// TODO: Add number, array, string, etc. versions of pdfioFileCreateObject?
 	FileCreatePage      :: proc(pdf: ^file_t, dict: ^dict_t) -> ^stream_t ---
 	FileCreateStringObj :: proc(pdf: ^file_t, s: cstring) -> ^obj_t ---
-	FileCreateTemporary :: proc(buffer: [^]cstring, bufsize: uint, version: cstring, media_box: ^rect_t, crop_box: ^rect_t, error_cb: error_cb_t, error_data: rawptr) -> ^file_t ---
-	FileFindObj         :: proc(pdf: ^file_t, number: uint) -> ^obj_t ---
+	FileCreateTemporary :: proc(buffer: [^]cstring, bufsize: c.size_t, version: cstring, media_box: ^rect_t, crop_box: ^rect_t, error_cb: error_cb_t, error_data: rawptr) -> ^file_t ---
+	FileFindObj         :: proc(pdf: ^file_t, number: c.size_t) -> ^obj_t ---
 	FileGetAuthor       :: proc(pdf: ^file_t) -> cstring ---
 	FileGetCatalog      :: proc(pdf: ^file_t) -> ^dict_t ---
 	FileGetCreationDate :: proc(pdf: ^file_t) -> libc.time_t ---
@@ -175,10 +175,10 @@ foreign lib {
 	FileGetID           :: proc(pdf: ^file_t) -> ^array_t ---
 	FileGetKeywords     :: proc(pdf: ^file_t) -> cstring ---
 	FileGetName         :: proc(pdf: ^file_t) -> cstring ---
-	FileGetNumObjs      :: proc(pdf: ^file_t) -> uint ---
-	FileGetNumPages     :: proc(pdf: ^file_t) -> uint ---
-	FileGetObj          :: proc(pdf: ^file_t, n: uint) -> ^obj_t ---
-	FileGetPage         :: proc(pdf: ^file_t, n: uint) -> ^obj_t ---
+	FileGetNumObjs      :: proc(pdf: ^file_t) -> c.size_t ---
+	FileGetNumPages     :: proc(pdf: ^file_t) -> c.size_t ---
+	FileGetObj          :: proc(pdf: ^file_t, n: c.size_t) -> ^obj_t ---
+	FileGetPage         :: proc(pdf: ^file_t, n: c.size_t) -> ^obj_t ---
 	FileGetPermissions  :: proc(pdf: ^file_t, encryption: ^encryption_t) -> permission_t ---
 	FileGetProducer     :: proc(pdf: ^file_t) -> cstring ---
 	FileGetSubject      :: proc(pdf: ^file_t) -> cstring ---
@@ -189,33 +189,33 @@ foreign lib {
 	FileSetCreationDate :: proc(pdf: ^file_t, value: libc.time_t) ---
 	FileSetCreator      :: proc(pdf: ^file_t, value: cstring) ---
 	FileSetKeywords     :: proc(pdf: ^file_t, value: cstring) ---
-	FileSetPermissions  :: proc(pdf: ^file_t, permissions: permission_t, encryption: encryption_t, owner_password: cstring, user_password: cstring) -> bool ---
+	FileSetPermissions  :: proc(pdf: ^file_t, permissions: permission_t, encryption: encryption_t, owner_password: cstring, user_password: cstring) -> c.bool ---
 	FileSetSubject      :: proc(pdf: ^file_t, value: cstring) ---
 	FileSetTitle        :: proc(pdf: ^file_t, value: cstring) ---
-	ObjClose            :: proc(obj: ^obj_t) -> bool ---
+	ObjClose            :: proc(obj: ^obj_t) -> c.bool ---
 	ObjCopy             :: proc(pdf: ^file_t, srcobj: ^obj_t) -> ^obj_t ---
 	ObjCreateStream     :: proc(obj: ^obj_t, compression: filter_t) -> ^stream_t ---
 	ObjGetArray         :: proc(obj: ^obj_t) -> ^array_t ---
 	ObjGetDict          :: proc(obj: ^obj_t) -> ^dict_t ---
-	ObjGetGeneration    :: proc(obj: ^obj_t) -> u16 ---
-	ObjGetLength        :: proc(obj: ^obj_t) -> uint ---
+	ObjGetGeneration    :: proc(obj: ^obj_t) -> c.ushort ---
+	ObjGetLength        :: proc(obj: ^obj_t) -> c.size_t ---
 	ObjGetName          :: proc(obj: ^obj_t) -> cstring ---
-	ObjGetNumber        :: proc(obj: ^obj_t) -> uint ---
+	ObjGetNumber        :: proc(obj: ^obj_t) -> c.size_t ---
 	ObjGetSubtype       :: proc(obj: ^obj_t) -> cstring ---
 	ObjGetType          :: proc(obj: ^obj_t) -> cstring ---
-	ObjOpenStream       :: proc(obj: ^obj_t, decode: bool) -> ^stream_t ---
-	PageCopy            :: proc(pdf: ^file_t, srcpage: ^obj_t) -> bool ---
-	PageGetNumStreams   :: proc(page: ^obj_t) -> uint ---
-	PageOpenStream      :: proc(page: ^obj_t, n: uint, decode: bool) -> ^stream_t ---
-	StreamClose         :: proc(st: ^stream_t) -> bool ---
-	StreamConsume       :: proc(st: ^stream_t, bytes: uint) -> bool ---
-	StreamGetToken      :: proc(st: ^stream_t, buffer: [^]cstring, bufsize: uint) -> bool ---
-	StreamPeek          :: proc(st: ^stream_t, buffer: rawptr, bytes: uint) -> int ---
-	StreamPrintf        :: proc(st: ^stream_t, format: cstring) -> bool ---
-	StreamPutChar       :: proc(st: ^stream_t, ch: i32) -> bool ---
-	StreamPuts          :: proc(st: ^stream_t, s: cstring) -> bool ---
-	StreamRead          :: proc(st: ^stream_t, buffer: rawptr, bytes: uint) -> int ---
-	StreamWrite         :: proc(st: ^stream_t, buffer: rawptr, bytes: uint) -> bool ---
+	ObjOpenStream       :: proc(obj: ^obj_t, decode: c.bool) -> ^stream_t ---
+	PageCopy            :: proc(pdf: ^file_t, srcpage: ^obj_t) -> c.bool ---
+	PageGetNumStreams   :: proc(page: ^obj_t) -> c.size_t ---
+	PageOpenStream      :: proc(page: ^obj_t, n: c.size_t, decode: c.bool) -> ^stream_t ---
+	StreamClose         :: proc(st: ^stream_t) -> c.bool ---
+	StreamConsume       :: proc(st: ^stream_t, bytes: c.size_t) -> c.bool ---
+	StreamGetToken      :: proc(st: ^stream_t, buffer: [^]cstring, bufsize: c.size_t) -> c.bool ---
+	StreamPeek          :: proc(st: ^stream_t, buffer: rawptr, bytes: c.size_t) -> c.ssize_t ---
+	StreamPrintf        :: proc(st: ^stream_t, format: cstring) -> c.bool ---
+	StreamPutChar       :: proc(st: ^stream_t, ch: c.int) -> c.bool ---
+	StreamPuts          :: proc(st: ^stream_t, s: cstring) -> c.bool ---
+	StreamRead          :: proc(st: ^stream_t, buffer: rawptr, bytes: c.size_t) -> c.ssize_t ---
+	StreamWrite         :: proc(st: ^stream_t, buffer: rawptr, bytes: c.size_t) -> c.bool ---
 	StringCreate        :: proc(pdf: ^file_t, s: cstring) -> cstring ---
 	StringCreatef       :: proc(pdf: ^file_t, format: cstring) -> cstring ---
 }

--- a/examples/pdfio/pdfio/pdfio.odin
+++ b/examples/pdfio/pdfio/pdfio.odin
@@ -22,13 +22,13 @@ array_t :: struct {}
 dict_t :: struct {}
 
 // Key/value dictionary
-dict_cb_t :: proc "c" (^dict_t, cstring, rawptr) -> c.bool
+dict_cb_t :: proc "c" (^dict_t, cstring, rawptr) -> bool
 
 // Dictionary iterator callback
 file_t :: struct {}
 
 // PDF file
-error_cb_t :: proc "c" (^file_t, cstring, rawptr) -> c.bool
+error_cb_t :: proc "c" (^file_t, cstring, rawptr) -> bool
 
 // Error callback
 encryption_t :: enum c.int {
@@ -77,10 +77,10 @@ permission_t :: distinct bit_set[permission_e; c.int]
 PERMISSION_ALL :: permission_t { .PRINT, .MODIFY, .COPY, .ANNOTATE, .FORMS, .READING, .ASSEMBLE, .PRINT_HIGH }
 
 rect_t :: struct {
-	x1: c.double, // Lower-left X coordinate
-	y1: c.double, // Lower-left Y coordinate
-	x2: c.double, // Upper-right X coordinate
-	y2: c.double, // Upper-right Y coordinate
+	x1: f64, // Lower-left X coordinate
+	y1: f64, // Lower-left Y coordinate
+	x2: f64, // Upper-right X coordinate
+	y2: f64, // Upper-right Y coordinate
 }
 
 stream_t :: struct {}
@@ -103,63 +103,63 @@ valtype_t :: enum c.int {
 @(default_calling_convention="c", link_prefix="pdfio")
 foreign lib {
 	// Functions...
-	ArrayAppendArray    :: proc(a: ^array_t, value: ^array_t) -> c.bool ---
-	ArrayAppendBinary   :: proc(a: ^array_t, value: [^]c.uchar, valuelen: c.size_t) -> c.bool ---
-	ArrayAppendBoolean  :: proc(a: ^array_t, value: c.bool) -> c.bool ---
-	ArrayAppendDate     :: proc(a: ^array_t, value: libc.time_t) -> c.bool ---
-	ArrayAppendDict     :: proc(a: ^array_t, value: ^dict_t) -> c.bool ---
-	ArrayAppendName     :: proc(a: ^array_t, value: cstring) -> c.bool ---
-	ArrayAppendNumber   :: proc(a: ^array_t, value: c.double) -> c.bool ---
-	ArrayAppendObj      :: proc(a: ^array_t, value: ^obj_t) -> c.bool ---
-	ArrayAppendString   :: proc(a: ^array_t, value: cstring) -> c.bool ---
+	ArrayAppendArray    :: proc(a: ^array_t, value: ^array_t) -> bool ---
+	ArrayAppendBinary   :: proc(a: ^array_t, value: [^]c.uchar, valuelen: c.size_t) -> bool ---
+	ArrayAppendBoolean  :: proc(a: ^array_t, value: bool) -> bool ---
+	ArrayAppendDate     :: proc(a: ^array_t, value: libc.time_t) -> bool ---
+	ArrayAppendDict     :: proc(a: ^array_t, value: ^dict_t) -> bool ---
+	ArrayAppendName     :: proc(a: ^array_t, value: cstring) -> bool ---
+	ArrayAppendNumber   :: proc(a: ^array_t, value: f64) -> bool ---
+	ArrayAppendObj      :: proc(a: ^array_t, value: ^obj_t) -> bool ---
+	ArrayAppendString   :: proc(a: ^array_t, value: cstring) -> bool ---
 	ArrayCopy           :: proc(pdf: ^file_t, a: ^array_t) -> ^array_t ---
 	ArrayCreate         :: proc(pdf: ^file_t) -> ^array_t ---
 	ArrayGetArray       :: proc(a: ^array_t, n: c.size_t) -> ^array_t ---
 	ArrayGetBinary      :: proc(a: ^array_t, n: c.size_t, length: ^c.size_t) -> [^]c.uchar ---
-	ArrayGetBoolean     :: proc(a: ^array_t, n: c.size_t) -> c.bool ---
+	ArrayGetBoolean     :: proc(a: ^array_t, n: c.size_t) -> bool ---
 	ArrayGetDate        :: proc(a: ^array_t, n: c.size_t) -> libc.time_t ---
 	ArrayGetDict        :: proc(a: ^array_t, n: c.size_t) -> ^dict_t ---
 	ArrayGetName        :: proc(a: ^array_t, n: c.size_t) -> cstring ---
-	ArrayGetNumber      :: proc(a: ^array_t, n: c.size_t) -> c.double ---
+	ArrayGetNumber      :: proc(a: ^array_t, n: c.size_t) -> f64 ---
 	ArrayGetObj         :: proc(a: ^array_t, n: c.size_t) -> ^obj_t ---
 	ArrayGetSize        :: proc(a: ^array_t) -> c.size_t ---
 	ArrayGetString      :: proc(a: ^array_t, n: c.size_t) -> cstring ---
 	ArrayGetType        :: proc(a: ^array_t, n: c.size_t) -> valtype_t ---
-	ArrayRemove         :: proc(a: ^array_t, n: c.size_t) -> c.bool ---
-	DictClear           :: proc(dict: ^dict_t, key: cstring) -> c.bool ---
+	ArrayRemove         :: proc(a: ^array_t, n: c.size_t) -> bool ---
+	DictClear           :: proc(dict: ^dict_t, key: cstring) -> bool ---
 	DictCopy            :: proc(pdf: ^file_t, dict: ^dict_t) -> ^dict_t ---
 	DictCreate          :: proc(pdf: ^file_t) -> ^dict_t ---
 	DictGetArray        :: proc(dict: ^dict_t, key: cstring) -> ^array_t ---
 	DictGetBinary       :: proc(dict: ^dict_t, key: cstring, length: ^c.size_t) -> ^c.uchar ---
-	DictGetBoolean      :: proc(dict: ^dict_t, key: cstring) -> c.bool ---
+	DictGetBoolean      :: proc(dict: ^dict_t, key: cstring) -> bool ---
 	DictGetDate         :: proc(dict: ^dict_t, key: cstring) -> libc.time_t ---
 	DictGetDict         :: proc(dict: ^dict_t, key: cstring) -> ^dict_t ---
 	DictGetKey          :: proc(dict: ^dict_t, n: c.size_t) -> cstring ---
 	DictGetName         :: proc(dict: ^dict_t, key: cstring) -> cstring ---
 	DictGetNumPairs     :: proc(dict: ^dict_t) -> c.size_t ---
-	DictGetNumber       :: proc(dict: ^dict_t, key: cstring) -> c.double ---
+	DictGetNumber       :: proc(dict: ^dict_t, key: cstring) -> f64 ---
 	DictGetObj          :: proc(dict: ^dict_t, key: cstring) -> ^obj_t ---
 	DictGetRect         :: proc(dict: ^dict_t, key: cstring, rect: ^rect_t) -> ^rect_t ---
 	DictGetString       :: proc(dict: ^dict_t, key: cstring) -> cstring ---
 	DictGetType         :: proc(dict: ^dict_t, key: cstring) -> valtype_t ---
 	DictIterateKeys     :: proc(dict: ^dict_t, cb: dict_cb_t, cb_data: rawptr) ---
-	DictSetArray        :: proc(dict: ^dict_t, key: cstring, value: ^array_t) -> c.bool ---
-	DictSetBinary       :: proc(dict: ^dict_t, key: cstring, value: ^c.uchar, valuelen: c.size_t) -> c.bool ---
-	DictSetBoolean      :: proc(dict: ^dict_t, key: cstring, value: c.bool) -> c.bool ---
-	DictSetDate         :: proc(dict: ^dict_t, key: cstring, value: libc.time_t) -> c.bool ---
-	DictSetDict         :: proc(dict: ^dict_t, key: cstring, value: ^dict_t) -> c.bool ---
-	DictSetName         :: proc(dict: ^dict_t, key: cstring, value: cstring) -> c.bool ---
-	DictSetNull         :: proc(dict: ^dict_t, key: cstring) -> c.bool ---
-	DictSetNumber       :: proc(dict: ^dict_t, key: cstring, value: c.double) -> c.bool ---
-	DictSetObj          :: proc(dict: ^dict_t, key: cstring, value: ^obj_t) -> c.bool ---
-	DictSetRect         :: proc(dict: ^dict_t, key: cstring, value: ^rect_t) -> c.bool ---
-	DictSetString       :: proc(dict: ^dict_t, key: cstring, value: cstring) -> c.bool ---
-	DictSetStringf      :: proc(dict: ^dict_t, key: cstring, format: cstring) -> c.bool ---
-	FileClose           :: proc(pdf: ^file_t) -> c.bool ---
+	DictSetArray        :: proc(dict: ^dict_t, key: cstring, value: ^array_t) -> bool ---
+	DictSetBinary       :: proc(dict: ^dict_t, key: cstring, value: ^c.uchar, valuelen: c.size_t) -> bool ---
+	DictSetBoolean      :: proc(dict: ^dict_t, key: cstring, value: bool) -> bool ---
+	DictSetDate         :: proc(dict: ^dict_t, key: cstring, value: libc.time_t) -> bool ---
+	DictSetDict         :: proc(dict: ^dict_t, key: cstring, value: ^dict_t) -> bool ---
+	DictSetName         :: proc(dict: ^dict_t, key: cstring, value: cstring) -> bool ---
+	DictSetNull         :: proc(dict: ^dict_t, key: cstring) -> bool ---
+	DictSetNumber       :: proc(dict: ^dict_t, key: cstring, value: f64) -> bool ---
+	DictSetObj          :: proc(dict: ^dict_t, key: cstring, value: ^obj_t) -> bool ---
+	DictSetRect         :: proc(dict: ^dict_t, key: cstring, value: ^rect_t) -> bool ---
+	DictSetString       :: proc(dict: ^dict_t, key: cstring, value: cstring) -> bool ---
+	DictSetStringf      :: proc(dict: ^dict_t, key: cstring, format: cstring) -> bool ---
+	FileClose           :: proc(pdf: ^file_t) -> bool ---
 	FileCreate          :: proc(filename: cstring, version: cstring, media_box: ^rect_t, crop_box: ^rect_t, error_cb: error_cb_t, error_data: rawptr) -> ^file_t ---
 	FileCreateArrayObj  :: proc(pdf: ^file_t, array: ^array_t) -> ^obj_t ---
 	FileCreateNameObj   :: proc(pdf: ^file_t, name: cstring) -> ^obj_t ---
-	FileCreateNumberObj :: proc(pdf: ^file_t, number: c.double) -> ^obj_t ---
+	FileCreateNumberObj :: proc(pdf: ^file_t, number: f64) -> ^obj_t ---
 	FileCreateObj       :: proc(pdf: ^file_t, dict: ^dict_t) -> ^obj_t ---
 	FileCreateOutput    :: proc(output_cb: output_cb_t, output_ctx: rawptr, version: cstring, media_box: ^rect_t, crop_box: ^rect_t, error_cb: error_cb_t, error_data: rawptr) -> ^file_t ---
 
@@ -189,10 +189,10 @@ foreign lib {
 	FileSetCreationDate :: proc(pdf: ^file_t, value: libc.time_t) ---
 	FileSetCreator      :: proc(pdf: ^file_t, value: cstring) ---
 	FileSetKeywords     :: proc(pdf: ^file_t, value: cstring) ---
-	FileSetPermissions  :: proc(pdf: ^file_t, permissions: permission_t, encryption: encryption_t, owner_password: cstring, user_password: cstring) -> c.bool ---
+	FileSetPermissions  :: proc(pdf: ^file_t, permissions: permission_t, encryption: encryption_t, owner_password: cstring, user_password: cstring) -> bool ---
 	FileSetSubject      :: proc(pdf: ^file_t, value: cstring) ---
 	FileSetTitle        :: proc(pdf: ^file_t, value: cstring) ---
-	ObjClose            :: proc(obj: ^obj_t) -> c.bool ---
+	ObjClose            :: proc(obj: ^obj_t) -> bool ---
 	ObjCopy             :: proc(pdf: ^file_t, srcobj: ^obj_t) -> ^obj_t ---
 	ObjCreateStream     :: proc(obj: ^obj_t, compression: filter_t) -> ^stream_t ---
 	ObjGetArray         :: proc(obj: ^obj_t) -> ^array_t ---
@@ -203,19 +203,19 @@ foreign lib {
 	ObjGetNumber        :: proc(obj: ^obj_t) -> c.size_t ---
 	ObjGetSubtype       :: proc(obj: ^obj_t) -> cstring ---
 	ObjGetType          :: proc(obj: ^obj_t) -> cstring ---
-	ObjOpenStream       :: proc(obj: ^obj_t, decode: c.bool) -> ^stream_t ---
-	PageCopy            :: proc(pdf: ^file_t, srcpage: ^obj_t) -> c.bool ---
+	ObjOpenStream       :: proc(obj: ^obj_t, decode: bool) -> ^stream_t ---
+	PageCopy            :: proc(pdf: ^file_t, srcpage: ^obj_t) -> bool ---
 	PageGetNumStreams   :: proc(page: ^obj_t) -> c.size_t ---
-	PageOpenStream      :: proc(page: ^obj_t, n: c.size_t, decode: c.bool) -> ^stream_t ---
-	StreamClose         :: proc(st: ^stream_t) -> c.bool ---
-	StreamConsume       :: proc(st: ^stream_t, bytes: c.size_t) -> c.bool ---
-	StreamGetToken      :: proc(st: ^stream_t, buffer: [^]cstring, bufsize: c.size_t) -> c.bool ---
+	PageOpenStream      :: proc(page: ^obj_t, n: c.size_t, decode: bool) -> ^stream_t ---
+	StreamClose         :: proc(st: ^stream_t) -> bool ---
+	StreamConsume       :: proc(st: ^stream_t, bytes: c.size_t) -> bool ---
+	StreamGetToken      :: proc(st: ^stream_t, buffer: [^]cstring, bufsize: c.size_t) -> bool ---
 	StreamPeek          :: proc(st: ^stream_t, buffer: rawptr, bytes: c.size_t) -> c.ssize_t ---
-	StreamPrintf        :: proc(st: ^stream_t, format: cstring) -> c.bool ---
-	StreamPutChar       :: proc(st: ^stream_t, ch: c.int) -> c.bool ---
-	StreamPuts          :: proc(st: ^stream_t, s: cstring) -> c.bool ---
+	StreamPrintf        :: proc(st: ^stream_t, format: cstring) -> bool ---
+	StreamPutChar       :: proc(st: ^stream_t, ch: c.int) -> bool ---
+	StreamPuts          :: proc(st: ^stream_t, s: cstring) -> bool ---
 	StreamRead          :: proc(st: ^stream_t, buffer: rawptr, bytes: c.size_t) -> c.ssize_t ---
-	StreamWrite         :: proc(st: ^stream_t, buffer: rawptr, bytes: c.size_t) -> c.bool ---
+	StreamWrite         :: proc(st: ^stream_t, buffer: rawptr, bytes: c.size_t) -> bool ---
 	StringCreate        :: proc(pdf: ^file_t, s: cstring) -> cstring ---
 	StringCreatef       :: proc(pdf: ^file_t, format: cstring) -> cstring ---
 }

--- a/examples/raylib/raylib/raylib.odin
+++ b/examples/raylib/raylib/raylib.odin
@@ -157,10 +157,10 @@ Color :: distinct [4]u8
 
 // Rectangle, 4 components
 Rectangle :: struct {
-	x:      c.float, // Rectangle top-left corner position x
-	y:      c.float, // Rectangle top-left corner position y
-	width:  c.float, // Rectangle width
-	height: c.float, // Rectangle height
+	x:      f32, // Rectangle top-left corner position x
+	y:      f32, // Rectangle top-left corner position y
+	width:  f32, // Rectangle width
+	height: f32, // Rectangle height
 }
 
 // Image, pixel data stored in CPU memory (RAM)
@@ -231,7 +231,7 @@ Camera3D :: struct {
 	position:   Vector3, // Camera position
 	target:     Vector3, // Camera target it looks-at
 	up:         Vector3, // Camera up vector (rotation over its axis)
-	fovy:       c.float, // Camera field-of-view aperture in Y (degrees) in perspective, used as near plane width in orthographic
+	fovy:       f32,     // Camera field-of-view aperture in Y (degrees) in perspective, used as near plane width in orthographic
 	projection: c.int,   // Camera projection: CAMERA_PERSPECTIVE or CAMERA_ORTHOGRAPHIC
 }
 
@@ -241,25 +241,25 @@ Camera :: Camera3D // Camera type fallback, defaults to Camera3D
 Camera2D :: struct {
 	offset:   Vector2, // Camera offset (displacement from target)
 	target:   Vector2, // Camera target (rotation and zoom origin)
-	rotation: c.float, // Camera rotation in degrees
-	zoom:     c.float, // Camera zoom (scaling), should be 1.0f by default
+	rotation: f32,     // Camera rotation in degrees
+	zoom:     f32,     // Camera zoom (scaling), should be 1.0f by default
 }
 
 // Mesh, vertex data and vao/vbo
 Mesh :: struct {
 	vertexCount:   c.int,       // Number of vertices stored in arrays
 	triangleCount: c.int,       // Number of triangles stored (indexed or not)
-	vertices:      [^]c.float,  // Vertex position (XYZ - 3 components per vertex) (shader-location = 0)
-	texcoords:     [^]c.float,  // Vertex texture coordinates (UV - 2 components per vertex) (shader-location = 1)
-	texcoords2:    [^]c.float,  // Vertex texture second coordinates (UV - 2 components per vertex) (shader-location = 5)
-	normals:       [^]c.float,  // Vertex normals (XYZ - 3 components per vertex) (shader-location = 2)
-	tangents:      [^]c.float,  // Vertex tangents (XYZW - 4 components per vertex) (shader-location = 4)
+	vertices:      [^]f32,      // Vertex position (XYZ - 3 components per vertex) (shader-location = 0)
+	texcoords:     [^]f32,      // Vertex texture coordinates (UV - 2 components per vertex) (shader-location = 1)
+	texcoords2:    [^]f32,      // Vertex texture second coordinates (UV - 2 components per vertex) (shader-location = 5)
+	normals:       [^]f32,      // Vertex normals (XYZ - 3 components per vertex) (shader-location = 2)
+	tangents:      [^]f32,      // Vertex tangents (XYZW - 4 components per vertex) (shader-location = 4)
 	colors:        [^]c.uchar,  // Vertex colors (RGBA - 4 components per vertex) (shader-location = 3)
 	indices:       [^]c.ushort, // Vertex indices (in case vertex data comes indexed)
-	animVertices:  [^]c.float,  // Animated vertex positions (after bones transformations)
-	animNormals:   [^]c.float,  // Animated normals (after bones transformations)
+	animVertices:  [^]f32,      // Animated vertex positions (after bones transformations)
+	animNormals:   [^]f32,      // Animated normals (after bones transformations)
 	boneIds:       [^]c.uchar,  // Vertex bone ids, max 255 bone ids, up to 4 bones influence by vertex (skinning) (shader-location = 6)
-	boneWeights:   [^]c.float,  // Vertex bone weight, up to 4 bones influence by vertex (skinning) (shader-location = 7)
+	boneWeights:   [^]f32,      // Vertex bone weight, up to 4 bones influence by vertex (skinning) (shader-location = 7)
 	boneMatrices:  [^]Matrix,   // Bones animated transformation matrices
 	boneCount:     c.int,       // Number of bones
 	vaoId:         c.uint,      // OpenGL Vertex Array Object id
@@ -276,14 +276,14 @@ Shader :: struct {
 MaterialMap :: struct {
 	texture: Texture2D, // Material map texture
 	color:   Color,     // Material map color
-	value:   c.float,   // Material map value
+	value:   f32,       // Material map value
 }
 
 // Material, includes shader and maps
 Material :: struct {
 	shader: Shader,         // Material shader
 	maps:   [^]MaterialMap, // Material maps array (MAX_MATERIAL_MAPS)
-	params: [4]c.float,     // Material generic parameters (if required)
+	params: [4]f32,         // Material generic parameters (if required)
 }
 
 // Transform, vertex transformation data
@@ -329,8 +329,8 @@ Ray :: struct {
 
 // RayCollision, ray hit information
 RayCollision :: struct {
-	hit:      c.bool,  // Did the ray hit something?
-	distance: c.float, // Distance to the nearest hit
+	hit:      bool,    // Did the ray hit something?
+	distance: f32,     // Distance to the nearest hit
 	point:    Vector3, // Point of the nearest hit
 	normal:   Vector3, // Surface normal of hit
 }
@@ -369,34 +369,34 @@ Sound :: struct {
 Music :: struct {
 	stream:     AudioStream, // Audio stream
 	frameCount: c.uint,      // Total number of frames (considering channels)
-	looping:    c.bool,      // Music looping enable
+	looping:    bool,        // Music looping enable
 	ctxType:    c.int,       // Type of music context (audio filetype)
 	ctxData:    rawptr,      // Audio context data, depends on type
 }
 
 // VrDeviceInfo, Head-Mounted-Display device parameters
 VrDeviceInfo :: struct {
-	hResolution:            c.int,      // Horizontal resolution in pixels
-	vResolution:            c.int,      // Vertical resolution in pixels
-	hScreenSize:            c.float,    // Horizontal size in meters
-	vScreenSize:            c.float,    // Vertical size in meters
-	eyeToScreenDistance:    c.float,    // Distance between eye and display in meters
-	lensSeparationDistance: c.float,    // Lens separation distance in meters
-	interpupillaryDistance: c.float,    // IPD (distance between pupils) in meters
-	lensDistortionValues:   [4]c.float, // Lens distortion constant parameters
-	chromaAbCorrection:     [4]c.float, // Chromatic aberration correction parameters
+	hResolution:            c.int,  // Horizontal resolution in pixels
+	vResolution:            c.int,  // Vertical resolution in pixels
+	hScreenSize:            f32,    // Horizontal size in meters
+	vScreenSize:            f32,    // Vertical size in meters
+	eyeToScreenDistance:    f32,    // Distance between eye and display in meters
+	lensSeparationDistance: f32,    // Lens separation distance in meters
+	interpupillaryDistance: f32,    // IPD (distance between pupils) in meters
+	lensDistortionValues:   [4]f32, // Lens distortion constant parameters
+	chromaAbCorrection:     [4]f32, // Chromatic aberration correction parameters
 }
 
 // VrStereoConfig, VR stereo rendering configuration for simulator
 VrStereoConfig :: struct {
-	projection:        [2]Matrix,  // VR projection matrices (per eye)
-	viewOffset:        [2]Matrix,  // VR view offset matrices (per eye)
-	leftLensCenter:    [2]c.float, // VR left lens center
-	rightLensCenter:   [2]c.float, // VR right lens center
-	leftScreenCenter:  [2]c.float, // VR left screen center
-	rightScreenCenter: [2]c.float, // VR right screen center
-	scale:             [2]c.float, // VR distortion scale
-	scaleIn:           [2]c.float, // VR distortion scale in
+	projection:        [2]Matrix, // VR projection matrices (per eye)
+	viewOffset:        [2]Matrix, // VR view offset matrices (per eye)
+	leftLensCenter:    [2]f32,    // VR left lens center
+	rightLensCenter:   [2]f32,    // VR right lens center
+	leftScreenCenter:  [2]f32,    // VR left screen center
+	rightScreenCenter: [2]f32,    // VR right screen center
+	scale:             [2]f32,    // VR distortion scale
+	scaleIn:           [2]f32,    // VR distortion scale in
 }
 
 // File path list
@@ -841,11 +841,11 @@ TraceLogCallback :: proc "c" (c.int, cstring, ^c.va_list) // Logging: Redirect t
 
 LoadFileDataCallback :: proc "c" (cstring, ^c.int) -> ^c.uchar // FileIO: Load binary data
 
-SaveFileDataCallback :: proc "c" (cstring, rawptr, c.int) -> c.bool // FileIO: Save binary data
+SaveFileDataCallback :: proc "c" (cstring, rawptr, c.int) -> bool // FileIO: Save binary data
 
 LoadFileTextCallback :: proc "c" (cstring) -> cstring // FileIO: Load text data
 
-SaveFileTextCallback :: proc "c" (cstring, cstring) -> c.bool // FileIO: Save text data
+SaveFileTextCallback :: proc "c" (cstring, cstring) -> bool // FileIO: Save text data
 
 // Screen-space-related functions
 // GetMouseRay :: GetScreenToWorldRay     // Compatibility hack for previous raylib versions
@@ -860,15 +860,15 @@ foreign lib {
 	// Window-related functions
 	InitWindow               :: proc(width: c.int, height: c.int, title: cstring) --- // Initialize window and OpenGL context
 	CloseWindow              :: proc() ---                                            // Close window and unload OpenGL context
-	WindowShouldClose        :: proc() -> c.bool ---                                  // Check if application should close (KEY_ESCAPE pressed or windows close icon clicked)
-	IsWindowReady            :: proc() -> c.bool ---                                  // Check if window has been initialized successfully
-	IsWindowFullscreen       :: proc() -> c.bool ---                                  // Check if window is currently fullscreen
-	IsWindowHidden           :: proc() -> c.bool ---                                  // Check if window is currently hidden
-	IsWindowMinimized        :: proc() -> c.bool ---                                  // Check if window is currently minimized
-	IsWindowMaximized        :: proc() -> c.bool ---                                  // Check if window is currently maximized
-	IsWindowFocused          :: proc() -> c.bool ---                                  // Check if window is currently focused
-	IsWindowResized          :: proc() -> c.bool ---                                  // Check if window has been resized last frame
-	IsWindowState            :: proc(flag: c.uint) -> c.bool ---                      // Check if one specific window flag is enabled
+	WindowShouldClose        :: proc() -> bool ---                                    // Check if application should close (KEY_ESCAPE pressed or windows close icon clicked)
+	IsWindowReady            :: proc() -> bool ---                                    // Check if window has been initialized successfully
+	IsWindowFullscreen       :: proc() -> bool ---                                    // Check if window is currently fullscreen
+	IsWindowHidden           :: proc() -> bool ---                                    // Check if window is currently hidden
+	IsWindowMinimized        :: proc() -> bool ---                                    // Check if window is currently minimized
+	IsWindowMaximized        :: proc() -> bool ---                                    // Check if window is currently maximized
+	IsWindowFocused          :: proc() -> bool ---                                    // Check if window is currently focused
+	IsWindowResized          :: proc() -> bool ---                                    // Check if window has been resized last frame
+	IsWindowState            :: proc(flag: c.uint) -> bool ---                        // Check if one specific window flag is enabled
 	SetWindowState           :: proc(flags: c.uint) ---                               // Set window configuration state using flags
 	ClearWindowState         :: proc(flags: c.uint) ---                               // Clear window configuration state flags
 	ToggleFullscreen         :: proc() ---                                            // Toggle window state: fullscreen/windowed, resizes monitor to match window resolution
@@ -884,7 +884,7 @@ foreign lib {
 	SetWindowMinSize         :: proc(width: c.int, height: c.int) ---                 // Set window minimum dimensions (for FLAG_WINDOW_RESIZABLE)
 	SetWindowMaxSize         :: proc(width: c.int, height: c.int) ---                 // Set window maximum dimensions (for FLAG_WINDOW_RESIZABLE)
 	SetWindowSize            :: proc(width: c.int, height: c.int) ---                 // Set window dimensions
-	SetWindowOpacity         :: proc(opacity: c.float) ---                            // Set window opacity [0.0f..1.0f]
+	SetWindowOpacity         :: proc(opacity: f32) ---                                // Set window opacity [0.0f..1.0f]
 	SetWindowFocused         :: proc() ---                                            // Set window focused
 	GetWindowHandle          :: proc() -> rawptr ---                                  // Get native window handle
 	GetScreenWidth           :: proc() -> c.int ---                                   // Get current screen width
@@ -909,12 +909,12 @@ foreign lib {
 	DisableEventWaiting      :: proc() ---                                            // Disable waiting for events on EndDrawing(), automatic events polling
 
 	// Cursor-related functions
-	ShowCursor       :: proc() ---           // Shows cursor
-	HideCursor       :: proc() ---           // Hides cursor
-	IsCursorHidden   :: proc() -> c.bool --- // Check if cursor is not visible
-	EnableCursor     :: proc() ---           // Enables cursor (unlock cursor)
-	DisableCursor    :: proc() ---           // Disables cursor (lock cursor)
-	IsCursorOnScreen :: proc() -> c.bool --- // Check if cursor is on the screen
+	ShowCursor       :: proc() ---         // Shows cursor
+	HideCursor       :: proc() ---         // Hides cursor
+	IsCursorHidden   :: proc() -> bool --- // Check if cursor is not visible
+	EnableCursor     :: proc() ---         // Enables cursor (unlock cursor)
+	DisableCursor    :: proc() ---         // Disables cursor (lock cursor)
+	IsCursorOnScreen :: proc() -> bool --- // Check if cursor is on the screen
 
 	// Drawing-related functions
 	ClearBackground   :: proc(color: Color) ---                                    // Set background color (framebuffer clear color)
@@ -943,7 +943,7 @@ foreign lib {
 	// NOTE: Shader functionality is not available on OpenGL 1.1
 	LoadShader              :: proc(vsFileName: cstring, fsFileName: cstring) -> Shader ---  // Load shader from files and bind default locations
 	LoadShaderFromMemory    :: proc(vsCode: cstring, fsCode: cstring) -> Shader ---          // Load shader from code strings and bind default locations
-	IsShaderValid           :: proc(shader: Shader) -> c.bool ---                            // Check if a shader is valid (loaded on GPU)
+	IsShaderValid           :: proc(shader: Shader) -> bool ---                              // Check if a shader is valid (loaded on GPU)
 	GetShaderLocation       :: proc(shader: Shader, uniformName: cstring) -> c.int ---       // Get shader uniform location
 	GetShaderLocationAttrib :: proc(shader: Shader, attribName: cstring) -> c.int ---        // Get shader attribute location
 	SetShaderValue          :: proc(shader: Shader, locIndex: c.int, value: rawptr, uniformType: ShaderUniformDataType) --- // Set shader uniform value
@@ -961,18 +961,18 @@ foreign lib {
 	GetCameraMatrix2D       :: proc(camera: Camera2D) -> Matrix ---                          // Get camera 2d transform matrix
 
 	// Timing-related functions
-	SetTargetFPS :: proc(fps: c.int) ---   // Set target FPS (maximum)
-	GetFrameTime :: proc() -> c.float ---  // Get time in seconds for last frame drawn (delta time)
-	GetTime      :: proc() -> c.double --- // Get elapsed time in seconds since InitWindow()
-	GetFPS       :: proc() -> c.int ---    // Get current FPS
+	SetTargetFPS :: proc(fps: c.int) --- // Set target FPS (maximum)
+	GetFrameTime :: proc() -> f32 ---    // Get time in seconds for last frame drawn (delta time)
+	GetTime      :: proc() -> f64 ---    // Get elapsed time in seconds since InitWindow()
+	GetFPS       :: proc() -> c.int ---  // Get current FPS
 
 	// Custom frame control functions
 	// NOTE: Those functions are intended for advanced users that want full control over the frame processing
 	// By default EndDrawing() does this job: draws everything + SwapScreenBuffer() + manage frame timing + PollInputEvents()
 	// To avoid that behaviour and control frame processes manually, enable in config.h: SUPPORT_CUSTOM_FRAME_CONTROL
-	SwapScreenBuffer :: proc() ---                  // Swap back buffer with front buffer (screen drawing)
-	PollInputEvents  :: proc() ---                  // Register all input events
-	WaitTime         :: proc(seconds: c.double) --- // Wait for some time (halt program execution)
+	SwapScreenBuffer :: proc() ---             // Swap back buffer with front buffer (screen drawing)
+	PollInputEvents  :: proc() ---             // Register all input events
+	WaitTime         :: proc(seconds: f64) --- // Wait for some time (halt program execution)
 
 	// Random values generation functions
 	SetRandomSeed        :: proc(seed: c.uint) ---                                    // Set the seed for the random number generator
@@ -1004,35 +1004,35 @@ foreign lib {
 	// Files management functions
 	LoadFileData     :: proc(fileName: cstring, dataSize: ^c.int) -> ^c.uchar ---            // Load file data as byte array (read)
 	UnloadFileData   :: proc(data: ^c.uchar) ---                                             // Unload file data allocated by LoadFileData()
-	SaveFileData     :: proc(fileName: cstring, data: rawptr, dataSize: c.int) -> c.bool --- // Save data to file from byte array (write), returns true on success
-	ExportDataAsCode :: proc(data: ^c.uchar, dataSize: c.int, fileName: cstring) -> c.bool --- // Export data to code (.h), returns true on success
+	SaveFileData     :: proc(fileName: cstring, data: rawptr, dataSize: c.int) -> bool ---   // Save data to file from byte array (write), returns true on success
+	ExportDataAsCode :: proc(data: ^c.uchar, dataSize: c.int, fileName: cstring) -> bool --- // Export data to code (.h), returns true on success
 	LoadFileText     :: proc(fileName: cstring) -> cstring ---                               // Load text data from file (read), returns a '\0' terminated string
 	UnloadFileText   :: proc(text: cstring) ---                                              // Unload file text data allocated by LoadFileText()
-	SaveFileText     :: proc(fileName: cstring, text: cstring) -> c.bool ---                 // Save text data to file (write), string must be '\0' terminated, returns true on success
+	SaveFileText     :: proc(fileName: cstring, text: cstring) -> bool ---                   // Save text data to file (write), string must be '\0' terminated, returns true on success
 
 	// File system functions
-	FileExists              :: proc(fileName: cstring) -> c.bool ---               // Check if file exists
-	DirectoryExists         :: proc(dirPath: cstring) -> c.bool ---                // Check if a directory path exists
-	IsFileExtension         :: proc(fileName: cstring, ext: cstring) -> c.bool --- // Check file extension (including point: .png, .wav)
-	GetFileLength           :: proc(fileName: cstring) -> c.int ---                // Get file length in bytes (NOTE: GetFileSize() conflicts with windows.h)
-	GetFileExtension        :: proc(fileName: cstring) -> cstring ---              // Get pointer to extension for a filename string (includes dot: '.png')
-	GetFileName             :: proc(filePath: cstring) -> cstring ---              // Get pointer to filename for a path string
-	GetFileNameWithoutExt   :: proc(filePath: cstring) -> cstring ---              // Get filename string without extension (uses static string)
-	GetDirectoryPath        :: proc(filePath: cstring) -> cstring ---              // Get full path for a given fileName with path (uses static string)
-	GetPrevDirectoryPath    :: proc(dirPath: cstring) -> cstring ---               // Get previous directory path for a given path (uses static string)
-	GetWorkingDirectory     :: proc() -> cstring ---                               // Get current working directory (uses static string)
-	GetApplicationDirectory :: proc() -> cstring ---                               // Get the directory of the running application (uses static string)
-	MakeDirectory           :: proc(dirPath: cstring) -> c.int ---                 // Create directories (including full path requested), returns 0 on success
-	ChangeDirectory         :: proc(dir: cstring) -> c.bool ---                    // Change working directory, return true on success
-	IsPathFile              :: proc(path: cstring) -> c.bool ---                   // Check if a given path is a file or a directory
-	IsFileNameValid         :: proc(fileName: cstring) -> c.bool ---               // Check if fileName is valid for the platform/OS
-	LoadDirectoryFiles      :: proc(dirPath: cstring) -> FilePathList ---          // Load directory filepaths
-	LoadDirectoryFilesEx    :: proc(basePath: cstring, filter: cstring, scanSubdirs: c.bool) -> FilePathList --- // Load directory filepaths with extension filtering and recursive directory scan. Use 'DIR' in the filter string to include directories in the result
-	UnloadDirectoryFiles    :: proc(files: FilePathList) ---                       // Unload filepaths
-	IsFileDropped           :: proc() -> c.bool ---                                // Check if a file has been dropped into window
-	LoadDroppedFiles        :: proc() -> FilePathList ---                          // Load dropped filepaths
-	UnloadDroppedFiles      :: proc(files: FilePathList) ---                       // Unload dropped filepaths
-	GetFileModTime          :: proc(fileName: cstring) -> c.long ---               // Get file modification time (last write time)
+	FileExists              :: proc(fileName: cstring) -> bool ---               // Check if file exists
+	DirectoryExists         :: proc(dirPath: cstring) -> bool ---                // Check if a directory path exists
+	IsFileExtension         :: proc(fileName: cstring, ext: cstring) -> bool --- // Check file extension (including point: .png, .wav)
+	GetFileLength           :: proc(fileName: cstring) -> c.int ---              // Get file length in bytes (NOTE: GetFileSize() conflicts with windows.h)
+	GetFileExtension        :: proc(fileName: cstring) -> cstring ---            // Get pointer to extension for a filename string (includes dot: '.png')
+	GetFileName             :: proc(filePath: cstring) -> cstring ---            // Get pointer to filename for a path string
+	GetFileNameWithoutExt   :: proc(filePath: cstring) -> cstring ---            // Get filename string without extension (uses static string)
+	GetDirectoryPath        :: proc(filePath: cstring) -> cstring ---            // Get full path for a given fileName with path (uses static string)
+	GetPrevDirectoryPath    :: proc(dirPath: cstring) -> cstring ---             // Get previous directory path for a given path (uses static string)
+	GetWorkingDirectory     :: proc() -> cstring ---                             // Get current working directory (uses static string)
+	GetApplicationDirectory :: proc() -> cstring ---                             // Get the directory of the running application (uses static string)
+	MakeDirectory           :: proc(dirPath: cstring) -> c.int ---               // Create directories (including full path requested), returns 0 on success
+	ChangeDirectory         :: proc(dir: cstring) -> bool ---                    // Change working directory, return true on success
+	IsPathFile              :: proc(path: cstring) -> bool ---                   // Check if a given path is a file or a directory
+	IsFileNameValid         :: proc(fileName: cstring) -> bool ---               // Check if fileName is valid for the platform/OS
+	LoadDirectoryFiles      :: proc(dirPath: cstring) -> FilePathList ---        // Load directory filepaths
+	LoadDirectoryFilesEx    :: proc(basePath: cstring, filter: cstring, scanSubdirs: bool) -> FilePathList --- // Load directory filepaths with extension filtering and recursive directory scan. Use 'DIR' in the filter string to include directories in the result
+	UnloadDirectoryFiles    :: proc(files: FilePathList) ---                     // Unload filepaths
+	IsFileDropped           :: proc() -> bool ---                                // Check if a file has been dropped into window
+	LoadDroppedFiles        :: proc() -> FilePathList ---                        // Load dropped filepaths
+	UnloadDroppedFiles      :: proc(files: FilePathList) ---                     // Unload dropped filepaths
+	GetFileModTime          :: proc(fileName: cstring) -> c.long ---             // Get file modification time (last write time)
 
 	// Compression/Encoding functionality
 	CompressData     :: proc(data: ^c.uchar, dataSize: c.int, compDataSize: ^c.int) -> ^c.uchar --- // Compress data (DEFLATE algorithm), memory must be MemFree()
@@ -1046,7 +1046,7 @@ foreign lib {
 	// Automation events functionality
 	LoadAutomationEventList       :: proc(fileName: cstring) -> AutomationEventList --- // Load automation events list from file, NULL for empty list, capacity = MAX_AUTOMATION_EVENTS
 	UnloadAutomationEventList     :: proc(list: AutomationEventList) ---                // Unload automation events list from file
-	ExportAutomationEventList     :: proc(list: AutomationEventList, fileName: cstring) -> c.bool --- // Export automation events list as text file
+	ExportAutomationEventList     :: proc(list: AutomationEventList, fileName: cstring) -> bool --- // Export automation events list as text file
 	SetAutomationEventList        :: proc(list: ^AutomationEventList) ---               // Set automation event list to record to
 	SetAutomationEventBaseFrame   :: proc(frame: c.int) ---                             // Set automation event internal base frame to start recording
 	StartAutomationEventRecording :: proc() ---                                         // Start recording automation events (AutomationEventList must be set)
@@ -1054,44 +1054,44 @@ foreign lib {
 	PlayAutomationEvent           :: proc(event: AutomationEvent) ---                   // Play a recorded automation event
 
 	// Input-related functions: keyboard
-	IsKeyPressed       :: proc(key: KeyboardKey) -> c.bool ---  // Check if a key has been pressed once
-	IsKeyPressedRepeat :: proc(key: KeyboardKey) -> c.bool ---  // Check if a key has been pressed again
-	IsKeyDown          :: proc(key: KeyboardKey) -> c.bool ---  // Check if a key is being pressed
-	IsKeyReleased      :: proc(key: KeyboardKey) -> c.bool ---  // Check if a key has been released once
-	IsKeyUp            :: proc(key: KeyboardKey) -> c.bool ---  // Check if a key is NOT being pressed
+	IsKeyPressed       :: proc(key: KeyboardKey) -> bool ---    // Check if a key has been pressed once
+	IsKeyPressedRepeat :: proc(key: KeyboardKey) -> bool ---    // Check if a key has been pressed again
+	IsKeyDown          :: proc(key: KeyboardKey) -> bool ---    // Check if a key is being pressed
+	IsKeyReleased      :: proc(key: KeyboardKey) -> bool ---    // Check if a key has been released once
+	IsKeyUp            :: proc(key: KeyboardKey) -> bool ---    // Check if a key is NOT being pressed
 	GetKeyPressed      :: proc() -> KeyboardKey ---             // Get key pressed (keycode), call it multiple times for keys queued, returns 0 when the queue is empty
 	GetCharPressed     :: proc() -> c.int ---                   // Get char pressed (unicode), call it multiple times for chars queued, returns 0 when the queue is empty
 	GetKeyName         :: proc(key: KeyboardKey) -> cstring --- // Get name of a QWERTY key on the current keyboard layout (eg returns string 'q' for KEY_A on an AZERTY keyboard)
 	SetExitKey         :: proc(key: KeyboardKey) ---            // Set a custom key to exit program (default is ESC)
 
 	// Input-related functions: gamepads
-	IsGamepadAvailable      :: proc(gamepad: c.int) -> c.bool ---                // Check if a gamepad is available
-	GetGamepadName          :: proc(gamepad: c.int) -> cstring ---               // Get gamepad internal name id
-	IsGamepadButtonPressed  :: proc(gamepad: c.int, button: c.int) -> c.bool --- // Check if a gamepad button has been pressed once
-	IsGamepadButtonDown     :: proc(gamepad: c.int, button: c.int) -> c.bool --- // Check if a gamepad button is being pressed
-	IsGamepadButtonReleased :: proc(gamepad: c.int, button: c.int) -> c.bool --- // Check if a gamepad button has been released once
-	IsGamepadButtonUp       :: proc(gamepad: c.int, button: c.int) -> c.bool --- // Check if a gamepad button is NOT being pressed
-	GetGamepadButtonPressed :: proc() -> c.int ---                               // Get the last gamepad button pressed
-	GetGamepadAxisCount     :: proc(gamepad: c.int) -> c.int ---                 // Get gamepad axis count for a gamepad
-	GetGamepadAxisMovement  :: proc(gamepad: c.int, axis: c.int) -> c.float ---  // Get axis movement value for a gamepad axis
-	SetGamepadMappings      :: proc(mappings: cstring) -> c.int ---              // Set internal gamepad mappings (SDL_GameControllerDB)
-	SetGamepadVibration     :: proc(gamepad: c.int, leftMotor: c.float, rightMotor: c.float, duration: c.float) --- // Set gamepad vibration for both motors (duration in seconds)
+	IsGamepadAvailable      :: proc(gamepad: c.int) -> bool ---                // Check if a gamepad is available
+	GetGamepadName          :: proc(gamepad: c.int) -> cstring ---             // Get gamepad internal name id
+	IsGamepadButtonPressed  :: proc(gamepad: c.int, button: c.int) -> bool --- // Check if a gamepad button has been pressed once
+	IsGamepadButtonDown     :: proc(gamepad: c.int, button: c.int) -> bool --- // Check if a gamepad button is being pressed
+	IsGamepadButtonReleased :: proc(gamepad: c.int, button: c.int) -> bool --- // Check if a gamepad button has been released once
+	IsGamepadButtonUp       :: proc(gamepad: c.int, button: c.int) -> bool --- // Check if a gamepad button is NOT being pressed
+	GetGamepadButtonPressed :: proc() -> c.int ---                             // Get the last gamepad button pressed
+	GetGamepadAxisCount     :: proc(gamepad: c.int) -> c.int ---               // Get gamepad axis count for a gamepad
+	GetGamepadAxisMovement  :: proc(gamepad: c.int, axis: c.int) -> f32 ---    // Get axis movement value for a gamepad axis
+	SetGamepadMappings      :: proc(mappings: cstring) -> c.int ---            // Set internal gamepad mappings (SDL_GameControllerDB)
+	SetGamepadVibration     :: proc(gamepad: c.int, leftMotor: f32, rightMotor: f32, duration: f32) --- // Set gamepad vibration for both motors (duration in seconds)
 
 	// Input-related functions: mouse
-	IsMouseButtonPressed  :: proc(button: MouseButton) -> c.bool ---    // Check if a mouse button has been pressed once
-	IsMouseButtonDown     :: proc(button: MouseButton) -> c.bool ---    // Check if a mouse button is being pressed
-	IsMouseButtonReleased :: proc(button: MouseButton) -> c.bool ---    // Check if a mouse button has been released once
-	IsMouseButtonUp       :: proc(button: MouseButton) -> c.bool ---    // Check if a mouse button is NOT being pressed
-	GetMouseX             :: proc() -> c.int ---                        // Get mouse position X
-	GetMouseY             :: proc() -> c.int ---                        // Get mouse position Y
-	GetMousePosition      :: proc() -> Vector2 ---                      // Get mouse position XY
-	GetMouseDelta         :: proc() -> Vector2 ---                      // Get mouse delta between frames
-	SetMousePosition      :: proc(x: c.int, y: c.int) ---               // Set mouse position XY
-	SetMouseOffset        :: proc(offsetX: c.int, offsetY: c.int) ---   // Set mouse offset
-	SetMouseScale         :: proc(scaleX: c.float, scaleY: c.float) --- // Set mouse scaling
-	GetMouseWheelMove     :: proc() -> c.float ---                      // Get mouse wheel movement for X or Y, whichever is larger
-	GetMouseWheelMoveV    :: proc() -> Vector2 ---                      // Get mouse wheel movement for both X and Y
-	SetMouseCursor        :: proc(cursor: c.int) ---                    // Set mouse cursor
+	IsMouseButtonPressed  :: proc(button: MouseButton) -> bool ---    // Check if a mouse button has been pressed once
+	IsMouseButtonDown     :: proc(button: MouseButton) -> bool ---    // Check if a mouse button is being pressed
+	IsMouseButtonReleased :: proc(button: MouseButton) -> bool ---    // Check if a mouse button has been released once
+	IsMouseButtonUp       :: proc(button: MouseButton) -> bool ---    // Check if a mouse button is NOT being pressed
+	GetMouseX             :: proc() -> c.int ---                      // Get mouse position X
+	GetMouseY             :: proc() -> c.int ---                      // Get mouse position Y
+	GetMousePosition      :: proc() -> Vector2 ---                    // Get mouse position XY
+	GetMouseDelta         :: proc() -> Vector2 ---                    // Get mouse delta between frames
+	SetMousePosition      :: proc(x: c.int, y: c.int) ---             // Set mouse position XY
+	SetMouseOffset        :: proc(offsetX: c.int, offsetY: c.int) --- // Set mouse offset
+	SetMouseScale         :: proc(scaleX: f32, scaleY: f32) ---       // Set mouse scaling
+	GetMouseWheelMove     :: proc() -> f32 ---                        // Get mouse wheel movement for X or Y, whichever is larger
+	GetMouseWheelMoveV    :: proc() -> Vector2 ---                    // Get mouse wheel movement for both X and Y
+	SetMouseCursor        :: proc(cursor: c.int) ---                  // Set mouse cursor
 
 	// Input-related functions: touch
 	GetTouchX          :: proc() -> c.int ---               // Get touch position X for touch point 0 (relative to screen size)
@@ -1103,20 +1103,20 @@ foreign lib {
 	//------------------------------------------------------------------------------------
 	// Gestures and Touch Handling Functions (Module: rgestures)
 	//------------------------------------------------------------------------------------
-	SetGesturesEnabled     :: proc(flags: Gestures) ---             // Enable a set of gestures using flags
-	IsGestureDetected      :: proc(gesture: Gestures) -> c.bool --- // Check if a gesture have been detected
-	GetGestureDetected     :: proc() -> c.int ---                   // Get latest detected gesture
-	GetGestureHoldDuration :: proc() -> c.float ---                 // Get gesture hold time in seconds
-	GetGestureDragVector   :: proc() -> Vector2 ---                 // Get gesture drag vector
-	GetGestureDragAngle    :: proc() -> c.float ---                 // Get gesture drag angle
-	GetGesturePinchVector  :: proc() -> Vector2 ---                 // Get gesture pinch delta
-	GetGesturePinchAngle   :: proc() -> c.float ---                 // Get gesture pinch angle
+	SetGesturesEnabled     :: proc(flags: Gestures) ---           // Enable a set of gestures using flags
+	IsGestureDetected      :: proc(gesture: Gestures) -> bool --- // Check if a gesture have been detected
+	GetGestureDetected     :: proc() -> c.int ---                 // Get latest detected gesture
+	GetGestureHoldDuration :: proc() -> f32 ---                   // Get gesture hold time in seconds
+	GetGestureDragVector   :: proc() -> Vector2 ---               // Get gesture drag vector
+	GetGestureDragAngle    :: proc() -> f32 ---                   // Get gesture drag angle
+	GetGesturePinchVector  :: proc() -> Vector2 ---               // Get gesture pinch delta
+	GetGesturePinchAngle   :: proc() -> f32 ---                   // Get gesture pinch angle
 
 	//------------------------------------------------------------------------------------
 	// Camera System Functions (Module: rcamera)
 	//------------------------------------------------------------------------------------
 	UpdateCamera    :: proc(camera: ^Camera, mode: c.int) --- // Update camera position for selected mode
-	UpdateCameraPro :: proc(camera: ^Camera, movement: Vector3, rotation: Vector3, zoom: c.float) --- // Update camera movement/rotation
+	UpdateCameraPro :: proc(camera: ^Camera, movement: Vector3, rotation: Vector3, zoom: f32) --- // Update camera movement/rotation
 
 	//------------------------------------------------------------------------------------
 	// Basic Shapes Drawing Functions (Module: shapes)
@@ -1133,70 +1133,70 @@ foreign lib {
 	DrawPixelV                  :: proc(position: Vector2, color: Color) ---                  // Draw a pixel using geometry (Vector version) [Can be slow, use with care]
 	DrawLine                    :: proc(startPosX: c.int, startPosY: c.int, endPosX: c.int, endPosY: c.int, color: Color) --- // Draw a line
 	DrawLineV                   :: proc(startPos: Vector2, endPos: Vector2, color: Color) --- // Draw a line (using gl lines)
-	DrawLineEx                  :: proc(startPos: Vector2, endPos: Vector2, thick: c.float, color: Color) --- // Draw a line (using triangles/quads)
+	DrawLineEx                  :: proc(startPos: Vector2, endPos: Vector2, thick: f32, color: Color) --- // Draw a line (using triangles/quads)
 	DrawLineStrip               :: proc(points: ^Vector2, pointCount: c.int, color: Color) --- // Draw lines sequence (using gl lines)
-	DrawLineBezier              :: proc(startPos: Vector2, endPos: Vector2, thick: c.float, color: Color) --- // Draw line segment cubic-bezier in-out interpolation
-	DrawCircle                  :: proc(centerX: c.int, centerY: c.int, radius: c.float, color: Color) --- // Draw a color-filled circle
-	DrawCircleSector            :: proc(center: Vector2, radius: c.float, startAngle: c.float, endAngle: c.float, segments: c.int, color: Color) --- // Draw a piece of a circle
-	DrawCircleSectorLines       :: proc(center: Vector2, radius: c.float, startAngle: c.float, endAngle: c.float, segments: c.int, color: Color) --- // Draw circle sector outline
-	DrawCircleGradient          :: proc(centerX: c.int, centerY: c.int, radius: c.float, inner: Color, outer: Color) --- // Draw a gradient-filled circle
-	DrawCircleV                 :: proc(center: Vector2, radius: c.float, color: Color) ---   // Draw a color-filled circle (Vector version)
-	DrawCircleLines             :: proc(centerX: c.int, centerY: c.int, radius: c.float, color: Color) --- // Draw circle outline
-	DrawCircleLinesV            :: proc(center: Vector2, radius: c.float, color: Color) ---   // Draw circle outline (Vector version)
-	DrawEllipse                 :: proc(centerX: c.int, centerY: c.int, radiusH: c.float, radiusV: c.float, color: Color) --- // Draw ellipse
-	DrawEllipseLines            :: proc(centerX: c.int, centerY: c.int, radiusH: c.float, radiusV: c.float, color: Color) --- // Draw ellipse outline
-	DrawRing                    :: proc(center: Vector2, innerRadius: c.float, outerRadius: c.float, startAngle: c.float, endAngle: c.float, segments: c.int, color: Color) --- // Draw ring
-	DrawRingLines               :: proc(center: Vector2, innerRadius: c.float, outerRadius: c.float, startAngle: c.float, endAngle: c.float, segments: c.int, color: Color) --- // Draw ring outline
+	DrawLineBezier              :: proc(startPos: Vector2, endPos: Vector2, thick: f32, color: Color) --- // Draw line segment cubic-bezier in-out interpolation
+	DrawCircle                  :: proc(centerX: c.int, centerY: c.int, radius: f32, color: Color) --- // Draw a color-filled circle
+	DrawCircleSector            :: proc(center: Vector2, radius: f32, startAngle: f32, endAngle: f32, segments: c.int, color: Color) --- // Draw a piece of a circle
+	DrawCircleSectorLines       :: proc(center: Vector2, radius: f32, startAngle: f32, endAngle: f32, segments: c.int, color: Color) --- // Draw circle sector outline
+	DrawCircleGradient          :: proc(centerX: c.int, centerY: c.int, radius: f32, inner: Color, outer: Color) --- // Draw a gradient-filled circle
+	DrawCircleV                 :: proc(center: Vector2, radius: f32, color: Color) ---       // Draw a color-filled circle (Vector version)
+	DrawCircleLines             :: proc(centerX: c.int, centerY: c.int, radius: f32, color: Color) --- // Draw circle outline
+	DrawCircleLinesV            :: proc(center: Vector2, radius: f32, color: Color) ---       // Draw circle outline (Vector version)
+	DrawEllipse                 :: proc(centerX: c.int, centerY: c.int, radiusH: f32, radiusV: f32, color: Color) --- // Draw ellipse
+	DrawEllipseLines            :: proc(centerX: c.int, centerY: c.int, radiusH: f32, radiusV: f32, color: Color) --- // Draw ellipse outline
+	DrawRing                    :: proc(center: Vector2, innerRadius: f32, outerRadius: f32, startAngle: f32, endAngle: f32, segments: c.int, color: Color) --- // Draw ring
+	DrawRingLines               :: proc(center: Vector2, innerRadius: f32, outerRadius: f32, startAngle: f32, endAngle: f32, segments: c.int, color: Color) --- // Draw ring outline
 	DrawRectangle               :: proc(posX: c.int, posY: c.int, width: c.int, height: c.int, color: Color) --- // Draw a color-filled rectangle
 	DrawRectangleV              :: proc(position: Vector2, size: Vector2, color: Color) ---   // Draw a color-filled rectangle (Vector version)
 	DrawRectangleRec            :: proc(rec: Rectangle, color: Color) ---                     // Draw a color-filled rectangle
-	DrawRectanglePro            :: proc(rec: Rectangle, origin: Vector2, rotation: c.float, color: Color) --- // Draw a color-filled rectangle with pro parameters
+	DrawRectanglePro            :: proc(rec: Rectangle, origin: Vector2, rotation: f32, color: Color) --- // Draw a color-filled rectangle with pro parameters
 	DrawRectangleGradientV      :: proc(posX: c.int, posY: c.int, width: c.int, height: c.int, top: Color, bottom: Color) --- // Draw a vertical-gradient-filled rectangle
 	DrawRectangleGradientH      :: proc(posX: c.int, posY: c.int, width: c.int, height: c.int, left: Color, right: Color) --- // Draw a horizontal-gradient-filled rectangle
 	DrawRectangleGradientEx     :: proc(rec: Rectangle, topLeft: Color, bottomLeft: Color, topRight: Color, bottomRight: Color) --- // Draw a gradient-filled rectangle with custom vertex colors
 	DrawRectangleLines          :: proc(posX: c.int, posY: c.int, width: c.int, height: c.int, color: Color) --- // Draw rectangle outline
-	DrawRectangleLinesEx        :: proc(rec: Rectangle, lineThick: c.float, color: Color) --- // Draw rectangle outline with extended parameters
-	DrawRectangleRounded        :: proc(rec: Rectangle, roundness: c.float, segments: c.int, color: Color) --- // Draw rectangle with rounded edges
-	DrawRectangleRoundedLines   :: proc(rec: Rectangle, roundness: c.float, segments: c.int, color: Color) --- // Draw rectangle lines with rounded edges
-	DrawRectangleRoundedLinesEx :: proc(rec: Rectangle, roundness: c.float, segments: c.int, lineThick: c.float, color: Color) --- // Draw rectangle with rounded edges outline
+	DrawRectangleLinesEx        :: proc(rec: Rectangle, lineThick: f32, color: Color) ---     // Draw rectangle outline with extended parameters
+	DrawRectangleRounded        :: proc(rec: Rectangle, roundness: f32, segments: c.int, color: Color) --- // Draw rectangle with rounded edges
+	DrawRectangleRoundedLines   :: proc(rec: Rectangle, roundness: f32, segments: c.int, color: Color) --- // Draw rectangle lines with rounded edges
+	DrawRectangleRoundedLinesEx :: proc(rec: Rectangle, roundness: f32, segments: c.int, lineThick: f32, color: Color) --- // Draw rectangle with rounded edges outline
 	DrawTriangle                :: proc(v1: Vector2, v2: Vector2, v3: Vector2, color: Color) --- // Draw a color-filled triangle (vertex in counter-clockwise order!)
 	DrawTriangleLines           :: proc(v1: Vector2, v2: Vector2, v3: Vector2, color: Color) --- // Draw triangle outline (vertex in counter-clockwise order!)
 	DrawTriangleFan             :: proc(points: ^Vector2, pointCount: c.int, color: Color) --- // Draw a triangle fan defined by points (first vertex is the center)
 	DrawTriangleStrip           :: proc(points: ^Vector2, pointCount: c.int, color: Color) --- // Draw a triangle strip defined by points
-	DrawPoly                    :: proc(center: Vector2, sides: c.int, radius: c.float, rotation: c.float, color: Color) --- // Draw a regular polygon (Vector version)
-	DrawPolyLines               :: proc(center: Vector2, sides: c.int, radius: c.float, rotation: c.float, color: Color) --- // Draw a polygon outline of n sides
-	DrawPolyLinesEx             :: proc(center: Vector2, sides: c.int, radius: c.float, rotation: c.float, lineThick: c.float, color: Color) --- // Draw a polygon outline of n sides with extended parameters
+	DrawPoly                    :: proc(center: Vector2, sides: c.int, radius: f32, rotation: f32, color: Color) --- // Draw a regular polygon (Vector version)
+	DrawPolyLines               :: proc(center: Vector2, sides: c.int, radius: f32, rotation: f32, color: Color) --- // Draw a polygon outline of n sides
+	DrawPolyLinesEx             :: proc(center: Vector2, sides: c.int, radius: f32, rotation: f32, lineThick: f32, color: Color) --- // Draw a polygon outline of n sides with extended parameters
 
 	// Splines drawing functions
-	DrawSplineLinear                 :: proc(points: ^Vector2, pointCount: c.int, thick: c.float, color: Color) --- // Draw spline: Linear, minimum 2 points
-	DrawSplineBasis                  :: proc(points: ^Vector2, pointCount: c.int, thick: c.float, color: Color) --- // Draw spline: B-Spline, minimum 4 points
-	DrawSplineCatmullRom             :: proc(points: ^Vector2, pointCount: c.int, thick: c.float, color: Color) --- // Draw spline: Catmull-Rom, minimum 4 points
-	DrawSplineBezierQuadratic        :: proc(points: ^Vector2, pointCount: c.int, thick: c.float, color: Color) --- // Draw spline: Quadratic Bezier, minimum 3 points (1 control point): [p1, c2, p3, c4...]
-	DrawSplineBezierCubic            :: proc(points: ^Vector2, pointCount: c.int, thick: c.float, color: Color) --- // Draw spline: Cubic Bezier, minimum 4 points (2 control points): [p1, c2, c3, p4, c5, c6...]
-	DrawSplineSegmentLinear          :: proc(p1: Vector2, p2: Vector2, thick: c.float, color: Color) --- // Draw spline segment: Linear, 2 points
-	DrawSplineSegmentBasis           :: proc(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, thick: c.float, color: Color) --- // Draw spline segment: B-Spline, 4 points
-	DrawSplineSegmentCatmullRom      :: proc(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, thick: c.float, color: Color) --- // Draw spline segment: Catmull-Rom, 4 points
-	DrawSplineSegmentBezierQuadratic :: proc(p1: Vector2, c2: Vector2, p3: Vector2, thick: c.float, color: Color) --- // Draw spline segment: Quadratic Bezier, 2 points, 1 control point
-	DrawSplineSegmentBezierCubic     :: proc(p1: Vector2, c2: Vector2, c3: Vector2, p4: Vector2, thick: c.float, color: Color) --- // Draw spline segment: Cubic Bezier, 2 points, 2 control points
+	DrawSplineLinear                 :: proc(points: ^Vector2, pointCount: c.int, thick: f32, color: Color) --- // Draw spline: Linear, minimum 2 points
+	DrawSplineBasis                  :: proc(points: ^Vector2, pointCount: c.int, thick: f32, color: Color) --- // Draw spline: B-Spline, minimum 4 points
+	DrawSplineCatmullRom             :: proc(points: ^Vector2, pointCount: c.int, thick: f32, color: Color) --- // Draw spline: Catmull-Rom, minimum 4 points
+	DrawSplineBezierQuadratic        :: proc(points: ^Vector2, pointCount: c.int, thick: f32, color: Color) --- // Draw spline: Quadratic Bezier, minimum 3 points (1 control point): [p1, c2, p3, c4...]
+	DrawSplineBezierCubic            :: proc(points: ^Vector2, pointCount: c.int, thick: f32, color: Color) --- // Draw spline: Cubic Bezier, minimum 4 points (2 control points): [p1, c2, c3, p4, c5, c6...]
+	DrawSplineSegmentLinear          :: proc(p1: Vector2, p2: Vector2, thick: f32, color: Color) --- // Draw spline segment: Linear, 2 points
+	DrawSplineSegmentBasis           :: proc(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, thick: f32, color: Color) --- // Draw spline segment: B-Spline, 4 points
+	DrawSplineSegmentCatmullRom      :: proc(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, thick: f32, color: Color) --- // Draw spline segment: Catmull-Rom, 4 points
+	DrawSplineSegmentBezierQuadratic :: proc(p1: Vector2, c2: Vector2, p3: Vector2, thick: f32, color: Color) --- // Draw spline segment: Quadratic Bezier, 2 points, 1 control point
+	DrawSplineSegmentBezierCubic     :: proc(p1: Vector2, c2: Vector2, c3: Vector2, p4: Vector2, thick: f32, color: Color) --- // Draw spline segment: Cubic Bezier, 2 points, 2 control points
 
 	// Spline segment point evaluation functions, for a given t [0.0f .. 1.0f]
-	GetSplinePointLinear      :: proc(startPos: Vector2, endPos: Vector2, t: c.float) -> Vector2 --- // Get (evaluate) spline point: Linear
-	GetSplinePointBasis       :: proc(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, t: c.float) -> Vector2 --- // Get (evaluate) spline point: B-Spline
-	GetSplinePointCatmullRom  :: proc(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, t: c.float) -> Vector2 --- // Get (evaluate) spline point: Catmull-Rom
-	GetSplinePointBezierQuad  :: proc(p1: Vector2, c2: Vector2, p3: Vector2, t: c.float) -> Vector2 --- // Get (evaluate) spline point: Quadratic Bezier
-	GetSplinePointBezierCubic :: proc(p1: Vector2, c2: Vector2, c3: Vector2, p4: Vector2, t: c.float) -> Vector2 --- // Get (evaluate) spline point: Cubic Bezier
+	GetSplinePointLinear      :: proc(startPos: Vector2, endPos: Vector2, t: f32) -> Vector2 --- // Get (evaluate) spline point: Linear
+	GetSplinePointBasis       :: proc(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, t: f32) -> Vector2 --- // Get (evaluate) spline point: B-Spline
+	GetSplinePointCatmullRom  :: proc(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, t: f32) -> Vector2 --- // Get (evaluate) spline point: Catmull-Rom
+	GetSplinePointBezierQuad  :: proc(p1: Vector2, c2: Vector2, p3: Vector2, t: f32) -> Vector2 --- // Get (evaluate) spline point: Quadratic Bezier
+	GetSplinePointBezierCubic :: proc(p1: Vector2, c2: Vector2, c3: Vector2, p4: Vector2, t: f32) -> Vector2 --- // Get (evaluate) spline point: Cubic Bezier
 
 	// Basic shapes collision detection functions
-	CheckCollisionRecs          :: proc(rec1: Rectangle, rec2: Rectangle) -> c.bool ---    // Check collision between two rectangles
-	CheckCollisionCircles       :: proc(center1: Vector2, radius1: c.float, center2: Vector2, radius2: c.float) -> c.bool --- // Check collision between two circles
-	CheckCollisionCircleRec     :: proc(center: Vector2, radius: c.float, rec: Rectangle) -> c.bool --- // Check collision between circle and rectangle
-	CheckCollisionCircleLine    :: proc(center: Vector2, radius: c.float, p1: Vector2, p2: Vector2) -> c.bool --- // Check if circle collides with a line created betweeen two points [p1] and [p2]
-	CheckCollisionPointRec      :: proc(point: Vector2, rec: Rectangle) -> c.bool ---      // Check if point is inside rectangle
-	CheckCollisionPointCircle   :: proc(point: Vector2, center: Vector2, radius: c.float) -> c.bool --- // Check if point is inside circle
-	CheckCollisionPointTriangle :: proc(point: Vector2, p1: Vector2, p2: Vector2, p3: Vector2) -> c.bool --- // Check if point is inside a triangle
-	CheckCollisionPointLine     :: proc(point: Vector2, p1: Vector2, p2: Vector2, threshold: c.int) -> c.bool --- // Check if point belongs to line created between two points [p1] and [p2] with defined margin in pixels [threshold]
-	CheckCollisionPointPoly     :: proc(point: Vector2, points: ^Vector2, pointCount: c.int) -> c.bool --- // Check if point is within a polygon described by array of vertices
-	CheckCollisionLines         :: proc(startPos1: Vector2, endPos1: Vector2, startPos2: Vector2, endPos2: Vector2, collisionPoint: ^Vector2) -> c.bool --- // Check the collision between two lines defined by two points each, returns collision point by reference
+	CheckCollisionRecs          :: proc(rec1: Rectangle, rec2: Rectangle) -> bool ---      // Check collision between two rectangles
+	CheckCollisionCircles       :: proc(center1: Vector2, radius1: f32, center2: Vector2, radius2: f32) -> bool --- // Check collision between two circles
+	CheckCollisionCircleRec     :: proc(center: Vector2, radius: f32, rec: Rectangle) -> bool --- // Check collision between circle and rectangle
+	CheckCollisionCircleLine    :: proc(center: Vector2, radius: f32, p1: Vector2, p2: Vector2) -> bool --- // Check if circle collides with a line created betweeen two points [p1] and [p2]
+	CheckCollisionPointRec      :: proc(point: Vector2, rec: Rectangle) -> bool ---        // Check if point is inside rectangle
+	CheckCollisionPointCircle   :: proc(point: Vector2, center: Vector2, radius: f32) -> bool --- // Check if point is inside circle
+	CheckCollisionPointTriangle :: proc(point: Vector2, p1: Vector2, p2: Vector2, p3: Vector2) -> bool --- // Check if point is inside a triangle
+	CheckCollisionPointLine     :: proc(point: Vector2, p1: Vector2, p2: Vector2, threshold: c.int) -> bool --- // Check if point belongs to line created between two points [p1] and [p2] with defined margin in pixels [threshold]
+	CheckCollisionPointPoly     :: proc(point: Vector2, points: ^Vector2, pointCount: c.int) -> bool --- // Check if point is within a polygon described by array of vertices
+	CheckCollisionLines         :: proc(startPos1: Vector2, endPos1: Vector2, startPos2: Vector2, endPos2: Vector2, collisionPoint: ^Vector2) -> bool --- // Check the collision between two lines defined by two points each, returns collision point by reference
 	GetCollisionRec             :: proc(rec1: Rectangle, rec2: Rectangle) -> Rectangle --- // Get collision rectangle for two rectangles collision
 
 	// Image loading functions
@@ -1208,20 +1208,20 @@ foreign lib {
 	LoadImageFromMemory     :: proc(fileType: cstring, fileData: ^c.uchar, dataSize: c.int) -> Image --- // Load image from memory buffer, fileType refers to extension: i.e. '.png'
 	LoadImageFromTexture    :: proc(texture: Texture2D) -> Image ---                // Load image from GPU texture data
 	LoadImageFromScreen     :: proc() -> Image ---                                  // Load image from screen buffer and (screenshot)
-	IsImageValid            :: proc(image: Image) -> c.bool ---                     // Check if an image is valid (data and parameters)
+	IsImageValid            :: proc(image: Image) -> bool ---                       // Check if an image is valid (data and parameters)
 	UnloadImage             :: proc(image: Image) ---                               // Unload image from CPU memory (RAM)
-	ExportImage             :: proc(image: Image, fileName: cstring) -> c.bool ---  // Export image data to file, returns true on success
+	ExportImage             :: proc(image: Image, fileName: cstring) -> bool ---    // Export image data to file, returns true on success
 	ExportImageToMemory     :: proc(image: Image, fileType: cstring, fileSize: ^c.int) -> ^c.uchar --- // Export image to memory buffer
-	ExportImageAsCode       :: proc(image: Image, fileName: cstring) -> c.bool ---  // Export image as code file defining an array of bytes, returns true on success
+	ExportImageAsCode       :: proc(image: Image, fileName: cstring) -> bool ---    // Export image as code file defining an array of bytes, returns true on success
 
 	// Image generation functions
 	GenImageColor          :: proc(width: c.int, height: c.int, color: Color) -> Image ---    // Generate image: plain color
 	GenImageGradientLinear :: proc(width: c.int, height: c.int, direction: c.int, start: Color, end: Color) -> Image --- // Generate image: linear gradient, direction in degrees [0..360], 0=Vertical gradient
-	GenImageGradientRadial :: proc(width: c.int, height: c.int, density: c.float, inner: Color, outer: Color) -> Image --- // Generate image: radial gradient
-	GenImageGradientSquare :: proc(width: c.int, height: c.int, density: c.float, inner: Color, outer: Color) -> Image --- // Generate image: square gradient
+	GenImageGradientRadial :: proc(width: c.int, height: c.int, density: f32, inner: Color, outer: Color) -> Image --- // Generate image: radial gradient
+	GenImageGradientSquare :: proc(width: c.int, height: c.int, density: f32, inner: Color, outer: Color) -> Image --- // Generate image: square gradient
 	GenImageChecked        :: proc(width: c.int, height: c.int, checksX: c.int, checksY: c.int, col1: Color, col2: Color) -> Image --- // Generate image: checked
-	GenImageWhiteNoise     :: proc(width: c.int, height: c.int, factor: c.float) -> Image --- // Generate image: white noise
-	GenImagePerlinNoise    :: proc(width: c.int, height: c.int, offsetX: c.int, offsetY: c.int, scale: c.float) -> Image --- // Generate image: perlin noise
+	GenImageWhiteNoise     :: proc(width: c.int, height: c.int, factor: f32) -> Image ---     // Generate image: white noise
+	GenImagePerlinNoise    :: proc(width: c.int, height: c.int, offsetX: c.int, offsetY: c.int, scale: f32) -> Image --- // Generate image: perlin noise
 	GenImageCellular       :: proc(width: c.int, height: c.int, tileSize: c.int) -> Image --- // Generate image: cellular algorithm, bigger tileSize means bigger cells
 	GenImageText           :: proc(width: c.int, height: c.int, text: cstring) -> Image ---   // Generate image: grayscale image from text data
 
@@ -1230,16 +1230,16 @@ foreign lib {
 	ImageFromImage         :: proc(image: Image, rec: Rectangle) -> Image ---                 // Create an image from another image piece
 	ImageFromChannel       :: proc(image: Image, selectedChannel: c.int) -> Image ---         // Create an image from a selected channel of another image (GRAYSCALE)
 	ImageText              :: proc(text: cstring, fontSize: c.int, color: Color) -> Image --- // Create an image from text (default font)
-	ImageTextEx            :: proc(font: Font, text: cstring, fontSize: c.float, spacing: c.float, tint: Color) -> Image --- // Create an image from text (custom sprite font)
+	ImageTextEx            :: proc(font: Font, text: cstring, fontSize: f32, spacing: f32, tint: Color) -> Image --- // Create an image from text (custom sprite font)
 	ImageFormat            :: proc(image: ^Image, newFormat: c.int) ---                       // Convert image data to desired format
 	ImageToPOT             :: proc(image: ^Image, fill: Color) ---                            // Convert image to POT (power-of-two)
 	ImageCrop              :: proc(image: ^Image, crop: Rectangle) ---                        // Crop an image to a defined rectangle
-	ImageAlphaCrop         :: proc(image: ^Image, threshold: c.float) ---                     // Crop image depending on alpha value
-	ImageAlphaClear        :: proc(image: ^Image, color: Color, threshold: c.float) ---       // Clear alpha channel to desired color
+	ImageAlphaCrop         :: proc(image: ^Image, threshold: f32) ---                         // Crop image depending on alpha value
+	ImageAlphaClear        :: proc(image: ^Image, color: Color, threshold: f32) ---           // Clear alpha channel to desired color
 	ImageAlphaMask         :: proc(image: ^Image, alphaMask: Image) ---                       // Apply alpha mask to image
 	ImageAlphaPremultiply  :: proc(image: ^Image) ---                                         // Premultiply alpha channel
 	ImageBlurGaussian      :: proc(image: ^Image, blurSize: c.int) ---                        // Apply Gaussian blur using a box blur approximation
-	ImageKernelConvolution :: proc(image: ^Image, kernel: ^c.float, kernelSize: c.int) ---    // Apply custom square convolution kernel to image
+	ImageKernelConvolution :: proc(image: ^Image, kernel: ^f32, kernelSize: c.int) ---        // Apply custom square convolution kernel to image
 	ImageResize            :: proc(image: ^Image, newWidth: c.int, newHeight: c.int) ---      // Resize image (Bicubic scaling algorithm)
 	ImageResizeNN          :: proc(image: ^Image, newWidth: c.int, newHeight: c.int) ---      // Resize image (Nearest-Neighbor scaling algorithm)
 	ImageResizeCanvas      :: proc(image: ^Image, newWidth: c.int, newHeight: c.int, offsetX: c.int, offsetY: c.int, fill: Color) --- // Resize canvas and fill with color
@@ -1253,14 +1253,14 @@ foreign lib {
 	ImageColorTint         :: proc(image: ^Image, color: Color) ---                           // Modify image color: tint
 	ImageColorInvert       :: proc(image: ^Image) ---                                         // Modify image color: invert
 	ImageColorGrayscale    :: proc(image: ^Image) ---                                         // Modify image color: grayscale
-	ImageColorContrast     :: proc(image: ^Image, contrast: c.float) ---                      // Modify image color: contrast (-100 to 100)
+	ImageColorContrast     :: proc(image: ^Image, contrast: f32) ---                          // Modify image color: contrast (-100 to 100)
 	ImageColorBrightness   :: proc(image: ^Image, brightness: c.int) ---                      // Modify image color: brightness (-255 to 255)
 	ImageColorReplace      :: proc(image: ^Image, color: Color, replace: Color) ---           // Modify image color: replace color
 	LoadImageColors        :: proc(image: Image) -> ^Color ---                                // Load color data from image as a Color array (RGBA - 32bit)
 	LoadImagePalette       :: proc(image: Image, maxPaletteSize: c.int, colorCount: ^c.int) -> ^Color --- // Load colors palette from image as a Color array (RGBA - 32bit)
 	UnloadImageColors      :: proc(colors: ^Color) ---                                        // Unload color data loaded with LoadImageColors()
 	UnloadImagePalette     :: proc(colors: ^Color) ---                                        // Unload colors palette loaded with LoadImagePalette()
-	GetImageAlphaBorder    :: proc(image: Image, threshold: c.float) -> Rectangle ---         // Get image alpha border rectangle
+	GetImageAlphaBorder    :: proc(image: Image, threshold: f32) -> Rectangle ---             // Get image alpha border rectangle
 	GetImageColor          :: proc(image: Image, x: c.int, y: c.int) -> Color ---             // Get image pixel color at (x, y) position
 
 	// Image drawing functions
@@ -1286,7 +1286,7 @@ foreign lib {
 	ImageDrawTriangleStrip  :: proc(dst: ^Image, points: ^Vector2, pointCount: c.int, color: Color) --- // Draw a triangle strip defined by points within an image
 	ImageDraw               :: proc(dst: ^Image, src: Image, srcRec: Rectangle, dstRec: Rectangle, tint: Color) --- // Draw a source image within a destination image (tint applied to source)
 	ImageDrawText           :: proc(dst: ^Image, text: cstring, posX: c.int, posY: c.int, fontSize: c.int, color: Color) --- // Draw text (using default font) within an image (destination)
-	ImageDrawTextEx         :: proc(dst: ^Image, font: Font, text: cstring, position: Vector2, fontSize: c.float, spacing: c.float, tint: Color) --- // Draw text (custom sprite font) within an image (destination)
+	ImageDrawTextEx         :: proc(dst: ^Image, font: Font, text: cstring, position: Vector2, fontSize: f32, spacing: f32, tint: Color) --- // Draw text (custom sprite font) within an image (destination)
 
 	// Texture loading functions
 	// NOTE: These functions require GPU access
@@ -1294,9 +1294,9 @@ foreign lib {
 	LoadTextureFromImage :: proc(image: Image) -> Texture2D ---                          // Load texture from image data
 	LoadTextureCubemap   :: proc(image: Image, layout: c.int) -> TextureCubemap ---      // Load cubemap from image, multiple image cubemap layouts supported
 	LoadRenderTexture    :: proc(width: c.int, height: c.int) -> RenderTexture2D ---     // Load texture for rendering (framebuffer)
-	IsTextureValid       :: proc(texture: Texture2D) -> c.bool ---                       // Check if a texture is valid (loaded in GPU)
+	IsTextureValid       :: proc(texture: Texture2D) -> bool ---                         // Check if a texture is valid (loaded in GPU)
 	UnloadTexture        :: proc(texture: Texture2D) ---                                 // Unload texture from GPU memory (VRAM)
-	IsRenderTextureValid :: proc(target: RenderTexture2D) -> c.bool ---                  // Check if a render texture is valid (loaded in GPU)
+	IsRenderTextureValid :: proc(target: RenderTexture2D) -> bool ---                    // Check if a render texture is valid (loaded in GPU)
 	UnloadRenderTexture  :: proc(target: RenderTexture2D) ---                            // Unload render texture from GPU memory (VRAM)
 	UpdateTexture        :: proc(texture: Texture2D, pixels: rawptr) ---                 // Update GPU texture with new data
 	UpdateTextureRec     :: proc(texture: Texture2D, rec: Rectangle, pixels: rawptr) --- // Update GPU texture rectangle with new data
@@ -1309,29 +1309,29 @@ foreign lib {
 	// Texture drawing functions
 	DrawTexture       :: proc(texture: Texture2D, posX: c.int, posY: c.int, tint: Color) --- // Draw a Texture2D
 	DrawTextureV      :: proc(texture: Texture2D, position: Vector2, tint: Color) ---        // Draw a Texture2D with position defined as Vector2
-	DrawTextureEx     :: proc(texture: Texture2D, position: Vector2, rotation: c.float, scale: c.float, tint: Color) --- // Draw a Texture2D with extended parameters
+	DrawTextureEx     :: proc(texture: Texture2D, position: Vector2, rotation: f32, scale: f32, tint: Color) --- // Draw a Texture2D with extended parameters
 	DrawTextureRec    :: proc(texture: Texture2D, source: Rectangle, position: Vector2, tint: Color) --- // Draw a part of a texture defined by a rectangle
-	DrawTexturePro    :: proc(texture: Texture2D, source: Rectangle, dest: Rectangle, origin: Vector2, rotation: c.float, tint: Color) --- // Draw a part of a texture defined by a rectangle with 'pro' parameters
-	DrawTextureNPatch :: proc(texture: Texture2D, nPatchInfo: NPatchInfo, dest: Rectangle, origin: Vector2, rotation: c.float, tint: Color) --- // Draws a texture (or part of it) that stretches or shrinks nicely
+	DrawTexturePro    :: proc(texture: Texture2D, source: Rectangle, dest: Rectangle, origin: Vector2, rotation: f32, tint: Color) --- // Draw a part of a texture defined by a rectangle with 'pro' parameters
+	DrawTextureNPatch :: proc(texture: Texture2D, nPatchInfo: NPatchInfo, dest: Rectangle, origin: Vector2, rotation: f32, tint: Color) --- // Draws a texture (or part of it) that stretches or shrinks nicely
 
 	// Color/pixel related functions
-	ColorIsEqual        :: proc(col1: Color, col2: Color) -> c.bool ---                     // Check if two colors are equal
-	Fade                :: proc(color: Color, alpha: c.float) -> Color ---                  // Get color with alpha applied, alpha goes from 0.0f to 1.0f
-	ColorToInt          :: proc(color: Color) -> c.int ---                                  // Get hexadecimal value for a Color (0xRRGGBBAA)
-	ColorNormalize      :: proc(color: Color) -> Vector4 ---                                // Get Color normalized as float [0..1]
-	ColorFromNormalized :: proc(normalized: Vector4) -> Color ---                           // Get Color from normalized values [0..1]
-	ColorToHSV          :: proc(color: Color) -> Vector3 ---                                // Get HSV values for a Color, hue [0..360], saturation/value [0..1]
-	ColorFromHSV        :: proc(hue: c.float, saturation: c.float, value: c.float) -> Color --- // Get a Color from HSV values, hue [0..360], saturation/value [0..1]
-	ColorTint           :: proc(color: Color, tint: Color) -> Color ---                     // Get color multiplied with another color
-	ColorBrightness     :: proc(color: Color, factor: c.float) -> Color ---                 // Get color with brightness correction, brightness factor goes from -1.0f to 1.0f
-	ColorContrast       :: proc(color: Color, contrast: c.float) -> Color ---               // Get color with contrast correction, contrast values between -1.0f and 1.0f
-	ColorAlpha          :: proc(color: Color, alpha: c.float) -> Color ---                  // Get color with alpha applied, alpha goes from 0.0f to 1.0f
-	ColorAlphaBlend     :: proc(dst: Color, src: Color, tint: Color) -> Color ---           // Get src alpha-blended into dst color with tint
-	ColorLerp           :: proc(color1: Color, color2: Color, factor: c.float) -> Color --- // Get color lerp interpolation between two colors, factor [0.0f..1.0f]
-	GetColor            :: proc(hexValue: c.uint) -> Color ---                              // Get Color structure from hexadecimal value
-	GetPixelColor       :: proc(srcPtr: rawptr, format: c.int) -> Color ---                 // Get Color from a source pixel pointer of certain format
-	SetPixelColor       :: proc(dstPtr: rawptr, color: Color, format: c.int) ---            // Set color formatted into destination pixel pointer
-	GetPixelDataSize    :: proc(width: c.int, height: c.int, format: c.int) -> c.int ---    // Get pixel data size in bytes for certain format
+	ColorIsEqual        :: proc(col1: Color, col2: Color) -> bool ---                    // Check if two colors are equal
+	Fade                :: proc(color: Color, alpha: f32) -> Color ---                   // Get color with alpha applied, alpha goes from 0.0f to 1.0f
+	ColorToInt          :: proc(color: Color) -> c.int ---                               // Get hexadecimal value for a Color (0xRRGGBBAA)
+	ColorNormalize      :: proc(color: Color) -> Vector4 ---                             // Get Color normalized as float [0..1]
+	ColorFromNormalized :: proc(normalized: Vector4) -> Color ---                        // Get Color from normalized values [0..1]
+	ColorToHSV          :: proc(color: Color) -> Vector3 ---                             // Get HSV values for a Color, hue [0..360], saturation/value [0..1]
+	ColorFromHSV        :: proc(hue: f32, saturation: f32, value: f32) -> Color ---      // Get a Color from HSV values, hue [0..360], saturation/value [0..1]
+	ColorTint           :: proc(color: Color, tint: Color) -> Color ---                  // Get color multiplied with another color
+	ColorBrightness     :: proc(color: Color, factor: f32) -> Color ---                  // Get color with brightness correction, brightness factor goes from -1.0f to 1.0f
+	ColorContrast       :: proc(color: Color, contrast: f32) -> Color ---                // Get color with contrast correction, contrast values between -1.0f and 1.0f
+	ColorAlpha          :: proc(color: Color, alpha: f32) -> Color ---                   // Get color with alpha applied, alpha goes from 0.0f to 1.0f
+	ColorAlphaBlend     :: proc(dst: Color, src: Color, tint: Color) -> Color ---        // Get src alpha-blended into dst color with tint
+	ColorLerp           :: proc(color1: Color, color2: Color, factor: f32) -> Color ---  // Get color lerp interpolation between two colors, factor [0.0f..1.0f]
+	GetColor            :: proc(hexValue: c.uint) -> Color ---                           // Get Color structure from hexadecimal value
+	GetPixelColor       :: proc(srcPtr: rawptr, format: c.int) -> Color ---              // Get Color from a source pixel pointer of certain format
+	SetPixelColor       :: proc(dstPtr: rawptr, color: Color, format: c.int) ---         // Set color formatted into destination pixel pointer
+	GetPixelDataSize    :: proc(width: c.int, height: c.int, format: c.int) -> c.int --- // Get pixel data size in bytes for certain format
 
 	// Font loading/unloading functions
 	GetFontDefault     :: proc() -> Font ---                                           // Get the default Font
@@ -1339,25 +1339,25 @@ foreign lib {
 	LoadFontEx         :: proc(fileName: cstring, fontSize: c.int, codepoints: ^c.int, codepointCount: c.int) -> Font --- // Load font from file with extended parameters, use NULL for codepoints and 0 for codepointCount to load the default character set, font size is provided in pixels height
 	LoadFontFromImage  :: proc(image: Image, key: Color, firstChar: c.int) -> Font --- // Load font from Image (XNA style)
 	LoadFontFromMemory :: proc(fileType: cstring, fileData: ^c.uchar, dataSize: c.int, fontSize: c.int, codepoints: ^c.int, codepointCount: c.int) -> Font --- // Load font from memory buffer, fileType refers to extension: i.e. '.ttf'
-	IsFontValid        :: proc(font: Font) -> c.bool ---                               // Check if a font is valid (font data loaded, WARNING: GPU texture not checked)
+	IsFontValid        :: proc(font: Font) -> bool ---                                 // Check if a font is valid (font data loaded, WARNING: GPU texture not checked)
 	LoadFontData       :: proc(fileData: ^c.uchar, dataSize: c.int, fontSize: c.int, codepoints: ^c.int, codepointCount: c.int, type: c.int) -> ^GlyphInfo --- // Load font data for further use
 	GenImageFontAtlas  :: proc(glyphs: ^GlyphInfo, glyphRecs: ^^Rectangle, glyphCount: c.int, fontSize: c.int, padding: c.int, packMethod: c.int) -> Image --- // Generate image font atlas using chars info
 	UnloadFontData     :: proc(glyphs: ^GlyphInfo, glyphCount: c.int) ---              // Unload font chars info data (RAM)
 	UnloadFont         :: proc(font: Font) ---                                         // Unload font from GPU memory (VRAM)
-	ExportFontAsCode   :: proc(font: Font, fileName: cstring) -> c.bool ---            // Export font as code file, returns true on success
+	ExportFontAsCode   :: proc(font: Font, fileName: cstring) -> bool ---              // Export font as code file, returns true on success
 
 	// Text drawing functions
 	DrawFPS            :: proc(posX: c.int, posY: c.int) --- // Draw current FPS
 	DrawText           :: proc(text: cstring, posX: c.int, posY: c.int, fontSize: c.int, color: Color) --- // Draw text (using default font)
-	DrawTextEx         :: proc(font: Font, text: cstring, position: Vector2, fontSize: c.float, spacing: c.float, tint: Color) --- // Draw text using font and additional parameters
-	DrawTextPro        :: proc(font: Font, text: cstring, position: Vector2, origin: Vector2, rotation: c.float, fontSize: c.float, spacing: c.float, tint: Color) --- // Draw text using Font and pro parameters (rotation)
-	DrawTextCodepoint  :: proc(font: Font, codepoint: c.int, position: Vector2, fontSize: c.float, tint: Color) --- // Draw one character (codepoint)
-	DrawTextCodepoints :: proc(font: Font, codepoints: ^c.int, codepointCount: c.int, position: Vector2, fontSize: c.float, spacing: c.float, tint: Color) --- // Draw multiple character (codepoint)
+	DrawTextEx         :: proc(font: Font, text: cstring, position: Vector2, fontSize: f32, spacing: f32, tint: Color) --- // Draw text using font and additional parameters
+	DrawTextPro        :: proc(font: Font, text: cstring, position: Vector2, origin: Vector2, rotation: f32, fontSize: f32, spacing: f32, tint: Color) --- // Draw text using Font and pro parameters (rotation)
+	DrawTextCodepoint  :: proc(font: Font, codepoint: c.int, position: Vector2, fontSize: f32, tint: Color) --- // Draw one character (codepoint)
+	DrawTextCodepoints :: proc(font: Font, codepoints: ^c.int, codepointCount: c.int, position: Vector2, fontSize: f32, spacing: f32, tint: Color) --- // Draw multiple character (codepoint)
 
 	// Text font info functions
 	SetTextLineSpacing :: proc(spacing: c.int) ---                            // Set vertical line spacing when drawing with line-breaks
 	MeasureText        :: proc(text: cstring, fontSize: c.int) -> c.int ---   // Measure string width for default font
-	MeasureTextEx      :: proc(font: Font, text: cstring, fontSize: c.float, spacing: c.float) -> Vector2 --- // Measure string size for Font
+	MeasureTextEx      :: proc(font: Font, text: cstring, fontSize: f32, spacing: f32) -> Vector2 --- // Measure string size for Font
 	GetGlyphIndex      :: proc(font: Font, codepoint: c.int) -> c.int ---     // Get glyph index position in font for a codepoint (unicode character), fallback to '?' if not found
 	GetGlyphInfo       :: proc(font: Font, codepoint: c.int) -> GlyphInfo --- // Get glyph font info data for a codepoint (unicode character), fallback to '?' if not found
 	GetGlyphAtlasRec   :: proc(font: Font, codepoint: c.int) -> Rectangle --- // Get glyph rectangle in font atlas for a codepoint (unicode character), fallback to '?' if not found
@@ -1377,7 +1377,7 @@ foreign lib {
 	// WARNING 1: Most of these functions use internal static buffers, it's recommended to store returned data on user-side for re-use
 	// WARNING 2: Some strings allocate memory internally for the returned strings, those strings must be free by user using MemFree()
 	TextCopy      :: proc(dst: cstring, src: cstring) -> c.int ---                         // Copy one string to another, returns bytes copied
-	TextIsEqual   :: proc(text1: cstring, text2: cstring) -> c.bool ---                    // Check if two text string are equal
+	TextIsEqual   :: proc(text1: cstring, text2: cstring) -> bool ---                      // Check if two text string are equal
 	TextLength    :: proc(text: cstring) -> c.uint ---                                     // Get text length, checks for '\0' ending
 	TextFormat    :: proc(text: cstring) -> cstring ---                                    // Text formatting with variables (sprintf() style)
 	TextSubtext   :: proc(text: cstring, position: c.int, length: c.int) -> cstring ---    // Get a piece of a text string
@@ -1393,78 +1393,78 @@ foreign lib {
 	TextToSnake   :: proc(text: cstring) -> cstring ---                                    // Get Snake case notation version of provided string
 	TextToCamel   :: proc(text: cstring) -> cstring ---                                    // Get Camel case notation version of provided string
 	TextToInteger :: proc(text: cstring) -> c.int ---                                      // Get integer value from text
-	TextToFloat   :: proc(text: cstring) -> c.float ---                                    // Get float value from text
+	TextToFloat   :: proc(text: cstring) -> f32 ---                                        // Get float value from text
 
 	// Basic geometric 3D shapes drawing functions
 	DrawLine3D          :: proc(startPos: Vector3, endPos: Vector3, color: Color) ---    // Draw a line in 3D world space
 	DrawPoint3D         :: proc(position: Vector3, color: Color) ---                     // Draw a point in 3D space, actually a small line
-	DrawCircle3D        :: proc(center: Vector3, radius: c.float, rotationAxis: Vector3, rotationAngle: c.float, color: Color) --- // Draw a circle in 3D world space
+	DrawCircle3D        :: proc(center: Vector3, radius: f32, rotationAxis: Vector3, rotationAngle: f32, color: Color) --- // Draw a circle in 3D world space
 	DrawTriangle3D      :: proc(v1: Vector3, v2: Vector3, v3: Vector3, color: Color) --- // Draw a color-filled triangle (vertex in counter-clockwise order!)
 	DrawTriangleStrip3D :: proc(points: ^Vector3, pointCount: c.int, color: Color) ---   // Draw a triangle strip defined by points
-	DrawCube            :: proc(position: Vector3, width: c.float, height: c.float, length: c.float, color: Color) --- // Draw cube
+	DrawCube            :: proc(position: Vector3, width: f32, height: f32, length: f32, color: Color) --- // Draw cube
 	DrawCubeV           :: proc(position: Vector3, size: Vector3, color: Color) ---      // Draw cube (Vector version)
-	DrawCubeWires       :: proc(position: Vector3, width: c.float, height: c.float, length: c.float, color: Color) --- // Draw cube wires
+	DrawCubeWires       :: proc(position: Vector3, width: f32, height: f32, length: f32, color: Color) --- // Draw cube wires
 	DrawCubeWiresV      :: proc(position: Vector3, size: Vector3, color: Color) ---      // Draw cube wires (Vector version)
-	DrawSphere          :: proc(centerPos: Vector3, radius: c.float, color: Color) ---   // Draw sphere
-	DrawSphereEx        :: proc(centerPos: Vector3, radius: c.float, rings: c.int, slices: c.int, color: Color) --- // Draw sphere with extended parameters
-	DrawSphereWires     :: proc(centerPos: Vector3, radius: c.float, rings: c.int, slices: c.int, color: Color) --- // Draw sphere wires
-	DrawCylinder        :: proc(position: Vector3, radiusTop: c.float, radiusBottom: c.float, height: c.float, slices: c.int, color: Color) --- // Draw a cylinder/cone
-	DrawCylinderEx      :: proc(startPos: Vector3, endPos: Vector3, startRadius: c.float, endRadius: c.float, sides: c.int, color: Color) --- // Draw a cylinder with base at startPos and top at endPos
-	DrawCylinderWires   :: proc(position: Vector3, radiusTop: c.float, radiusBottom: c.float, height: c.float, slices: c.int, color: Color) --- // Draw a cylinder/cone wires
-	DrawCylinderWiresEx :: proc(startPos: Vector3, endPos: Vector3, startRadius: c.float, endRadius: c.float, sides: c.int, color: Color) --- // Draw a cylinder wires with base at startPos and top at endPos
-	DrawCapsule         :: proc(startPos: Vector3, endPos: Vector3, radius: c.float, slices: c.int, rings: c.int, color: Color) --- // Draw a capsule with the center of its sphere caps at startPos and endPos
-	DrawCapsuleWires    :: proc(startPos: Vector3, endPos: Vector3, radius: c.float, slices: c.int, rings: c.int, color: Color) --- // Draw capsule wireframe with the center of its sphere caps at startPos and endPos
+	DrawSphere          :: proc(centerPos: Vector3, radius: f32, color: Color) ---       // Draw sphere
+	DrawSphereEx        :: proc(centerPos: Vector3, radius: f32, rings: c.int, slices: c.int, color: Color) --- // Draw sphere with extended parameters
+	DrawSphereWires     :: proc(centerPos: Vector3, radius: f32, rings: c.int, slices: c.int, color: Color) --- // Draw sphere wires
+	DrawCylinder        :: proc(position: Vector3, radiusTop: f32, radiusBottom: f32, height: f32, slices: c.int, color: Color) --- // Draw a cylinder/cone
+	DrawCylinderEx      :: proc(startPos: Vector3, endPos: Vector3, startRadius: f32, endRadius: f32, sides: c.int, color: Color) --- // Draw a cylinder with base at startPos and top at endPos
+	DrawCylinderWires   :: proc(position: Vector3, radiusTop: f32, radiusBottom: f32, height: f32, slices: c.int, color: Color) --- // Draw a cylinder/cone wires
+	DrawCylinderWiresEx :: proc(startPos: Vector3, endPos: Vector3, startRadius: f32, endRadius: f32, sides: c.int, color: Color) --- // Draw a cylinder wires with base at startPos and top at endPos
+	DrawCapsule         :: proc(startPos: Vector3, endPos: Vector3, radius: f32, slices: c.int, rings: c.int, color: Color) --- // Draw a capsule with the center of its sphere caps at startPos and endPos
+	DrawCapsuleWires    :: proc(startPos: Vector3, endPos: Vector3, radius: f32, slices: c.int, rings: c.int, color: Color) --- // Draw capsule wireframe with the center of its sphere caps at startPos and endPos
 	DrawPlane           :: proc(centerPos: Vector3, size: Vector2, color: Color) ---     // Draw a plane XZ
 	DrawRay             :: proc(ray: Ray, color: Color) ---                              // Draw a ray line
-	DrawGrid            :: proc(slices: c.int, spacing: c.float) ---                     // Draw a grid (centered at (0, 0, 0))
+	DrawGrid            :: proc(slices: c.int, spacing: f32) ---                         // Draw a grid (centered at (0, 0, 0))
 
 	// Model management functions
 	LoadModel           :: proc(fileName: cstring) -> Model ---  // Load model from files (meshes and materials)
 	LoadModelFromMesh   :: proc(mesh: Mesh) -> Model ---         // Load model from generated mesh (default material)
-	IsModelValid        :: proc(model: Model) -> c.bool ---      // Check if a model is valid (loaded in GPU, VAO/VBOs)
+	IsModelValid        :: proc(model: Model) -> bool ---        // Check if a model is valid (loaded in GPU, VAO/VBOs)
 	UnloadModel         :: proc(model: Model) ---                // Unload model (including meshes) from memory (RAM and/or VRAM)
 	GetModelBoundingBox :: proc(model: Model) -> BoundingBox --- // Compute model bounding box limits (considers all meshes)
 
 	// Model drawing functions
-	DrawModel         :: proc(model: Model, position: Vector3, scale: c.float, tint: Color) --- // Draw a model (with texture if set)
-	DrawModelEx       :: proc(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: c.float, scale: Vector3, tint: Color) --- // Draw a model with extended parameters
-	DrawModelWires    :: proc(model: Model, position: Vector3, scale: c.float, tint: Color) --- // Draw a model wires (with texture if set)
-	DrawModelWiresEx  :: proc(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: c.float, scale: Vector3, tint: Color) --- // Draw a model wires (with texture if set) with extended parameters
-	DrawModelPoints   :: proc(model: Model, position: Vector3, scale: c.float, tint: Color) --- // Draw a model as points
-	DrawModelPointsEx :: proc(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: c.float, scale: Vector3, tint: Color) --- // Draw a model as points with extended parameters
-	DrawBoundingBox   :: proc(box: BoundingBox, color: Color) --- // Draw bounding box (wires)
-	DrawBillboard     :: proc(camera: Camera, texture: Texture2D, position: Vector3, scale: c.float, tint: Color) --- // Draw a billboard texture
+	DrawModel         :: proc(model: Model, position: Vector3, scale: f32, tint: Color) --- // Draw a model (with texture if set)
+	DrawModelEx       :: proc(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: f32, scale: Vector3, tint: Color) --- // Draw a model with extended parameters
+	DrawModelWires    :: proc(model: Model, position: Vector3, scale: f32, tint: Color) --- // Draw a model wires (with texture if set)
+	DrawModelWiresEx  :: proc(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: f32, scale: Vector3, tint: Color) --- // Draw a model wires (with texture if set) with extended parameters
+	DrawModelPoints   :: proc(model: Model, position: Vector3, scale: f32, tint: Color) --- // Draw a model as points
+	DrawModelPointsEx :: proc(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: f32, scale: Vector3, tint: Color) --- // Draw a model as points with extended parameters
+	DrawBoundingBox   :: proc(box: BoundingBox, color: Color) ---                           // Draw bounding box (wires)
+	DrawBillboard     :: proc(camera: Camera, texture: Texture2D, position: Vector3, scale: f32, tint: Color) --- // Draw a billboard texture
 	DrawBillboardRec  :: proc(camera: Camera, texture: Texture2D, source: Rectangle, position: Vector3, size: Vector2, tint: Color) --- // Draw a billboard texture defined by source
-	DrawBillboardPro  :: proc(camera: Camera, texture: Texture2D, source: Rectangle, position: Vector3, up: Vector3, size: Vector2, origin: Vector2, rotation: c.float, tint: Color) --- // Draw a billboard texture defined by source and rotation
+	DrawBillboardPro  :: proc(camera: Camera, texture: Texture2D, source: Rectangle, position: Vector3, up: Vector3, size: Vector2, origin: Vector2, rotation: f32, tint: Color) --- // Draw a billboard texture defined by source and rotation
 
 	// Mesh management functions
-	UploadMesh         :: proc(mesh: ^Mesh, _dynamic: c.bool) ---                     // Upload mesh vertex data in GPU and provide VAO/VBO ids
+	UploadMesh         :: proc(mesh: ^Mesh, _dynamic: bool) ---                       // Upload mesh vertex data in GPU and provide VAO/VBO ids
 	UpdateMeshBuffer   :: proc(mesh: Mesh, index: c.int, data: rawptr, dataSize: c.int, offset: c.int) --- // Update mesh vertex data in GPU for a specific buffer index
 	UnloadMesh         :: proc(mesh: Mesh) ---                                        // Unload mesh data from CPU and GPU
 	DrawMesh           :: proc(mesh: Mesh, material: Material, transform: Matrix) --- // Draw a 3d mesh with material and transform
 	DrawMeshInstanced  :: proc(mesh: Mesh, material: Material, transforms: ^Matrix, instances: c.int) --- // Draw multiple mesh instances with material and different transforms
 	GetMeshBoundingBox :: proc(mesh: Mesh) -> BoundingBox ---                         // Compute mesh bounding box limits
 	GenMeshTangents    :: proc(mesh: ^Mesh) ---                                       // Compute mesh tangents
-	ExportMesh         :: proc(mesh: Mesh, fileName: cstring) -> c.bool ---           // Export mesh data to file, returns true on success
-	ExportMeshAsCode   :: proc(mesh: Mesh, fileName: cstring) -> c.bool ---           // Export mesh as code file (.h) defining multiple arrays of vertex attributes
+	ExportMesh         :: proc(mesh: Mesh, fileName: cstring) -> bool ---             // Export mesh data to file, returns true on success
+	ExportMeshAsCode   :: proc(mesh: Mesh, fileName: cstring) -> bool ---             // Export mesh as code file (.h) defining multiple arrays of vertex attributes
 
 	// Mesh generation functions
-	GenMeshPoly       :: proc(sides: c.int, radius: c.float) -> Mesh ---                    // Generate polygonal mesh
-	GenMeshPlane      :: proc(width: c.float, length: c.float, resX: c.int, resZ: c.int) -> Mesh --- // Generate plane mesh (with subdivisions)
-	GenMeshCube       :: proc(width: c.float, height: c.float, length: c.float) -> Mesh --- // Generate cuboid mesh
-	GenMeshSphere     :: proc(radius: c.float, rings: c.int, slices: c.int) -> Mesh ---     // Generate sphere mesh (standard sphere)
-	GenMeshHemiSphere :: proc(radius: c.float, rings: c.int, slices: c.int) -> Mesh ---     // Generate half-sphere mesh (no bottom cap)
-	GenMeshCylinder   :: proc(radius: c.float, height: c.float, slices: c.int) -> Mesh ---  // Generate cylinder mesh
-	GenMeshCone       :: proc(radius: c.float, height: c.float, slices: c.int) -> Mesh ---  // Generate cone/pyramid mesh
-	GenMeshTorus      :: proc(radius: c.float, size: c.float, radSeg: c.int, sides: c.int) -> Mesh --- // Generate torus mesh
-	GenMeshKnot       :: proc(radius: c.float, size: c.float, radSeg: c.int, sides: c.int) -> Mesh --- // Generate trefoil knot mesh
-	GenMeshHeightmap  :: proc(heightmap: Image, size: Vector3) -> Mesh ---                  // Generate heightmap mesh from image data
-	GenMeshCubicmap   :: proc(cubicmap: Image, cubeSize: Vector3) -> Mesh ---               // Generate cubes-based map mesh from image data
+	GenMeshPoly       :: proc(sides: c.int, radius: f32) -> Mesh ---                         // Generate polygonal mesh
+	GenMeshPlane      :: proc(width: f32, length: f32, resX: c.int, resZ: c.int) -> Mesh --- // Generate plane mesh (with subdivisions)
+	GenMeshCube       :: proc(width: f32, height: f32, length: f32) -> Mesh ---              // Generate cuboid mesh
+	GenMeshSphere     :: proc(radius: f32, rings: c.int, slices: c.int) -> Mesh ---          // Generate sphere mesh (standard sphere)
+	GenMeshHemiSphere :: proc(radius: f32, rings: c.int, slices: c.int) -> Mesh ---          // Generate half-sphere mesh (no bottom cap)
+	GenMeshCylinder   :: proc(radius: f32, height: f32, slices: c.int) -> Mesh ---           // Generate cylinder mesh
+	GenMeshCone       :: proc(radius: f32, height: f32, slices: c.int) -> Mesh ---           // Generate cone/pyramid mesh
+	GenMeshTorus      :: proc(radius: f32, size: f32, radSeg: c.int, sides: c.int) -> Mesh --- // Generate torus mesh
+	GenMeshKnot       :: proc(radius: f32, size: f32, radSeg: c.int, sides: c.int) -> Mesh --- // Generate trefoil knot mesh
+	GenMeshHeightmap  :: proc(heightmap: Image, size: Vector3) -> Mesh ---                   // Generate heightmap mesh from image data
+	GenMeshCubicmap   :: proc(cubicmap: Image, cubeSize: Vector3) -> Mesh ---                // Generate cubes-based map mesh from image data
 
 	// Material loading/unloading functions
 	LoadMaterials        :: proc(fileName: cstring, materialCount: ^c.int) -> ^Material ---   // Load materials from model file
 	LoadMaterialDefault  :: proc() -> Material ---                                            // Load default material (Supports: DIFFUSE, SPECULAR, NORMAL maps)
-	IsMaterialValid      :: proc(material: Material) -> c.bool ---                            // Check if a material is valid (shader assigned, map textures loaded in GPU)
+	IsMaterialValid      :: proc(material: Material) -> bool ---                              // Check if a material is valid (shader assigned, map textures loaded in GPU)
 	UnloadMaterial       :: proc(material: Material) ---                                      // Unload material from GPU memory (VRAM)
 	SetMaterialTexture   :: proc(material: ^Material, mapType: c.int, texture: Texture2D) --- // Set texture for a material map type (MATERIAL_MAP_DIFFUSE, MATERIAL_MAP_SPECULAR...)
 	SetModelMeshMaterial :: proc(model: ^Model, meshId: c.int, materialId: c.int) ---         // Set material for a mesh
@@ -1475,87 +1475,87 @@ foreign lib {
 	UpdateModelAnimationBones :: proc(model: Model, anim: ModelAnimation, frame: c.int) --- // Update model animation mesh bone matrices (GPU skinning)
 	UnloadModelAnimation      :: proc(anim: ModelAnimation) ---                             // Unload animation data
 	UnloadModelAnimations     :: proc(animations: ^ModelAnimation, animCount: c.int) ---    // Unload animation array data
-	IsModelAnimationValid     :: proc(model: Model, anim: ModelAnimation) -> c.bool ---     // Check model animation skeleton match
+	IsModelAnimationValid     :: proc(model: Model, anim: ModelAnimation) -> bool ---       // Check model animation skeleton match
 
 	// Collision detection functions
-	CheckCollisionSpheres   :: proc(center1: Vector3, radius1: c.float, center2: Vector3, radius2: c.float) -> c.bool --- // Check collision between two spheres
-	CheckCollisionBoxes     :: proc(box1: BoundingBox, box2: BoundingBox) -> c.bool --- // Check collision between two bounding boxes
-	CheckCollisionBoxSphere :: proc(box: BoundingBox, center: Vector3, radius: c.float) -> c.bool --- // Check collision between box and sphere
-	GetRayCollisionSphere   :: proc(ray: Ray, center: Vector3, radius: c.float) -> RayCollision --- // Get collision info between ray and sphere
-	GetRayCollisionBox      :: proc(ray: Ray, box: BoundingBox) -> RayCollision ---     // Get collision info between ray and box
+	CheckCollisionSpheres   :: proc(center1: Vector3, radius1: f32, center2: Vector3, radius2: f32) -> bool --- // Check collision between two spheres
+	CheckCollisionBoxes     :: proc(box1: BoundingBox, box2: BoundingBox) -> bool --- // Check collision between two bounding boxes
+	CheckCollisionBoxSphere :: proc(box: BoundingBox, center: Vector3, radius: f32) -> bool --- // Check collision between box and sphere
+	GetRayCollisionSphere   :: proc(ray: Ray, center: Vector3, radius: f32) -> RayCollision --- // Get collision info between ray and sphere
+	GetRayCollisionBox      :: proc(ray: Ray, box: BoundingBox) -> RayCollision ---   // Get collision info between ray and box
 	GetRayCollisionMesh     :: proc(ray: Ray, mesh: Mesh, transform: Matrix) -> RayCollision --- // Get collision info between ray and mesh
 	GetRayCollisionTriangle :: proc(ray: Ray, p1: Vector3, p2: Vector3, p3: Vector3) -> RayCollision --- // Get collision info between ray and triangle
 	GetRayCollisionQuad     :: proc(ray: Ray, p1: Vector3, p2: Vector3, p3: Vector3, p4: Vector3) -> RayCollision --- // Get collision info between ray and quad
 
 	// Audio device management functions
-	InitAudioDevice    :: proc() ---                // Initialize audio device and context
-	CloseAudioDevice   :: proc() ---                // Close the audio device and context
-	IsAudioDeviceReady :: proc() -> c.bool ---      // Check if audio device has been initialized successfully
-	SetMasterVolume    :: proc(volume: c.float) --- // Set master volume (listener)
-	GetMasterVolume    :: proc() -> c.float ---     // Get master volume (listener)
+	InitAudioDevice    :: proc() ---            // Initialize audio device and context
+	CloseAudioDevice   :: proc() ---            // Close the audio device and context
+	IsAudioDeviceReady :: proc() -> bool ---    // Check if audio device has been initialized successfully
+	SetMasterVolume    :: proc(volume: f32) --- // Set master volume (listener)
+	GetMasterVolume    :: proc() -> f32 ---     // Get master volume (listener)
 
 	// Wave/Sound loading/unloading functions
 	LoadWave           :: proc(fileName: cstring) -> Wave ---                      // Load wave data from file
 	LoadWaveFromMemory :: proc(fileType: cstring, fileData: ^c.uchar, dataSize: c.int) -> Wave --- // Load wave from memory buffer, fileType refers to extension: i.e. '.wav'
-	IsWaveValid        :: proc(wave: Wave) -> c.bool ---                           // Checks if wave data is valid (data loaded and parameters)
+	IsWaveValid        :: proc(wave: Wave) -> bool ---                             // Checks if wave data is valid (data loaded and parameters)
 	LoadSound          :: proc(fileName: cstring) -> Sound ---                     // Load sound from file
 	LoadSoundFromWave  :: proc(wave: Wave) -> Sound ---                            // Load sound from wave data
 	LoadSoundAlias     :: proc(source: Sound) -> Sound ---                         // Create a new sound that shares the same sample data as the source sound, does not own the sound data
-	IsSoundValid       :: proc(sound: Sound) -> c.bool ---                         // Checks if a sound is valid (data loaded and buffers initialized)
+	IsSoundValid       :: proc(sound: Sound) -> bool ---                           // Checks if a sound is valid (data loaded and buffers initialized)
 	UpdateSound        :: proc(sound: Sound, data: rawptr, sampleCount: c.int) --- // Update sound buffer with new data
 	UnloadWave         :: proc(wave: Wave) ---                                     // Unload wave data
 	UnloadSound        :: proc(sound: Sound) ---                                   // Unload sound
 	UnloadSoundAlias   :: proc(alias: Sound) ---                                   // Unload a sound alias (does not deallocate sample data)
-	ExportWave         :: proc(wave: Wave, fileName: cstring) -> c.bool ---        // Export wave data to file, returns true on success
-	ExportWaveAsCode   :: proc(wave: Wave, fileName: cstring) -> c.bool ---        // Export wave sample data to code (.h), returns true on success
+	ExportWave         :: proc(wave: Wave, fileName: cstring) -> bool ---          // Export wave data to file, returns true on success
+	ExportWaveAsCode   :: proc(wave: Wave, fileName: cstring) -> bool ---          // Export wave sample data to code (.h), returns true on success
 
 	// Wave/Sound management functions
 	PlaySound         :: proc(sound: Sound) ---                                     // Play a sound
 	StopSound         :: proc(sound: Sound) ---                                     // Stop playing a sound
 	PauseSound        :: proc(sound: Sound) ---                                     // Pause a sound
 	ResumeSound       :: proc(sound: Sound) ---                                     // Resume a paused sound
-	IsSoundPlaying    :: proc(sound: Sound) -> c.bool ---                           // Check if a sound is currently playing
-	SetSoundVolume    :: proc(sound: Sound, volume: c.float) ---                    // Set volume for a sound (1.0 is max level)
-	SetSoundPitch     :: proc(sound: Sound, pitch: c.float) ---                     // Set pitch for a sound (1.0 is base level)
-	SetSoundPan       :: proc(sound: Sound, pan: c.float) ---                       // Set pan for a sound (0.5 is center)
+	IsSoundPlaying    :: proc(sound: Sound) -> bool ---                             // Check if a sound is currently playing
+	SetSoundVolume    :: proc(sound: Sound, volume: f32) ---                        // Set volume for a sound (1.0 is max level)
+	SetSoundPitch     :: proc(sound: Sound, pitch: f32) ---                         // Set pitch for a sound (1.0 is base level)
+	SetSoundPan       :: proc(sound: Sound, pan: f32) ---                           // Set pan for a sound (0.5 is center)
 	WaveCopy          :: proc(wave: Wave) -> Wave ---                               // Copy a wave to a new wave
 	WaveCrop          :: proc(wave: ^Wave, initFrame: c.int, finalFrame: c.int) --- // Crop a wave to defined frames range
 	WaveFormat        :: proc(wave: ^Wave, sampleRate: c.int, sampleSize: c.int, channels: c.int) --- // Convert wave data to desired format
-	LoadWaveSamples   :: proc(wave: Wave) -> ^c.float ---                           // Load samples data from wave as a 32bit float data array
-	UnloadWaveSamples :: proc(samples: ^c.float) ---                                // Unload samples data loaded with LoadWaveSamples()
+	LoadWaveSamples   :: proc(wave: Wave) -> ^f32 ---                               // Load samples data from wave as a 32bit float data array
+	UnloadWaveSamples :: proc(samples: ^f32) ---                                    // Unload samples data loaded with LoadWaveSamples()
 
 	// Music management functions
-	LoadMusicStream           :: proc(fileName: cstring) -> Music ---      // Load music stream from file
+	LoadMusicStream           :: proc(fileName: cstring) -> Music ---  // Load music stream from file
 	LoadMusicStreamFromMemory :: proc(fileType: cstring, data: ^c.uchar, dataSize: c.int) -> Music --- // Load music stream from data
-	IsMusicValid              :: proc(music: Music) -> c.bool ---          // Checks if a music stream is valid (context and buffers initialized)
-	UnloadMusicStream         :: proc(music: Music) ---                    // Unload music stream
-	PlayMusicStream           :: proc(music: Music) ---                    // Start music playing
-	IsMusicStreamPlaying      :: proc(music: Music) -> c.bool ---          // Check if music is playing
-	UpdateMusicStream         :: proc(music: Music) ---                    // Updates buffers for music streaming
-	StopMusicStream           :: proc(music: Music) ---                    // Stop music playing
-	PauseMusicStream          :: proc(music: Music) ---                    // Pause music playing
-	ResumeMusicStream         :: proc(music: Music) ---                    // Resume playing paused music
-	SeekMusicStream           :: proc(music: Music, position: c.float) --- // Seek music to a position (in seconds)
-	SetMusicVolume            :: proc(music: Music, volume: c.float) ---   // Set volume for music (1.0 is max level)
-	SetMusicPitch             :: proc(music: Music, pitch: c.float) ---    // Set pitch for a music (1.0 is base level)
-	SetMusicPan               :: proc(music: Music, pan: c.float) ---      // Set pan for a music (0.5 is center)
-	GetMusicTimeLength        :: proc(music: Music) -> c.float ---         // Get music time length (in seconds)
-	GetMusicTimePlayed        :: proc(music: Music) -> c.float ---         // Get current music time played (in seconds)
+	IsMusicValid              :: proc(music: Music) -> bool ---        // Checks if a music stream is valid (context and buffers initialized)
+	UnloadMusicStream         :: proc(music: Music) ---                // Unload music stream
+	PlayMusicStream           :: proc(music: Music) ---                // Start music playing
+	IsMusicStreamPlaying      :: proc(music: Music) -> bool ---        // Check if music is playing
+	UpdateMusicStream         :: proc(music: Music) ---                // Updates buffers for music streaming
+	StopMusicStream           :: proc(music: Music) ---                // Stop music playing
+	PauseMusicStream          :: proc(music: Music) ---                // Pause music playing
+	ResumeMusicStream         :: proc(music: Music) ---                // Resume playing paused music
+	SeekMusicStream           :: proc(music: Music, position: f32) --- // Seek music to a position (in seconds)
+	SetMusicVolume            :: proc(music: Music, volume: f32) ---   // Set volume for music (1.0 is max level)
+	SetMusicPitch             :: proc(music: Music, pitch: f32) ---    // Set pitch for a music (1.0 is base level)
+	SetMusicPan               :: proc(music: Music, pan: f32) ---      // Set pan for a music (0.5 is center)
+	GetMusicTimeLength        :: proc(music: Music) -> f32 ---         // Get music time length (in seconds)
+	GetMusicTimePlayed        :: proc(music: Music) -> f32 ---         // Get current music time played (in seconds)
 
 	// AudioStream management functions
 	LoadAudioStream                 :: proc(sampleRate: c.uint, sampleSize: c.uint, channels: c.uint) -> AudioStream --- // Load audio stream (to stream raw audio pcm data)
-	IsAudioStreamValid              :: proc(stream: AudioStream) -> c.bool ---                // Checks if an audio stream is valid (buffers initialized)
+	IsAudioStreamValid              :: proc(stream: AudioStream) -> bool ---                  // Checks if an audio stream is valid (buffers initialized)
 	UnloadAudioStream               :: proc(stream: AudioStream) ---                          // Unload audio stream and free memory
 	UpdateAudioStream               :: proc(stream: AudioStream, data: rawptr, frameCount: c.int) --- // Update audio stream buffers with data
-	IsAudioStreamProcessed          :: proc(stream: AudioStream) -> c.bool ---                // Check if any audio stream buffers requires refill
+	IsAudioStreamProcessed          :: proc(stream: AudioStream) -> bool ---                  // Check if any audio stream buffers requires refill
 	PlayAudioStream                 :: proc(stream: AudioStream) ---                          // Play audio stream
 	PauseAudioStream                :: proc(stream: AudioStream) ---                          // Pause audio stream
 	ResumeAudioStream               :: proc(stream: AudioStream) ---                          // Resume audio stream
-	IsAudioStreamPlaying            :: proc(stream: AudioStream) -> c.bool ---                // Check if audio stream is playing
+	IsAudioStreamPlaying            :: proc(stream: AudioStream) -> bool ---                  // Check if audio stream is playing
 	StopAudioStream                 :: proc(stream: AudioStream) ---                          // Stop audio stream
-	SetAudioStreamVolume            :: proc(stream: AudioStream, volume: c.float) ---         // Set volume for audio stream (1.0 is max level)
-	SetAudioStreamPitch             :: proc(stream: AudioStream, pitch: c.float) ---          // Set pitch for audio stream (1.0 is base level)
-	SetAudioStreamPan               :: proc(stream: AudioStream, pan: c.float) ---            // Set pan for audio stream (0.5 is centered)
+	SetAudioStreamVolume            :: proc(stream: AudioStream, volume: f32) ---             // Set volume for audio stream (1.0 is max level)
+	SetAudioStreamPitch             :: proc(stream: AudioStream, pitch: f32) ---              // Set pitch for audio stream (1.0 is base level)
+	SetAudioStreamPan               :: proc(stream: AudioStream, pan: f32) ---                // Set pan for audio stream (0.5 is centered)
 	SetAudioStreamBufferSizeDefault :: proc(size: c.int) ---                                  // Default size for new audio streams
 	SetAudioStreamCallback          :: proc(stream: AudioStream, callback: AudioCallback) --- // Audio thread callback to request new data
 	AttachAudioStreamProcessor      :: proc(stream: AudioStream, processor: AudioCallback) --- // Attach audio stream processor to stream, receives the samples as 'float'

--- a/examples/raylib/raylib/raylib.odin
+++ b/examples/raylib/raylib/raylib.odin
@@ -157,27 +157,27 @@ Color :: distinct [4]u8
 
 // Rectangle, 4 components
 Rectangle :: struct {
-	x:      f32, // Rectangle top-left corner position x
-	y:      f32, // Rectangle top-left corner position y
-	width:  f32, // Rectangle width
-	height: f32, // Rectangle height
+	x:      c.float, // Rectangle top-left corner position x
+	y:      c.float, // Rectangle top-left corner position y
+	width:  c.float, // Rectangle width
+	height: c.float, // Rectangle height
 }
 
 // Image, pixel data stored in CPU memory (RAM)
 Image :: struct {
 	data:    rawptr,      // Image raw data
-	width:   i32,         // Image base width
-	height:  i32,         // Image base height
-	mipmaps: i32,         // Mipmap levels, 1 by default
+	width:   c.int,       // Image base width
+	height:  c.int,       // Image base height
+	mipmaps: c.int,       // Mipmap levels, 1 by default
 	format:  PixelFormat, // Data format (PixelFormat type)
 }
 
 // Texture, tex data stored in GPU memory (VRAM)
 Texture :: struct {
-	id:      u32,         // OpenGL texture id
-	width:   i32,         // Texture base width
-	height:  i32,         // Texture base height
-	mipmaps: i32,         // Mipmap levels, 1 by default
+	id:      c.uint,      // OpenGL texture id
+	width:   c.int,       // Texture base width
+	height:  c.int,       // Texture base height
+	mipmaps: c.int,       // Mipmap levels, 1 by default
 	format:  PixelFormat, // Data format (PixelFormat type)
 }
 
@@ -189,7 +189,7 @@ TextureCubemap :: Texture
 
 // RenderTexture, fbo for texture rendering
 RenderTexture :: struct {
-	id:      u32,     // OpenGL framebuffer object id
+	id:      c.uint,  // OpenGL framebuffer object id
 	texture: Texture, // Color buffer attachment texture
 	depth:   Texture, // Depth buffer attachment texture
 }
@@ -200,27 +200,27 @@ RenderTexture2D :: RenderTexture
 // NPatchInfo, n-patch layout info
 NPatchInfo :: struct {
 	source: Rectangle,    // Texture source rectangle
-	left:   i32,          // Left border offset
-	top:    i32,          // Top border offset
-	right:  i32,          // Right border offset
-	bottom: i32,          // Bottom border offset
+	left:   c.int,        // Left border offset
+	top:    c.int,        // Top border offset
+	right:  c.int,        // Right border offset
+	bottom: c.int,        // Bottom border offset
 	layout: NPatchLayout, // Layout of the n-patch: 3x3, 1x3 or 3x1
 }
 
 // GlyphInfo, font characters glyphs info
 GlyphInfo :: struct {
 	value:    rune,  // Character value (Unicode)
-	offsetX:  i32,   // Character offset X when drawing
-	offsetY:  i32,   // Character offset Y when drawing
-	advanceX: i32,   // Character advance position X
+	offsetX:  c.int, // Character offset X when drawing
+	offsetY:  c.int, // Character offset Y when drawing
+	advanceX: c.int, // Character advance position X
 	image:    Image, // Character image data
 }
 
 // Font, font texture and GlyphInfo array data
 Font :: struct {
-	baseSize:     i32,        // Base size (default chars height)
-	glyphCount:   i32,        // Number of glyph characters
-	glyphPadding: i32,        // Padding around the glyph characters
+	baseSize:     c.int,      // Base size (default chars height)
+	glyphCount:   c.int,      // Number of glyph characters
+	glyphPadding: c.int,      // Padding around the glyph characters
 	texture:      Texture2D,  // Texture atlas containing the glyphs
 	recs:         ^Rectangle, // Rectangles in texture for the glyphs
 	glyphs:       ^GlyphInfo, // Glyphs info data
@@ -231,8 +231,8 @@ Camera3D :: struct {
 	position:   Vector3, // Camera position
 	target:     Vector3, // Camera target it looks-at
 	up:         Vector3, // Camera up vector (rotation over its axis)
-	fovy:       f32,     // Camera field-of-view aperture in Y (degrees) in perspective, used as near plane width in orthographic
-	projection: i32,     // Camera projection: CAMERA_PERSPECTIVE or CAMERA_ORTHOGRAPHIC
+	fovy:       c.float, // Camera field-of-view aperture in Y (degrees) in perspective, used as near plane width in orthographic
+	projection: c.int,   // Camera projection: CAMERA_PERSPECTIVE or CAMERA_ORTHOGRAPHIC
 }
 
 Camera :: Camera3D // Camera type fallback, defaults to Camera3D
@@ -241,49 +241,49 @@ Camera :: Camera3D // Camera type fallback, defaults to Camera3D
 Camera2D :: struct {
 	offset:   Vector2, // Camera offset (displacement from target)
 	target:   Vector2, // Camera target (rotation and zoom origin)
-	rotation: f32,     // Camera rotation in degrees
-	zoom:     f32,     // Camera zoom (scaling), should be 1.0f by default
+	rotation: c.float, // Camera rotation in degrees
+	zoom:     c.float, // Camera zoom (scaling), should be 1.0f by default
 }
 
 // Mesh, vertex data and vao/vbo
 Mesh :: struct {
-	vertexCount:   i32,       // Number of vertices stored in arrays
-	triangleCount: i32,       // Number of triangles stored (indexed or not)
-	vertices:      [^]f32,    // Vertex position (XYZ - 3 components per vertex) (shader-location = 0)
-	texcoords:     [^]f32,    // Vertex texture coordinates (UV - 2 components per vertex) (shader-location = 1)
-	texcoords2:    [^]f32,    // Vertex texture second coordinates (UV - 2 components per vertex) (shader-location = 5)
-	normals:       [^]f32,    // Vertex normals (XYZ - 3 components per vertex) (shader-location = 2)
-	tangents:      [^]f32,    // Vertex tangents (XYZW - 4 components per vertex) (shader-location = 4)
-	colors:        [^]u8,     // Vertex colors (RGBA - 4 components per vertex) (shader-location = 3)
-	indices:       [^]u16,    // Vertex indices (in case vertex data comes indexed)
-	animVertices:  [^]f32,    // Animated vertex positions (after bones transformations)
-	animNormals:   [^]f32,    // Animated normals (after bones transformations)
-	boneIds:       [^]u8,     // Vertex bone ids, max 255 bone ids, up to 4 bones influence by vertex (skinning) (shader-location = 6)
-	boneWeights:   [^]f32,    // Vertex bone weight, up to 4 bones influence by vertex (skinning) (shader-location = 7)
-	boneMatrices:  [^]Matrix, // Bones animated transformation matrices
-	boneCount:     i32,       // Number of bones
-	vaoId:         u32,       // OpenGL Vertex Array Object id
-	vboId:         [^]u32,    // OpenGL Vertex Buffer Objects id (default vertex data)
+	vertexCount:   c.int,       // Number of vertices stored in arrays
+	triangleCount: c.int,       // Number of triangles stored (indexed or not)
+	vertices:      [^]c.float,  // Vertex position (XYZ - 3 components per vertex) (shader-location = 0)
+	texcoords:     [^]c.float,  // Vertex texture coordinates (UV - 2 components per vertex) (shader-location = 1)
+	texcoords2:    [^]c.float,  // Vertex texture second coordinates (UV - 2 components per vertex) (shader-location = 5)
+	normals:       [^]c.float,  // Vertex normals (XYZ - 3 components per vertex) (shader-location = 2)
+	tangents:      [^]c.float,  // Vertex tangents (XYZW - 4 components per vertex) (shader-location = 4)
+	colors:        [^]c.uchar,  // Vertex colors (RGBA - 4 components per vertex) (shader-location = 3)
+	indices:       [^]c.ushort, // Vertex indices (in case vertex data comes indexed)
+	animVertices:  [^]c.float,  // Animated vertex positions (after bones transformations)
+	animNormals:   [^]c.float,  // Animated normals (after bones transformations)
+	boneIds:       [^]c.uchar,  // Vertex bone ids, max 255 bone ids, up to 4 bones influence by vertex (skinning) (shader-location = 6)
+	boneWeights:   [^]c.float,  // Vertex bone weight, up to 4 bones influence by vertex (skinning) (shader-location = 7)
+	boneMatrices:  [^]Matrix,   // Bones animated transformation matrices
+	boneCount:     c.int,       // Number of bones
+	vaoId:         c.uint,      // OpenGL Vertex Array Object id
+	vboId:         [^]c.uint,   // OpenGL Vertex Buffer Objects id (default vertex data)
 }
 
 // Shader
 Shader :: struct {
-	id:   u32,    // Shader program id
-	locs: [^]i32, // Shader locations array (RL_MAX_SHADER_LOCATIONS)
+	id:   c.uint,   // Shader program id
+	locs: [^]c.int, // Shader locations array (RL_MAX_SHADER_LOCATIONS)
 }
 
 // MaterialMap
 MaterialMap :: struct {
 	texture: Texture2D, // Material map texture
 	color:   Color,     // Material map color
-	value:   f32,       // Material map value
+	value:   c.float,   // Material map value
 }
 
 // Material, includes shader and maps
 Material :: struct {
 	shader: Shader,         // Material shader
 	maps:   [^]MaterialMap, // Material maps array (MAX_MATERIAL_MAPS)
-	params: [4]f32,         // Material generic parameters (if required)
+	params: [4]c.float,     // Material generic parameters (if required)
 }
 
 // Transform, vertex transformation data
@@ -295,30 +295,30 @@ Transform :: struct {
 
 // Bone, skeletal animation bone
 BoneInfo :: struct {
-	name:   [32]u8, // Bone name
-	parent: i32,    // Bone parent
+	name:   [32]c.char, // Bone name
+	parent: c.int,      // Bone parent
 }
 
 // Model, meshes, materials and animation data
 Model :: struct {
 	transform:     Matrix,       // Local transform matrix
-	meshCount:     i32,          // Number of meshes
-	materialCount: i32,          // Number of materials
+	meshCount:     c.int,        // Number of meshes
+	materialCount: c.int,        // Number of materials
 	meshes:        [^]Mesh,      // Meshes array
 	materials:     [^]Material,  // Materials array
-	meshMaterial:  ^i32,         // Mesh material number
-	boneCount:     i32,          // Number of bones
+	meshMaterial:  ^c.int,       // Mesh material number
+	boneCount:     c.int,        // Number of bones
 	bones:         [^]BoneInfo,  // Bones information (skeleton)
 	bindPose:      [^]Transform, // Bones base transformation (pose)
 }
 
 // ModelAnimation
 ModelAnimation :: struct {
-	boneCount:  i32,             // Number of bones
-	frameCount: i32,             // Number of animation frames
+	boneCount:  c.int,           // Number of bones
+	frameCount: c.int,           // Number of animation frames
 	bones:      [^]BoneInfo,     // Bones information (skeleton)
 	framePoses: [^][^]Transform, // Poses array by frame
-	name:       [32]u8,          // Animation name
+	name:       [32]c.char,      // Animation name
 }
 
 // Ray, ray for raycasting
@@ -329,8 +329,8 @@ Ray :: struct {
 
 // RayCollision, ray hit information
 RayCollision :: struct {
-	hit:      bool,    // Did the ray hit something?
-	distance: f32,     // Distance to the nearest hit
+	hit:      c.bool,  // Did the ray hit something?
+	distance: c.float, // Distance to the nearest hit
 	point:    Vector3, // Point of the nearest hit
 	normal:   Vector3, // Surface normal of hit
 }
@@ -343,10 +343,10 @@ BoundingBox :: struct {
 
 // Wave, audio wave data
 Wave :: struct {
-	frameCount: u32,    // Total number of frames (considering channels)
-	sampleRate: u32,    // Frequency (samples per second)
-	sampleSize: u32,    // Bit depth (bits per sample): 8, 16, 32 (24 not supported)
-	channels:   u32,    // Number of channels (1-mono, 2-stereo, ...)
+	frameCount: c.uint, // Total number of frames (considering channels)
+	sampleRate: c.uint, // Frequency (samples per second)
+	sampleSize: c.uint, // Bit depth (bits per sample): 8, 16, 32 (24 not supported)
+	channels:   c.uint, // Number of channels (1-mono, 2-stereo, ...)
 	data:       rawptr, // Buffer data pointer
 }
 
@@ -354,69 +354,69 @@ Wave :: struct {
 AudioStream :: struct {
 	buffer:     rawptr, // Pointer to internal data used by the audio system
 	processor:  rawptr, // Pointer to internal data processor, useful for audio effects
-	sampleRate: u32,    // Frequency (samples per second)
-	sampleSize: u32,    // Bit depth (bits per sample): 8, 16, 32 (24 not supported)
-	channels:   u32,    // Number of channels (1-mono, 2-stereo, ...)
+	sampleRate: c.uint, // Frequency (samples per second)
+	sampleSize: c.uint, // Bit depth (bits per sample): 8, 16, 32 (24 not supported)
+	channels:   c.uint, // Number of channels (1-mono, 2-stereo, ...)
 }
 
 // Sound
 Sound :: struct {
 	stream:     AudioStream, // Audio stream
-	frameCount: u32,         // Total number of frames (considering channels)
+	frameCount: c.uint,      // Total number of frames (considering channels)
 }
 
 // Music, audio stream, anything longer than ~10 seconds should be streamed
 Music :: struct {
 	stream:     AudioStream, // Audio stream
-	frameCount: u32,         // Total number of frames (considering channels)
-	looping:    bool,        // Music looping enable
-	ctxType:    i32,         // Type of music context (audio filetype)
+	frameCount: c.uint,      // Total number of frames (considering channels)
+	looping:    c.bool,      // Music looping enable
+	ctxType:    c.int,       // Type of music context (audio filetype)
 	ctxData:    rawptr,      // Audio context data, depends on type
 }
 
 // VrDeviceInfo, Head-Mounted-Display device parameters
 VrDeviceInfo :: struct {
-	hResolution:            i32,    // Horizontal resolution in pixels
-	vResolution:            i32,    // Vertical resolution in pixels
-	hScreenSize:            f32,    // Horizontal size in meters
-	vScreenSize:            f32,    // Vertical size in meters
-	eyeToScreenDistance:    f32,    // Distance between eye and display in meters
-	lensSeparationDistance: f32,    // Lens separation distance in meters
-	interpupillaryDistance: f32,    // IPD (distance between pupils) in meters
-	lensDistortionValues:   [4]f32, // Lens distortion constant parameters
-	chromaAbCorrection:     [4]f32, // Chromatic aberration correction parameters
+	hResolution:            c.int,      // Horizontal resolution in pixels
+	vResolution:            c.int,      // Vertical resolution in pixels
+	hScreenSize:            c.float,    // Horizontal size in meters
+	vScreenSize:            c.float,    // Vertical size in meters
+	eyeToScreenDistance:    c.float,    // Distance between eye and display in meters
+	lensSeparationDistance: c.float,    // Lens separation distance in meters
+	interpupillaryDistance: c.float,    // IPD (distance between pupils) in meters
+	lensDistortionValues:   [4]c.float, // Lens distortion constant parameters
+	chromaAbCorrection:     [4]c.float, // Chromatic aberration correction parameters
 }
 
 // VrStereoConfig, VR stereo rendering configuration for simulator
 VrStereoConfig :: struct {
-	projection:        [2]Matrix, // VR projection matrices (per eye)
-	viewOffset:        [2]Matrix, // VR view offset matrices (per eye)
-	leftLensCenter:    [2]f32,    // VR left lens center
-	rightLensCenter:   [2]f32,    // VR right lens center
-	leftScreenCenter:  [2]f32,    // VR left screen center
-	rightScreenCenter: [2]f32,    // VR right screen center
-	scale:             [2]f32,    // VR distortion scale
-	scaleIn:           [2]f32,    // VR distortion scale in
+	projection:        [2]Matrix,  // VR projection matrices (per eye)
+	viewOffset:        [2]Matrix,  // VR view offset matrices (per eye)
+	leftLensCenter:    [2]c.float, // VR left lens center
+	rightLensCenter:   [2]c.float, // VR right lens center
+	leftScreenCenter:  [2]c.float, // VR left screen center
+	rightScreenCenter: [2]c.float, // VR right screen center
+	scale:             [2]c.float, // VR distortion scale
+	scaleIn:           [2]c.float, // VR distortion scale in
 }
 
 // File path list
 FilePathList :: struct {
-	capacity: u32,  // Filepaths max entries
-	count:    u32,  // Filepaths entries count
-	paths:    ^^u8, // Filepaths entries
+	capacity: c.uint,   // Filepaths max entries
+	count:    c.uint,   // Filepaths entries count
+	paths:    ^^c.char, // Filepaths entries
 }
 
 // Automation event
 AutomationEvent :: struct {
-	frame:  u32,    // Event frame
-	type:   u32,    // Event type (AutomationEventType)
-	params: [4]i32, // Event parameters (if required)
+	frame:  c.uint,   // Event frame
+	type:   c.uint,   // Event type (AutomationEventType)
+	params: [4]c.int, // Event parameters (if required)
 }
 
 // Automation event list
 AutomationEventList :: struct {
-	capacity: u32,              // Events max entries (MAX_AUTOMATION_EVENTS)
-	count:    u32,              // Events entries count
+	capacity: c.uint,           // Events max entries (MAX_AUTOMATION_EVENTS)
+	count:    c.uint,           // Events entries count
 	events:   ^AutomationEvent, // Events entries
 }
 
@@ -837,15 +837,15 @@ NPatchLayout :: enum c.int {
 
 // Callbacks to hook some internal functions
 // WARNING: These callbacks are intended for advanced users
-TraceLogCallback :: proc "c" (i32, cstring, ^c.va_list) // Logging: Redirect trace log messages
+TraceLogCallback :: proc "c" (c.int, cstring, ^c.va_list) // Logging: Redirect trace log messages
 
-LoadFileDataCallback :: proc "c" (cstring, ^i32) -> ^u8 // FileIO: Load binary data
+LoadFileDataCallback :: proc "c" (cstring, ^c.int) -> ^c.uchar // FileIO: Load binary data
 
-SaveFileDataCallback :: proc "c" (cstring, rawptr, i32) -> bool // FileIO: Save binary data
+SaveFileDataCallback :: proc "c" (cstring, rawptr, c.int) -> c.bool // FileIO: Save binary data
 
 LoadFileTextCallback :: proc "c" (cstring) -> cstring // FileIO: Load text data
 
-SaveFileTextCallback :: proc "c" (cstring, cstring) -> bool // FileIO: Save text data
+SaveFileTextCallback :: proc "c" (cstring, cstring) -> c.bool // FileIO: Save text data
 
 // Screen-space-related functions
 // GetMouseRay :: GetScreenToWorldRay     // Compatibility hack for previous raylib versions
@@ -853,87 +853,87 @@ SaveFileTextCallback :: proc "c" (cstring, cstring) -> bool // FileIO: Save text
 //------------------------------------------------------------------------------------
 // Audio Loading and Playing Functions (Module: audio)
 //------------------------------------------------------------------------------------
-AudioCallback :: proc "c" (rawptr, u32)
+AudioCallback :: proc "c" (rawptr, c.uint)
 
 @(default_calling_convention="c", link_prefix="")
 foreign lib {
 	// Window-related functions
-	InitWindow               :: proc(width: i32, height: i32, title: cstring) --- // Initialize window and OpenGL context
-	CloseWindow              :: proc() ---                                        // Close window and unload OpenGL context
-	WindowShouldClose        :: proc() -> bool ---                                // Check if application should close (KEY_ESCAPE pressed or windows close icon clicked)
-	IsWindowReady            :: proc() -> bool ---                                // Check if window has been initialized successfully
-	IsWindowFullscreen       :: proc() -> bool ---                                // Check if window is currently fullscreen
-	IsWindowHidden           :: proc() -> bool ---                                // Check if window is currently hidden
-	IsWindowMinimized        :: proc() -> bool ---                                // Check if window is currently minimized
-	IsWindowMaximized        :: proc() -> bool ---                                // Check if window is currently maximized
-	IsWindowFocused          :: proc() -> bool ---                                // Check if window is currently focused
-	IsWindowResized          :: proc() -> bool ---                                // Check if window has been resized last frame
-	IsWindowState            :: proc(flag: u32) -> bool ---                       // Check if one specific window flag is enabled
-	SetWindowState           :: proc(flags: u32) ---                              // Set window configuration state using flags
-	ClearWindowState         :: proc(flags: u32) ---                              // Clear window configuration state flags
-	ToggleFullscreen         :: proc() ---                                        // Toggle window state: fullscreen/windowed, resizes monitor to match window resolution
-	ToggleBorderlessWindowed :: proc() ---                                        // Toggle window state: borderless windowed, resizes window to match monitor resolution
-	MaximizeWindow           :: proc() ---                                        // Set window state: maximized, if resizable
-	MinimizeWindow           :: proc() ---                                        // Set window state: minimized, if resizable
-	RestoreWindow            :: proc() ---                                        // Set window state: not minimized/maximized
-	SetWindowIcon            :: proc(image: Image) ---                            // Set icon for window (single image, RGBA 32bit)
-	SetWindowIcons           :: proc(images: ^Image, count: i32) ---              // Set icon for window (multiple images, RGBA 32bit)
-	SetWindowTitle           :: proc(title: cstring) ---                          // Set title for window
-	SetWindowPosition        :: proc(x: i32, y: i32) ---                          // Set window position on screen
-	SetWindowMonitor         :: proc(monitor: i32) ---                            // Set monitor for the current window
-	SetWindowMinSize         :: proc(width: i32, height: i32) ---                 // Set window minimum dimensions (for FLAG_WINDOW_RESIZABLE)
-	SetWindowMaxSize         :: proc(width: i32, height: i32) ---                 // Set window maximum dimensions (for FLAG_WINDOW_RESIZABLE)
-	SetWindowSize            :: proc(width: i32, height: i32) ---                 // Set window dimensions
-	SetWindowOpacity         :: proc(opacity: f32) ---                            // Set window opacity [0.0f..1.0f]
-	SetWindowFocused         :: proc() ---                                        // Set window focused
-	GetWindowHandle          :: proc() -> rawptr ---                              // Get native window handle
-	GetScreenWidth           :: proc() -> i32 ---                                 // Get current screen width
-	GetScreenHeight          :: proc() -> i32 ---                                 // Get current screen height
-	GetRenderWidth           :: proc() -> i32 ---                                 // Get current render width (it considers HiDPI)
-	GetRenderHeight          :: proc() -> i32 ---                                 // Get current render height (it considers HiDPI)
-	GetMonitorCount          :: proc() -> i32 ---                                 // Get number of connected monitors
-	GetCurrentMonitor        :: proc() -> i32 ---                                 // Get current monitor where window is placed
-	GetMonitorPosition       :: proc(monitor: i32) -> Vector2 ---                 // Get specified monitor position
-	GetMonitorWidth          :: proc(monitor: i32) -> i32 ---                     // Get specified monitor width (current video mode used by monitor)
-	GetMonitorHeight         :: proc(monitor: i32) -> i32 ---                     // Get specified monitor height (current video mode used by monitor)
-	GetMonitorPhysicalWidth  :: proc(monitor: i32) -> i32 ---                     // Get specified monitor physical width in millimetres
-	GetMonitorPhysicalHeight :: proc(monitor: i32) -> i32 ---                     // Get specified monitor physical height in millimetres
-	GetMonitorRefreshRate    :: proc(monitor: i32) -> i32 ---                     // Get specified monitor refresh rate
-	GetWindowPosition        :: proc() -> Vector2 ---                             // Get window position XY on monitor
-	GetWindowScaleDPI        :: proc() -> Vector2 ---                             // Get window scale DPI factor
-	GetMonitorName           :: proc(monitor: i32) -> cstring ---                 // Get the human-readable, UTF-8 encoded name of the specified monitor
-	SetClipboardText         :: proc(text: cstring) ---                           // Set clipboard text content
-	GetClipboardText         :: proc() -> cstring ---                             // Get clipboard text content
-	GetClipboardImage        :: proc() -> Image ---                               // Get clipboard image content
-	EnableEventWaiting       :: proc() ---                                        // Enable waiting for events on EndDrawing(), no automatic event polling
-	DisableEventWaiting      :: proc() ---                                        // Disable waiting for events on EndDrawing(), automatic events polling
+	InitWindow               :: proc(width: c.int, height: c.int, title: cstring) --- // Initialize window and OpenGL context
+	CloseWindow              :: proc() ---                                            // Close window and unload OpenGL context
+	WindowShouldClose        :: proc() -> c.bool ---                                  // Check if application should close (KEY_ESCAPE pressed or windows close icon clicked)
+	IsWindowReady            :: proc() -> c.bool ---                                  // Check if window has been initialized successfully
+	IsWindowFullscreen       :: proc() -> c.bool ---                                  // Check if window is currently fullscreen
+	IsWindowHidden           :: proc() -> c.bool ---                                  // Check if window is currently hidden
+	IsWindowMinimized        :: proc() -> c.bool ---                                  // Check if window is currently minimized
+	IsWindowMaximized        :: proc() -> c.bool ---                                  // Check if window is currently maximized
+	IsWindowFocused          :: proc() -> c.bool ---                                  // Check if window is currently focused
+	IsWindowResized          :: proc() -> c.bool ---                                  // Check if window has been resized last frame
+	IsWindowState            :: proc(flag: c.uint) -> c.bool ---                      // Check if one specific window flag is enabled
+	SetWindowState           :: proc(flags: c.uint) ---                               // Set window configuration state using flags
+	ClearWindowState         :: proc(flags: c.uint) ---                               // Clear window configuration state flags
+	ToggleFullscreen         :: proc() ---                                            // Toggle window state: fullscreen/windowed, resizes monitor to match window resolution
+	ToggleBorderlessWindowed :: proc() ---                                            // Toggle window state: borderless windowed, resizes window to match monitor resolution
+	MaximizeWindow           :: proc() ---                                            // Set window state: maximized, if resizable
+	MinimizeWindow           :: proc() ---                                            // Set window state: minimized, if resizable
+	RestoreWindow            :: proc() ---                                            // Set window state: not minimized/maximized
+	SetWindowIcon            :: proc(image: Image) ---                                // Set icon for window (single image, RGBA 32bit)
+	SetWindowIcons           :: proc(images: ^Image, count: c.int) ---                // Set icon for window (multiple images, RGBA 32bit)
+	SetWindowTitle           :: proc(title: cstring) ---                              // Set title for window
+	SetWindowPosition        :: proc(x: c.int, y: c.int) ---                          // Set window position on screen
+	SetWindowMonitor         :: proc(monitor: c.int) ---                              // Set monitor for the current window
+	SetWindowMinSize         :: proc(width: c.int, height: c.int) ---                 // Set window minimum dimensions (for FLAG_WINDOW_RESIZABLE)
+	SetWindowMaxSize         :: proc(width: c.int, height: c.int) ---                 // Set window maximum dimensions (for FLAG_WINDOW_RESIZABLE)
+	SetWindowSize            :: proc(width: c.int, height: c.int) ---                 // Set window dimensions
+	SetWindowOpacity         :: proc(opacity: c.float) ---                            // Set window opacity [0.0f..1.0f]
+	SetWindowFocused         :: proc() ---                                            // Set window focused
+	GetWindowHandle          :: proc() -> rawptr ---                                  // Get native window handle
+	GetScreenWidth           :: proc() -> c.int ---                                   // Get current screen width
+	GetScreenHeight          :: proc() -> c.int ---                                   // Get current screen height
+	GetRenderWidth           :: proc() -> c.int ---                                   // Get current render width (it considers HiDPI)
+	GetRenderHeight          :: proc() -> c.int ---                                   // Get current render height (it considers HiDPI)
+	GetMonitorCount          :: proc() -> c.int ---                                   // Get number of connected monitors
+	GetCurrentMonitor        :: proc() -> c.int ---                                   // Get current monitor where window is placed
+	GetMonitorPosition       :: proc(monitor: c.int) -> Vector2 ---                   // Get specified monitor position
+	GetMonitorWidth          :: proc(monitor: c.int) -> c.int ---                     // Get specified monitor width (current video mode used by monitor)
+	GetMonitorHeight         :: proc(monitor: c.int) -> c.int ---                     // Get specified monitor height (current video mode used by monitor)
+	GetMonitorPhysicalWidth  :: proc(monitor: c.int) -> c.int ---                     // Get specified monitor physical width in millimetres
+	GetMonitorPhysicalHeight :: proc(monitor: c.int) -> c.int ---                     // Get specified monitor physical height in millimetres
+	GetMonitorRefreshRate    :: proc(monitor: c.int) -> c.int ---                     // Get specified monitor refresh rate
+	GetWindowPosition        :: proc() -> Vector2 ---                                 // Get window position XY on monitor
+	GetWindowScaleDPI        :: proc() -> Vector2 ---                                 // Get window scale DPI factor
+	GetMonitorName           :: proc(monitor: c.int) -> cstring ---                   // Get the human-readable, UTF-8 encoded name of the specified monitor
+	SetClipboardText         :: proc(text: cstring) ---                               // Set clipboard text content
+	GetClipboardText         :: proc() -> cstring ---                                 // Get clipboard text content
+	GetClipboardImage        :: proc() -> Image ---                                   // Get clipboard image content
+	EnableEventWaiting       :: proc() ---                                            // Enable waiting for events on EndDrawing(), no automatic event polling
+	DisableEventWaiting      :: proc() ---                                            // Disable waiting for events on EndDrawing(), automatic events polling
 
 	// Cursor-related functions
-	ShowCursor       :: proc() ---         // Shows cursor
-	HideCursor       :: proc() ---         // Hides cursor
-	IsCursorHidden   :: proc() -> bool --- // Check if cursor is not visible
-	EnableCursor     :: proc() ---         // Enables cursor (unlock cursor)
-	DisableCursor    :: proc() ---         // Disables cursor (lock cursor)
-	IsCursorOnScreen :: proc() -> bool --- // Check if cursor is on the screen
+	ShowCursor       :: proc() ---           // Shows cursor
+	HideCursor       :: proc() ---           // Hides cursor
+	IsCursorHidden   :: proc() -> c.bool --- // Check if cursor is not visible
+	EnableCursor     :: proc() ---           // Enables cursor (unlock cursor)
+	DisableCursor    :: proc() ---           // Disables cursor (lock cursor)
+	IsCursorOnScreen :: proc() -> c.bool --- // Check if cursor is on the screen
 
 	// Drawing-related functions
-	ClearBackground   :: proc(color: Color) ---                            // Set background color (framebuffer clear color)
-	BeginDrawing      :: proc() ---                                        // Setup canvas (framebuffer) to start drawing
-	EndDrawing        :: proc() ---                                        // End canvas drawing and swap buffers (double buffering)
-	BeginMode2D       :: proc(camera: Camera2D) ---                        // Begin 2D mode with custom camera (2D)
-	EndMode2D         :: proc() ---                                        // Ends 2D mode with custom camera
-	BeginMode3D       :: proc(camera: Camera3D) ---                        // Begin 3D mode with custom camera (3D)
-	EndMode3D         :: proc() ---                                        // Ends 3D mode and returns to default 2D orthographic mode
-	BeginTextureMode  :: proc(target: RenderTexture2D) ---                 // Begin drawing to render texture
-	EndTextureMode    :: proc() ---                                        // Ends drawing to render texture
-	BeginShaderMode   :: proc(shader: Shader) ---                          // Begin custom shader drawing
-	EndShaderMode     :: proc() ---                                        // End custom shader drawing (use default shader)
-	BeginBlendMode    :: proc(mode: i32) ---                               // Begin blending mode (alpha, additive, multiplied, subtract, custom)
-	EndBlendMode      :: proc() ---                                        // End blending mode (reset to default: alpha blending)
-	BeginScissorMode  :: proc(x: i32, y: i32, width: i32, height: i32) --- // Begin scissor mode (define screen area for following drawing)
-	EndScissorMode    :: proc() ---                                        // End scissor mode
-	BeginVrStereoMode :: proc(config: VrStereoConfig) ---                  // Begin stereo rendering (requires VR simulator)
-	EndVrStereoMode   :: proc() ---                                        // End stereo rendering (requires VR simulator)
+	ClearBackground   :: proc(color: Color) ---                                    // Set background color (framebuffer clear color)
+	BeginDrawing      :: proc() ---                                                // Setup canvas (framebuffer) to start drawing
+	EndDrawing        :: proc() ---                                                // End canvas drawing and swap buffers (double buffering)
+	BeginMode2D       :: proc(camera: Camera2D) ---                                // Begin 2D mode with custom camera (2D)
+	EndMode2D         :: proc() ---                                                // Ends 2D mode with custom camera
+	BeginMode3D       :: proc(camera: Camera3D) ---                                // Begin 3D mode with custom camera (3D)
+	EndMode3D         :: proc() ---                                                // Ends 3D mode and returns to default 2D orthographic mode
+	BeginTextureMode  :: proc(target: RenderTexture2D) ---                         // Begin drawing to render texture
+	EndTextureMode    :: proc() ---                                                // Ends drawing to render texture
+	BeginShaderMode   :: proc(shader: Shader) ---                                  // Begin custom shader drawing
+	EndShaderMode     :: proc() ---                                                // End custom shader drawing (use default shader)
+	BeginBlendMode    :: proc(mode: c.int) ---                                     // Begin blending mode (alpha, additive, multiplied, subtract, custom)
+	EndBlendMode      :: proc() ---                                                // End blending mode (reset to default: alpha blending)
+	BeginScissorMode  :: proc(x: c.int, y: c.int, width: c.int, height: c.int) --- // Begin scissor mode (define screen area for following drawing)
+	EndScissorMode    :: proc() ---                                                // End scissor mode
+	BeginVrStereoMode :: proc(config: VrStereoConfig) ---                          // Begin stereo rendering (requires VR simulator)
+	EndVrStereoMode   :: proc() ---                                                // End stereo rendering (requires VR simulator)
 
 	// VR stereo config functions for VR simulator
 	LoadVrStereoConfig   :: proc(device: VrDeviceInfo) -> VrStereoConfig --- // Load VR stereo config for VR simulator device parameters
@@ -941,44 +941,44 @@ foreign lib {
 
 	// Shader management functions
 	// NOTE: Shader functionality is not available on OpenGL 1.1
-	LoadShader              :: proc(vsFileName: cstring, fsFileName: cstring) -> Shader --- // Load shader from files and bind default locations
-	LoadShaderFromMemory    :: proc(vsCode: cstring, fsCode: cstring) -> Shader ---         // Load shader from code strings and bind default locations
-	IsShaderValid           :: proc(shader: Shader) -> bool ---                             // Check if a shader is valid (loaded on GPU)
-	GetShaderLocation       :: proc(shader: Shader, uniformName: cstring) -> i32 ---        // Get shader uniform location
-	GetShaderLocationAttrib :: proc(shader: Shader, attribName: cstring) -> i32 ---         // Get shader attribute location
-	SetShaderValue          :: proc(shader: Shader, locIndex: i32, value: rawptr, uniformType: ShaderUniformDataType) --- // Set shader uniform value
-	SetShaderValueV         :: proc(shader: Shader, locIndex: i32, value: rawptr, uniformType: ShaderUniformDataType, count: i32) --- // Set shader uniform value vector
-	SetShaderValueMatrix    :: proc(shader: Shader, locIndex: i32, mat: Matrix) ---         // Set shader uniform value (matrix 4x4)
-	SetShaderValueTexture   :: proc(shader: Shader, locIndex: i32, texture: Texture2D) ---  // Set shader uniform value and bind the texture (sampler2d)
-	UnloadShader            :: proc(shader: Shader) ---                                     // Unload shader from GPU memory (VRAM)
-	GetScreenToWorldRay     :: proc(position: Vector2, camera: Camera) -> Ray ---           // Get a ray trace from screen position (i.e mouse)
-	GetScreenToWorldRayEx   :: proc(position: Vector2, camera: Camera, width: i32, height: i32) -> Ray --- // Get a ray trace from screen position (i.e mouse) in a viewport
-	GetWorldToScreen        :: proc(position: Vector3, camera: Camera) -> Vector2 ---       // Get the screen space position for a 3d world space position
-	GetWorldToScreenEx      :: proc(position: Vector3, camera: Camera, width: i32, height: i32) -> Vector2 --- // Get size position for a 3d world space position
-	GetWorldToScreen2D      :: proc(position: Vector2, camera: Camera2D) -> Vector2 ---     // Get the screen space position for a 2d camera world space position
-	GetScreenToWorld2D      :: proc(position: Vector2, camera: Camera2D) -> Vector2 ---     // Get the world space position for a 2d camera screen space position
-	GetCameraMatrix         :: proc(camera: Camera) -> Matrix ---                           // Get camera transform matrix (view matrix)
-	GetCameraMatrix2D       :: proc(camera: Camera2D) -> Matrix ---                         // Get camera 2d transform matrix
+	LoadShader              :: proc(vsFileName: cstring, fsFileName: cstring) -> Shader ---  // Load shader from files and bind default locations
+	LoadShaderFromMemory    :: proc(vsCode: cstring, fsCode: cstring) -> Shader ---          // Load shader from code strings and bind default locations
+	IsShaderValid           :: proc(shader: Shader) -> c.bool ---                            // Check if a shader is valid (loaded on GPU)
+	GetShaderLocation       :: proc(shader: Shader, uniformName: cstring) -> c.int ---       // Get shader uniform location
+	GetShaderLocationAttrib :: proc(shader: Shader, attribName: cstring) -> c.int ---        // Get shader attribute location
+	SetShaderValue          :: proc(shader: Shader, locIndex: c.int, value: rawptr, uniformType: ShaderUniformDataType) --- // Set shader uniform value
+	SetShaderValueV         :: proc(shader: Shader, locIndex: c.int, value: rawptr, uniformType: ShaderUniformDataType, count: c.int) --- // Set shader uniform value vector
+	SetShaderValueMatrix    :: proc(shader: Shader, locIndex: c.int, mat: Matrix) ---        // Set shader uniform value (matrix 4x4)
+	SetShaderValueTexture   :: proc(shader: Shader, locIndex: c.int, texture: Texture2D) --- // Set shader uniform value and bind the texture (sampler2d)
+	UnloadShader            :: proc(shader: Shader) ---                                      // Unload shader from GPU memory (VRAM)
+	GetScreenToWorldRay     :: proc(position: Vector2, camera: Camera) -> Ray ---            // Get a ray trace from screen position (i.e mouse)
+	GetScreenToWorldRayEx   :: proc(position: Vector2, camera: Camera, width: c.int, height: c.int) -> Ray --- // Get a ray trace from screen position (i.e mouse) in a viewport
+	GetWorldToScreen        :: proc(position: Vector3, camera: Camera) -> Vector2 ---        // Get the screen space position for a 3d world space position
+	GetWorldToScreenEx      :: proc(position: Vector3, camera: Camera, width: c.int, height: c.int) -> Vector2 --- // Get size position for a 3d world space position
+	GetWorldToScreen2D      :: proc(position: Vector2, camera: Camera2D) -> Vector2 ---      // Get the screen space position for a 2d camera world space position
+	GetScreenToWorld2D      :: proc(position: Vector2, camera: Camera2D) -> Vector2 ---      // Get the world space position for a 2d camera screen space position
+	GetCameraMatrix         :: proc(camera: Camera) -> Matrix ---                            // Get camera transform matrix (view matrix)
+	GetCameraMatrix2D       :: proc(camera: Camera2D) -> Matrix ---                          // Get camera 2d transform matrix
 
 	// Timing-related functions
-	SetTargetFPS :: proc(fps: i32) --- // Set target FPS (maximum)
-	GetFrameTime :: proc() -> f32 ---  // Get time in seconds for last frame drawn (delta time)
-	GetTime      :: proc() -> f64 ---  // Get elapsed time in seconds since InitWindow()
-	GetFPS       :: proc() -> i32 ---  // Get current FPS
+	SetTargetFPS :: proc(fps: c.int) ---   // Set target FPS (maximum)
+	GetFrameTime :: proc() -> c.float ---  // Get time in seconds for last frame drawn (delta time)
+	GetTime      :: proc() -> c.double --- // Get elapsed time in seconds since InitWindow()
+	GetFPS       :: proc() -> c.int ---    // Get current FPS
 
 	// Custom frame control functions
 	// NOTE: Those functions are intended for advanced users that want full control over the frame processing
 	// By default EndDrawing() does this job: draws everything + SwapScreenBuffer() + manage frame timing + PollInputEvents()
 	// To avoid that behaviour and control frame processes manually, enable in config.h: SUPPORT_CUSTOM_FRAME_CONTROL
-	SwapScreenBuffer :: proc() ---             // Swap back buffer with front buffer (screen drawing)
-	PollInputEvents  :: proc() ---             // Register all input events
-	WaitTime         :: proc(seconds: f64) --- // Wait for some time (halt program execution)
+	SwapScreenBuffer :: proc() ---                  // Swap back buffer with front buffer (screen drawing)
+	PollInputEvents  :: proc() ---                  // Register all input events
+	WaitTime         :: proc(seconds: c.double) --- // Wait for some time (halt program execution)
 
 	// Random values generation functions
-	SetRandomSeed        :: proc(seed: u32) ---                              // Set the seed for the random number generator
-	GetRandomValue       :: proc(min: i32, max: i32) -> i32 ---              // Get a random value between min and max (both included)
-	LoadRandomSequence   :: proc(count: u32, min: i32, max: i32) -> ^i32 --- // Load random values sequence, no values repeated
-	UnloadRandomSequence :: proc(sequence: ^i32) ---                         // Unload random values sequence
+	SetRandomSeed        :: proc(seed: c.uint) ---                                    // Set the seed for the random number generator
+	GetRandomValue       :: proc(min: c.int, max: c.int) -> c.int ---                 // Get a random value between min and max (both included)
+	LoadRandomSequence   :: proc(count: c.uint, min: c.int, max: c.int) -> ^c.int --- // Load random values sequence, no values repeated
+	UnloadRandomSequence :: proc(sequence: ^c.int) ---                                // Unload random values sequence
 
 	// Misc. functions
 	TakeScreenshot :: proc(fileName: cstring) ---  // Takes a screenshot of current screen (filename extension defines format)
@@ -987,11 +987,11 @@ foreign lib {
 
 	// NOTE: Following functions implemented in module [utils]
 	//------------------------------------------------------------------
-	TraceLog         :: proc(logLevel: i32, text: cstring) ---     // Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)
-	SetTraceLogLevel :: proc(logLevel: i32) ---                    // Set the current threshold (minimum) log level
-	MemAlloc         :: proc(size: u32) -> rawptr ---              // Internal memory allocator
-	MemRealloc       :: proc(ptr: rawptr, size: u32) -> rawptr --- // Internal memory reallocator
-	MemFree          :: proc(ptr: rawptr) ---                      // Internal memory free
+	TraceLog         :: proc(logLevel: c.int, text: cstring) ---      // Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)
+	SetTraceLogLevel :: proc(logLevel: c.int) ---                     // Set the current threshold (minimum) log level
+	MemAlloc         :: proc(size: c.uint) -> rawptr ---              // Internal memory allocator
+	MemRealloc       :: proc(ptr: rawptr, size: c.uint) -> rawptr --- // Internal memory reallocator
+	MemFree          :: proc(ptr: rawptr) ---                         // Internal memory free
 
 	// Set custom callbacks
 	// WARNING: Callbacks setup is intended for advanced users
@@ -1002,121 +1002,121 @@ foreign lib {
 	SetSaveFileTextCallback :: proc(callback: SaveFileTextCallback) --- // Set custom file text data saver
 
 	// Files management functions
-	LoadFileData     :: proc(fileName: cstring, dataSize: ^i32) -> ^u8 ---               // Load file data as byte array (read)
-	UnloadFileData   :: proc(data: ^u8) ---                                              // Unload file data allocated by LoadFileData()
-	SaveFileData     :: proc(fileName: cstring, data: rawptr, dataSize: i32) -> bool --- // Save data to file from byte array (write), returns true on success
-	ExportDataAsCode :: proc(data: ^u8, dataSize: i32, fileName: cstring) -> bool ---    // Export data to code (.h), returns true on success
-	LoadFileText     :: proc(fileName: cstring) -> cstring ---                           // Load text data from file (read), returns a '\0' terminated string
-	UnloadFileText   :: proc(text: cstring) ---                                          // Unload file text data allocated by LoadFileText()
-	SaveFileText     :: proc(fileName: cstring, text: cstring) -> bool ---               // Save text data to file (write), string must be '\0' terminated, returns true on success
+	LoadFileData     :: proc(fileName: cstring, dataSize: ^c.int) -> ^c.uchar ---            // Load file data as byte array (read)
+	UnloadFileData   :: proc(data: ^c.uchar) ---                                             // Unload file data allocated by LoadFileData()
+	SaveFileData     :: proc(fileName: cstring, data: rawptr, dataSize: c.int) -> c.bool --- // Save data to file from byte array (write), returns true on success
+	ExportDataAsCode :: proc(data: ^c.uchar, dataSize: c.int, fileName: cstring) -> c.bool --- // Export data to code (.h), returns true on success
+	LoadFileText     :: proc(fileName: cstring) -> cstring ---                               // Load text data from file (read), returns a '\0' terminated string
+	UnloadFileText   :: proc(text: cstring) ---                                              // Unload file text data allocated by LoadFileText()
+	SaveFileText     :: proc(fileName: cstring, text: cstring) -> c.bool ---                 // Save text data to file (write), string must be '\0' terminated, returns true on success
 
 	// File system functions
-	FileExists              :: proc(fileName: cstring) -> bool ---               // Check if file exists
-	DirectoryExists         :: proc(dirPath: cstring) -> bool ---                // Check if a directory path exists
-	IsFileExtension         :: proc(fileName: cstring, ext: cstring) -> bool --- // Check file extension (including point: .png, .wav)
-	GetFileLength           :: proc(fileName: cstring) -> i32 ---                // Get file length in bytes (NOTE: GetFileSize() conflicts with windows.h)
-	GetFileExtension        :: proc(fileName: cstring) -> cstring ---            // Get pointer to extension for a filename string (includes dot: '.png')
-	GetFileName             :: proc(filePath: cstring) -> cstring ---            // Get pointer to filename for a path string
-	GetFileNameWithoutExt   :: proc(filePath: cstring) -> cstring ---            // Get filename string without extension (uses static string)
-	GetDirectoryPath        :: proc(filePath: cstring) -> cstring ---            // Get full path for a given fileName with path (uses static string)
-	GetPrevDirectoryPath    :: proc(dirPath: cstring) -> cstring ---             // Get previous directory path for a given path (uses static string)
-	GetWorkingDirectory     :: proc() -> cstring ---                             // Get current working directory (uses static string)
-	GetApplicationDirectory :: proc() -> cstring ---                             // Get the directory of the running application (uses static string)
-	MakeDirectory           :: proc(dirPath: cstring) -> i32 ---                 // Create directories (including full path requested), returns 0 on success
-	ChangeDirectory         :: proc(dir: cstring) -> bool ---                    // Change working directory, return true on success
-	IsPathFile              :: proc(path: cstring) -> bool ---                   // Check if a given path is a file or a directory
-	IsFileNameValid         :: proc(fileName: cstring) -> bool ---               // Check if fileName is valid for the platform/OS
-	LoadDirectoryFiles      :: proc(dirPath: cstring) -> FilePathList ---        // Load directory filepaths
-	LoadDirectoryFilesEx    :: proc(basePath: cstring, filter: cstring, scanSubdirs: bool) -> FilePathList --- // Load directory filepaths with extension filtering and recursive directory scan. Use 'DIR' in the filter string to include directories in the result
-	UnloadDirectoryFiles    :: proc(files: FilePathList) ---                     // Unload filepaths
-	IsFileDropped           :: proc() -> bool ---                                // Check if a file has been dropped into window
-	LoadDroppedFiles        :: proc() -> FilePathList ---                        // Load dropped filepaths
-	UnloadDroppedFiles      :: proc(files: FilePathList) ---                     // Unload dropped filepaths
-	GetFileModTime          :: proc(fileName: cstring) -> c.long ---             // Get file modification time (last write time)
+	FileExists              :: proc(fileName: cstring) -> c.bool ---               // Check if file exists
+	DirectoryExists         :: proc(dirPath: cstring) -> c.bool ---                // Check if a directory path exists
+	IsFileExtension         :: proc(fileName: cstring, ext: cstring) -> c.bool --- // Check file extension (including point: .png, .wav)
+	GetFileLength           :: proc(fileName: cstring) -> c.int ---                // Get file length in bytes (NOTE: GetFileSize() conflicts with windows.h)
+	GetFileExtension        :: proc(fileName: cstring) -> cstring ---              // Get pointer to extension for a filename string (includes dot: '.png')
+	GetFileName             :: proc(filePath: cstring) -> cstring ---              // Get pointer to filename for a path string
+	GetFileNameWithoutExt   :: proc(filePath: cstring) -> cstring ---              // Get filename string without extension (uses static string)
+	GetDirectoryPath        :: proc(filePath: cstring) -> cstring ---              // Get full path for a given fileName with path (uses static string)
+	GetPrevDirectoryPath    :: proc(dirPath: cstring) -> cstring ---               // Get previous directory path for a given path (uses static string)
+	GetWorkingDirectory     :: proc() -> cstring ---                               // Get current working directory (uses static string)
+	GetApplicationDirectory :: proc() -> cstring ---                               // Get the directory of the running application (uses static string)
+	MakeDirectory           :: proc(dirPath: cstring) -> c.int ---                 // Create directories (including full path requested), returns 0 on success
+	ChangeDirectory         :: proc(dir: cstring) -> c.bool ---                    // Change working directory, return true on success
+	IsPathFile              :: proc(path: cstring) -> c.bool ---                   // Check if a given path is a file or a directory
+	IsFileNameValid         :: proc(fileName: cstring) -> c.bool ---               // Check if fileName is valid for the platform/OS
+	LoadDirectoryFiles      :: proc(dirPath: cstring) -> FilePathList ---          // Load directory filepaths
+	LoadDirectoryFilesEx    :: proc(basePath: cstring, filter: cstring, scanSubdirs: c.bool) -> FilePathList --- // Load directory filepaths with extension filtering and recursive directory scan. Use 'DIR' in the filter string to include directories in the result
+	UnloadDirectoryFiles    :: proc(files: FilePathList) ---                       // Unload filepaths
+	IsFileDropped           :: proc() -> c.bool ---                                // Check if a file has been dropped into window
+	LoadDroppedFiles        :: proc() -> FilePathList ---                          // Load dropped filepaths
+	UnloadDroppedFiles      :: proc(files: FilePathList) ---                       // Unload dropped filepaths
+	GetFileModTime          :: proc(fileName: cstring) -> c.long ---               // Get file modification time (last write time)
 
 	// Compression/Encoding functionality
-	CompressData     :: proc(data: ^u8, dataSize: i32, compDataSize: ^i32) -> ^u8 ---     // Compress data (DEFLATE algorithm), memory must be MemFree()
-	DecompressData   :: proc(compData: ^u8, compDataSize: i32, dataSize: ^i32) -> ^u8 --- // Decompress data (DEFLATE algorithm), memory must be MemFree()
-	EncodeDataBase64 :: proc(data: ^u8, dataSize: i32, outputSize: ^i32) -> cstring ---   // Encode data to Base64 string, memory must be MemFree()
-	DecodeDataBase64 :: proc(data: ^u8, outputSize: ^i32) -> ^u8 ---                      // Decode Base64 string data, memory must be MemFree()
-	ComputeCRC32     :: proc(data: ^u8, dataSize: i32) -> u32 ---                         // Compute CRC32 hash code
-	ComputeMD5       :: proc(data: ^u8, dataSize: i32) -> ^u32 ---                        // Compute MD5 hash code, returns static int[4] (16 bytes)
-	ComputeSHA1      :: proc(data: ^u8, dataSize: i32) -> ^u32 ---                        // Compute SHA1 hash code, returns static int[5] (20 bytes)
+	CompressData     :: proc(data: ^c.uchar, dataSize: c.int, compDataSize: ^c.int) -> ^c.uchar --- // Compress data (DEFLATE algorithm), memory must be MemFree()
+	DecompressData   :: proc(compData: ^c.uchar, compDataSize: c.int, dataSize: ^c.int) -> ^c.uchar --- // Decompress data (DEFLATE algorithm), memory must be MemFree()
+	EncodeDataBase64 :: proc(data: ^c.uchar, dataSize: c.int, outputSize: ^c.int) -> cstring --- // Encode data to Base64 string, memory must be MemFree()
+	DecodeDataBase64 :: proc(data: ^c.uchar, outputSize: ^c.int) -> ^c.uchar --- // Decode Base64 string data, memory must be MemFree()
+	ComputeCRC32     :: proc(data: ^c.uchar, dataSize: c.int) -> c.uint ---      // Compute CRC32 hash code
+	ComputeMD5       :: proc(data: ^c.uchar, dataSize: c.int) -> ^c.uint ---     // Compute MD5 hash code, returns static int[4] (16 bytes)
+	ComputeSHA1      :: proc(data: ^c.uchar, dataSize: c.int) -> ^c.uint ---     // Compute SHA1 hash code, returns static int[5] (20 bytes)
 
 	// Automation events functionality
 	LoadAutomationEventList       :: proc(fileName: cstring) -> AutomationEventList --- // Load automation events list from file, NULL for empty list, capacity = MAX_AUTOMATION_EVENTS
 	UnloadAutomationEventList     :: proc(list: AutomationEventList) ---                // Unload automation events list from file
-	ExportAutomationEventList     :: proc(list: AutomationEventList, fileName: cstring) -> bool --- // Export automation events list as text file
+	ExportAutomationEventList     :: proc(list: AutomationEventList, fileName: cstring) -> c.bool --- // Export automation events list as text file
 	SetAutomationEventList        :: proc(list: ^AutomationEventList) ---               // Set automation event list to record to
-	SetAutomationEventBaseFrame   :: proc(frame: i32) ---                               // Set automation event internal base frame to start recording
+	SetAutomationEventBaseFrame   :: proc(frame: c.int) ---                             // Set automation event internal base frame to start recording
 	StartAutomationEventRecording :: proc() ---                                         // Start recording automation events (AutomationEventList must be set)
 	StopAutomationEventRecording  :: proc() ---                                         // Stop recording automation events
 	PlayAutomationEvent           :: proc(event: AutomationEvent) ---                   // Play a recorded automation event
 
 	// Input-related functions: keyboard
-	IsKeyPressed       :: proc(key: KeyboardKey) -> bool ---    // Check if a key has been pressed once
-	IsKeyPressedRepeat :: proc(key: KeyboardKey) -> bool ---    // Check if a key has been pressed again
-	IsKeyDown          :: proc(key: KeyboardKey) -> bool ---    // Check if a key is being pressed
-	IsKeyReleased      :: proc(key: KeyboardKey) -> bool ---    // Check if a key has been released once
-	IsKeyUp            :: proc(key: KeyboardKey) -> bool ---    // Check if a key is NOT being pressed
+	IsKeyPressed       :: proc(key: KeyboardKey) -> c.bool ---  // Check if a key has been pressed once
+	IsKeyPressedRepeat :: proc(key: KeyboardKey) -> c.bool ---  // Check if a key has been pressed again
+	IsKeyDown          :: proc(key: KeyboardKey) -> c.bool ---  // Check if a key is being pressed
+	IsKeyReleased      :: proc(key: KeyboardKey) -> c.bool ---  // Check if a key has been released once
+	IsKeyUp            :: proc(key: KeyboardKey) -> c.bool ---  // Check if a key is NOT being pressed
 	GetKeyPressed      :: proc() -> KeyboardKey ---             // Get key pressed (keycode), call it multiple times for keys queued, returns 0 when the queue is empty
-	GetCharPressed     :: proc() -> i32 ---                     // Get char pressed (unicode), call it multiple times for chars queued, returns 0 when the queue is empty
+	GetCharPressed     :: proc() -> c.int ---                   // Get char pressed (unicode), call it multiple times for chars queued, returns 0 when the queue is empty
 	GetKeyName         :: proc(key: KeyboardKey) -> cstring --- // Get name of a QWERTY key on the current keyboard layout (eg returns string 'q' for KEY_A on an AZERTY keyboard)
 	SetExitKey         :: proc(key: KeyboardKey) ---            // Set a custom key to exit program (default is ESC)
 
 	// Input-related functions: gamepads
-	IsGamepadAvailable      :: proc(gamepad: i32) -> bool ---              // Check if a gamepad is available
-	GetGamepadName          :: proc(gamepad: i32) -> cstring ---           // Get gamepad internal name id
-	IsGamepadButtonPressed  :: proc(gamepad: i32, button: i32) -> bool --- // Check if a gamepad button has been pressed once
-	IsGamepadButtonDown     :: proc(gamepad: i32, button: i32) -> bool --- // Check if a gamepad button is being pressed
-	IsGamepadButtonReleased :: proc(gamepad: i32, button: i32) -> bool --- // Check if a gamepad button has been released once
-	IsGamepadButtonUp       :: proc(gamepad: i32, button: i32) -> bool --- // Check if a gamepad button is NOT being pressed
-	GetGamepadButtonPressed :: proc() -> i32 ---                           // Get the last gamepad button pressed
-	GetGamepadAxisCount     :: proc(gamepad: i32) -> i32 ---               // Get gamepad axis count for a gamepad
-	GetGamepadAxisMovement  :: proc(gamepad: i32, axis: i32) -> f32 ---    // Get axis movement value for a gamepad axis
-	SetGamepadMappings      :: proc(mappings: cstring) -> i32 ---          // Set internal gamepad mappings (SDL_GameControllerDB)
-	SetGamepadVibration     :: proc(gamepad: i32, leftMotor: f32, rightMotor: f32, duration: f32) --- // Set gamepad vibration for both motors (duration in seconds)
+	IsGamepadAvailable      :: proc(gamepad: c.int) -> c.bool ---                // Check if a gamepad is available
+	GetGamepadName          :: proc(gamepad: c.int) -> cstring ---               // Get gamepad internal name id
+	IsGamepadButtonPressed  :: proc(gamepad: c.int, button: c.int) -> c.bool --- // Check if a gamepad button has been pressed once
+	IsGamepadButtonDown     :: proc(gamepad: c.int, button: c.int) -> c.bool --- // Check if a gamepad button is being pressed
+	IsGamepadButtonReleased :: proc(gamepad: c.int, button: c.int) -> c.bool --- // Check if a gamepad button has been released once
+	IsGamepadButtonUp       :: proc(gamepad: c.int, button: c.int) -> c.bool --- // Check if a gamepad button is NOT being pressed
+	GetGamepadButtonPressed :: proc() -> c.int ---                               // Get the last gamepad button pressed
+	GetGamepadAxisCount     :: proc(gamepad: c.int) -> c.int ---                 // Get gamepad axis count for a gamepad
+	GetGamepadAxisMovement  :: proc(gamepad: c.int, axis: c.int) -> c.float ---  // Get axis movement value for a gamepad axis
+	SetGamepadMappings      :: proc(mappings: cstring) -> c.int ---              // Set internal gamepad mappings (SDL_GameControllerDB)
+	SetGamepadVibration     :: proc(gamepad: c.int, leftMotor: c.float, rightMotor: c.float, duration: c.float) --- // Set gamepad vibration for both motors (duration in seconds)
 
 	// Input-related functions: mouse
-	IsMouseButtonPressed  :: proc(button: MouseButton) -> bool --- // Check if a mouse button has been pressed once
-	IsMouseButtonDown     :: proc(button: MouseButton) -> bool --- // Check if a mouse button is being pressed
-	IsMouseButtonReleased :: proc(button: MouseButton) -> bool --- // Check if a mouse button has been released once
-	IsMouseButtonUp       :: proc(button: MouseButton) -> bool --- // Check if a mouse button is NOT being pressed
-	GetMouseX             :: proc() -> i32 ---                     // Get mouse position X
-	GetMouseY             :: proc() -> i32 ---                     // Get mouse position Y
-	GetMousePosition      :: proc() -> Vector2 ---                 // Get mouse position XY
-	GetMouseDelta         :: proc() -> Vector2 ---                 // Get mouse delta between frames
-	SetMousePosition      :: proc(x: i32, y: i32) ---              // Set mouse position XY
-	SetMouseOffset        :: proc(offsetX: i32, offsetY: i32) ---  // Set mouse offset
-	SetMouseScale         :: proc(scaleX: f32, scaleY: f32) ---    // Set mouse scaling
-	GetMouseWheelMove     :: proc() -> f32 ---                     // Get mouse wheel movement for X or Y, whichever is larger
-	GetMouseWheelMoveV    :: proc() -> Vector2 ---                 // Get mouse wheel movement for both X and Y
-	SetMouseCursor        :: proc(cursor: i32) ---                 // Set mouse cursor
+	IsMouseButtonPressed  :: proc(button: MouseButton) -> c.bool ---    // Check if a mouse button has been pressed once
+	IsMouseButtonDown     :: proc(button: MouseButton) -> c.bool ---    // Check if a mouse button is being pressed
+	IsMouseButtonReleased :: proc(button: MouseButton) -> c.bool ---    // Check if a mouse button has been released once
+	IsMouseButtonUp       :: proc(button: MouseButton) -> c.bool ---    // Check if a mouse button is NOT being pressed
+	GetMouseX             :: proc() -> c.int ---                        // Get mouse position X
+	GetMouseY             :: proc() -> c.int ---                        // Get mouse position Y
+	GetMousePosition      :: proc() -> Vector2 ---                      // Get mouse position XY
+	GetMouseDelta         :: proc() -> Vector2 ---                      // Get mouse delta between frames
+	SetMousePosition      :: proc(x: c.int, y: c.int) ---               // Set mouse position XY
+	SetMouseOffset        :: proc(offsetX: c.int, offsetY: c.int) ---   // Set mouse offset
+	SetMouseScale         :: proc(scaleX: c.float, scaleY: c.float) --- // Set mouse scaling
+	GetMouseWheelMove     :: proc() -> c.float ---                      // Get mouse wheel movement for X or Y, whichever is larger
+	GetMouseWheelMoveV    :: proc() -> Vector2 ---                      // Get mouse wheel movement for both X and Y
+	SetMouseCursor        :: proc(cursor: c.int) ---                    // Set mouse cursor
 
 	// Input-related functions: touch
-	GetTouchX          :: proc() -> i32 ---               // Get touch position X for touch point 0 (relative to screen size)
-	GetTouchY          :: proc() -> i32 ---               // Get touch position Y for touch point 0 (relative to screen size)
-	GetTouchPosition   :: proc(index: i32) -> Vector2 --- // Get touch position XY for a touch point index (relative to screen size)
-	GetTouchPointId    :: proc(index: i32) -> i32 ---     // Get touch point identifier for given index
-	GetTouchPointCount :: proc() -> i32 ---               // Get number of touch points
+	GetTouchX          :: proc() -> c.int ---               // Get touch position X for touch point 0 (relative to screen size)
+	GetTouchY          :: proc() -> c.int ---               // Get touch position Y for touch point 0 (relative to screen size)
+	GetTouchPosition   :: proc(index: c.int) -> Vector2 --- // Get touch position XY for a touch point index (relative to screen size)
+	GetTouchPointId    :: proc(index: c.int) -> c.int ---   // Get touch point identifier for given index
+	GetTouchPointCount :: proc() -> c.int ---               // Get number of touch points
 
 	//------------------------------------------------------------------------------------
 	// Gestures and Touch Handling Functions (Module: rgestures)
 	//------------------------------------------------------------------------------------
-	SetGesturesEnabled     :: proc(flags: Gestures) ---           // Enable a set of gestures using flags
-	IsGestureDetected      :: proc(gesture: Gestures) -> bool --- // Check if a gesture have been detected
-	GetGestureDetected     :: proc() -> i32 ---                   // Get latest detected gesture
-	GetGestureHoldDuration :: proc() -> f32 ---                   // Get gesture hold time in seconds
-	GetGestureDragVector   :: proc() -> Vector2 ---               // Get gesture drag vector
-	GetGestureDragAngle    :: proc() -> f32 ---                   // Get gesture drag angle
-	GetGesturePinchVector  :: proc() -> Vector2 ---               // Get gesture pinch delta
-	GetGesturePinchAngle   :: proc() -> f32 ---                   // Get gesture pinch angle
+	SetGesturesEnabled     :: proc(flags: Gestures) ---             // Enable a set of gestures using flags
+	IsGestureDetected      :: proc(gesture: Gestures) -> c.bool --- // Check if a gesture have been detected
+	GetGestureDetected     :: proc() -> c.int ---                   // Get latest detected gesture
+	GetGestureHoldDuration :: proc() -> c.float ---                 // Get gesture hold time in seconds
+	GetGestureDragVector   :: proc() -> Vector2 ---                 // Get gesture drag vector
+	GetGestureDragAngle    :: proc() -> c.float ---                 // Get gesture drag angle
+	GetGesturePinchVector  :: proc() -> Vector2 ---                 // Get gesture pinch delta
+	GetGesturePinchAngle   :: proc() -> c.float ---                 // Get gesture pinch angle
 
 	//------------------------------------------------------------------------------------
 	// Camera System Functions (Module: rcamera)
 	//------------------------------------------------------------------------------------
-	UpdateCamera    :: proc(camera: ^Camera, mode: i32) --- // Update camera position for selected mode
-	UpdateCameraPro :: proc(camera: ^Camera, movement: Vector3, rotation: Vector3, zoom: f32) --- // Update camera movement/rotation
+	UpdateCamera    :: proc(camera: ^Camera, mode: c.int) --- // Update camera position for selected mode
+	UpdateCameraPro :: proc(camera: ^Camera, movement: Vector3, rotation: Vector3, zoom: c.float) --- // Update camera movement/rotation
 
 	//------------------------------------------------------------------------------------
 	// Basic Shapes Drawing Functions (Module: shapes)
@@ -1129,434 +1129,434 @@ foreign lib {
 	GetShapesTextureRectangle :: proc() -> Rectangle ---                         // Get texture source rectangle that is used for shapes drawing
 
 	// Basic shapes drawing functions
-	DrawPixel                   :: proc(posX: i32, posY: i32, color: Color) ---               // Draw a pixel using geometry [Can be slow, use with care]
+	DrawPixel                   :: proc(posX: c.int, posY: c.int, color: Color) ---           // Draw a pixel using geometry [Can be slow, use with care]
 	DrawPixelV                  :: proc(position: Vector2, color: Color) ---                  // Draw a pixel using geometry (Vector version) [Can be slow, use with care]
-	DrawLine                    :: proc(startPosX: i32, startPosY: i32, endPosX: i32, endPosY: i32, color: Color) --- // Draw a line
+	DrawLine                    :: proc(startPosX: c.int, startPosY: c.int, endPosX: c.int, endPosY: c.int, color: Color) --- // Draw a line
 	DrawLineV                   :: proc(startPos: Vector2, endPos: Vector2, color: Color) --- // Draw a line (using gl lines)
-	DrawLineEx                  :: proc(startPos: Vector2, endPos: Vector2, thick: f32, color: Color) --- // Draw a line (using triangles/quads)
-	DrawLineStrip               :: proc(points: ^Vector2, pointCount: i32, color: Color) ---  // Draw lines sequence (using gl lines)
-	DrawLineBezier              :: proc(startPos: Vector2, endPos: Vector2, thick: f32, color: Color) --- // Draw line segment cubic-bezier in-out interpolation
-	DrawCircle                  :: proc(centerX: i32, centerY: i32, radius: f32, color: Color) --- // Draw a color-filled circle
-	DrawCircleSector            :: proc(center: Vector2, radius: f32, startAngle: f32, endAngle: f32, segments: i32, color: Color) --- // Draw a piece of a circle
-	DrawCircleSectorLines       :: proc(center: Vector2, radius: f32, startAngle: f32, endAngle: f32, segments: i32, color: Color) --- // Draw circle sector outline
-	DrawCircleGradient          :: proc(centerX: i32, centerY: i32, radius: f32, inner: Color, outer: Color) --- // Draw a gradient-filled circle
-	DrawCircleV                 :: proc(center: Vector2, radius: f32, color: Color) ---       // Draw a color-filled circle (Vector version)
-	DrawCircleLines             :: proc(centerX: i32, centerY: i32, radius: f32, color: Color) --- // Draw circle outline
-	DrawCircleLinesV            :: proc(center: Vector2, radius: f32, color: Color) ---       // Draw circle outline (Vector version)
-	DrawEllipse                 :: proc(centerX: i32, centerY: i32, radiusH: f32, radiusV: f32, color: Color) --- // Draw ellipse
-	DrawEllipseLines            :: proc(centerX: i32, centerY: i32, radiusH: f32, radiusV: f32, color: Color) --- // Draw ellipse outline
-	DrawRing                    :: proc(center: Vector2, innerRadius: f32, outerRadius: f32, startAngle: f32, endAngle: f32, segments: i32, color: Color) --- // Draw ring
-	DrawRingLines               :: proc(center: Vector2, innerRadius: f32, outerRadius: f32, startAngle: f32, endAngle: f32, segments: i32, color: Color) --- // Draw ring outline
-	DrawRectangle               :: proc(posX: i32, posY: i32, width: i32, height: i32, color: Color) --- // Draw a color-filled rectangle
+	DrawLineEx                  :: proc(startPos: Vector2, endPos: Vector2, thick: c.float, color: Color) --- // Draw a line (using triangles/quads)
+	DrawLineStrip               :: proc(points: ^Vector2, pointCount: c.int, color: Color) --- // Draw lines sequence (using gl lines)
+	DrawLineBezier              :: proc(startPos: Vector2, endPos: Vector2, thick: c.float, color: Color) --- // Draw line segment cubic-bezier in-out interpolation
+	DrawCircle                  :: proc(centerX: c.int, centerY: c.int, radius: c.float, color: Color) --- // Draw a color-filled circle
+	DrawCircleSector            :: proc(center: Vector2, radius: c.float, startAngle: c.float, endAngle: c.float, segments: c.int, color: Color) --- // Draw a piece of a circle
+	DrawCircleSectorLines       :: proc(center: Vector2, radius: c.float, startAngle: c.float, endAngle: c.float, segments: c.int, color: Color) --- // Draw circle sector outline
+	DrawCircleGradient          :: proc(centerX: c.int, centerY: c.int, radius: c.float, inner: Color, outer: Color) --- // Draw a gradient-filled circle
+	DrawCircleV                 :: proc(center: Vector2, radius: c.float, color: Color) ---   // Draw a color-filled circle (Vector version)
+	DrawCircleLines             :: proc(centerX: c.int, centerY: c.int, radius: c.float, color: Color) --- // Draw circle outline
+	DrawCircleLinesV            :: proc(center: Vector2, radius: c.float, color: Color) ---   // Draw circle outline (Vector version)
+	DrawEllipse                 :: proc(centerX: c.int, centerY: c.int, radiusH: c.float, radiusV: c.float, color: Color) --- // Draw ellipse
+	DrawEllipseLines            :: proc(centerX: c.int, centerY: c.int, radiusH: c.float, radiusV: c.float, color: Color) --- // Draw ellipse outline
+	DrawRing                    :: proc(center: Vector2, innerRadius: c.float, outerRadius: c.float, startAngle: c.float, endAngle: c.float, segments: c.int, color: Color) --- // Draw ring
+	DrawRingLines               :: proc(center: Vector2, innerRadius: c.float, outerRadius: c.float, startAngle: c.float, endAngle: c.float, segments: c.int, color: Color) --- // Draw ring outline
+	DrawRectangle               :: proc(posX: c.int, posY: c.int, width: c.int, height: c.int, color: Color) --- // Draw a color-filled rectangle
 	DrawRectangleV              :: proc(position: Vector2, size: Vector2, color: Color) ---   // Draw a color-filled rectangle (Vector version)
 	DrawRectangleRec            :: proc(rec: Rectangle, color: Color) ---                     // Draw a color-filled rectangle
-	DrawRectanglePro            :: proc(rec: Rectangle, origin: Vector2, rotation: f32, color: Color) --- // Draw a color-filled rectangle with pro parameters
-	DrawRectangleGradientV      :: proc(posX: i32, posY: i32, width: i32, height: i32, top: Color, bottom: Color) --- // Draw a vertical-gradient-filled rectangle
-	DrawRectangleGradientH      :: proc(posX: i32, posY: i32, width: i32, height: i32, left: Color, right: Color) --- // Draw a horizontal-gradient-filled rectangle
+	DrawRectanglePro            :: proc(rec: Rectangle, origin: Vector2, rotation: c.float, color: Color) --- // Draw a color-filled rectangle with pro parameters
+	DrawRectangleGradientV      :: proc(posX: c.int, posY: c.int, width: c.int, height: c.int, top: Color, bottom: Color) --- // Draw a vertical-gradient-filled rectangle
+	DrawRectangleGradientH      :: proc(posX: c.int, posY: c.int, width: c.int, height: c.int, left: Color, right: Color) --- // Draw a horizontal-gradient-filled rectangle
 	DrawRectangleGradientEx     :: proc(rec: Rectangle, topLeft: Color, bottomLeft: Color, topRight: Color, bottomRight: Color) --- // Draw a gradient-filled rectangle with custom vertex colors
-	DrawRectangleLines          :: proc(posX: i32, posY: i32, width: i32, height: i32, color: Color) --- // Draw rectangle outline
-	DrawRectangleLinesEx        :: proc(rec: Rectangle, lineThick: f32, color: Color) ---     // Draw rectangle outline with extended parameters
-	DrawRectangleRounded        :: proc(rec: Rectangle, roundness: f32, segments: i32, color: Color) --- // Draw rectangle with rounded edges
-	DrawRectangleRoundedLines   :: proc(rec: Rectangle, roundness: f32, segments: i32, color: Color) --- // Draw rectangle lines with rounded edges
-	DrawRectangleRoundedLinesEx :: proc(rec: Rectangle, roundness: f32, segments: i32, lineThick: f32, color: Color) --- // Draw rectangle with rounded edges outline
+	DrawRectangleLines          :: proc(posX: c.int, posY: c.int, width: c.int, height: c.int, color: Color) --- // Draw rectangle outline
+	DrawRectangleLinesEx        :: proc(rec: Rectangle, lineThick: c.float, color: Color) --- // Draw rectangle outline with extended parameters
+	DrawRectangleRounded        :: proc(rec: Rectangle, roundness: c.float, segments: c.int, color: Color) --- // Draw rectangle with rounded edges
+	DrawRectangleRoundedLines   :: proc(rec: Rectangle, roundness: c.float, segments: c.int, color: Color) --- // Draw rectangle lines with rounded edges
+	DrawRectangleRoundedLinesEx :: proc(rec: Rectangle, roundness: c.float, segments: c.int, lineThick: c.float, color: Color) --- // Draw rectangle with rounded edges outline
 	DrawTriangle                :: proc(v1: Vector2, v2: Vector2, v3: Vector2, color: Color) --- // Draw a color-filled triangle (vertex in counter-clockwise order!)
 	DrawTriangleLines           :: proc(v1: Vector2, v2: Vector2, v3: Vector2, color: Color) --- // Draw triangle outline (vertex in counter-clockwise order!)
-	DrawTriangleFan             :: proc(points: ^Vector2, pointCount: i32, color: Color) ---  // Draw a triangle fan defined by points (first vertex is the center)
-	DrawTriangleStrip           :: proc(points: ^Vector2, pointCount: i32, color: Color) ---  // Draw a triangle strip defined by points
-	DrawPoly                    :: proc(center: Vector2, sides: i32, radius: f32, rotation: f32, color: Color) --- // Draw a regular polygon (Vector version)
-	DrawPolyLines               :: proc(center: Vector2, sides: i32, radius: f32, rotation: f32, color: Color) --- // Draw a polygon outline of n sides
-	DrawPolyLinesEx             :: proc(center: Vector2, sides: i32, radius: f32, rotation: f32, lineThick: f32, color: Color) --- // Draw a polygon outline of n sides with extended parameters
+	DrawTriangleFan             :: proc(points: ^Vector2, pointCount: c.int, color: Color) --- // Draw a triangle fan defined by points (first vertex is the center)
+	DrawTriangleStrip           :: proc(points: ^Vector2, pointCount: c.int, color: Color) --- // Draw a triangle strip defined by points
+	DrawPoly                    :: proc(center: Vector2, sides: c.int, radius: c.float, rotation: c.float, color: Color) --- // Draw a regular polygon (Vector version)
+	DrawPolyLines               :: proc(center: Vector2, sides: c.int, radius: c.float, rotation: c.float, color: Color) --- // Draw a polygon outline of n sides
+	DrawPolyLinesEx             :: proc(center: Vector2, sides: c.int, radius: c.float, rotation: c.float, lineThick: c.float, color: Color) --- // Draw a polygon outline of n sides with extended parameters
 
 	// Splines drawing functions
-	DrawSplineLinear                 :: proc(points: ^Vector2, pointCount: i32, thick: f32, color: Color) --- // Draw spline: Linear, minimum 2 points
-	DrawSplineBasis                  :: proc(points: ^Vector2, pointCount: i32, thick: f32, color: Color) --- // Draw spline: B-Spline, minimum 4 points
-	DrawSplineCatmullRom             :: proc(points: ^Vector2, pointCount: i32, thick: f32, color: Color) --- // Draw spline: Catmull-Rom, minimum 4 points
-	DrawSplineBezierQuadratic        :: proc(points: ^Vector2, pointCount: i32, thick: f32, color: Color) --- // Draw spline: Quadratic Bezier, minimum 3 points (1 control point): [p1, c2, p3, c4...]
-	DrawSplineBezierCubic            :: proc(points: ^Vector2, pointCount: i32, thick: f32, color: Color) --- // Draw spline: Cubic Bezier, minimum 4 points (2 control points): [p1, c2, c3, p4, c5, c6...]
-	DrawSplineSegmentLinear          :: proc(p1: Vector2, p2: Vector2, thick: f32, color: Color) --- // Draw spline segment: Linear, 2 points
-	DrawSplineSegmentBasis           :: proc(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, thick: f32, color: Color) --- // Draw spline segment: B-Spline, 4 points
-	DrawSplineSegmentCatmullRom      :: proc(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, thick: f32, color: Color) --- // Draw spline segment: Catmull-Rom, 4 points
-	DrawSplineSegmentBezierQuadratic :: proc(p1: Vector2, c2: Vector2, p3: Vector2, thick: f32, color: Color) --- // Draw spline segment: Quadratic Bezier, 2 points, 1 control point
-	DrawSplineSegmentBezierCubic     :: proc(p1: Vector2, c2: Vector2, c3: Vector2, p4: Vector2, thick: f32, color: Color) --- // Draw spline segment: Cubic Bezier, 2 points, 2 control points
+	DrawSplineLinear                 :: proc(points: ^Vector2, pointCount: c.int, thick: c.float, color: Color) --- // Draw spline: Linear, minimum 2 points
+	DrawSplineBasis                  :: proc(points: ^Vector2, pointCount: c.int, thick: c.float, color: Color) --- // Draw spline: B-Spline, minimum 4 points
+	DrawSplineCatmullRom             :: proc(points: ^Vector2, pointCount: c.int, thick: c.float, color: Color) --- // Draw spline: Catmull-Rom, minimum 4 points
+	DrawSplineBezierQuadratic        :: proc(points: ^Vector2, pointCount: c.int, thick: c.float, color: Color) --- // Draw spline: Quadratic Bezier, minimum 3 points (1 control point): [p1, c2, p3, c4...]
+	DrawSplineBezierCubic            :: proc(points: ^Vector2, pointCount: c.int, thick: c.float, color: Color) --- // Draw spline: Cubic Bezier, minimum 4 points (2 control points): [p1, c2, c3, p4, c5, c6...]
+	DrawSplineSegmentLinear          :: proc(p1: Vector2, p2: Vector2, thick: c.float, color: Color) --- // Draw spline segment: Linear, 2 points
+	DrawSplineSegmentBasis           :: proc(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, thick: c.float, color: Color) --- // Draw spline segment: B-Spline, 4 points
+	DrawSplineSegmentCatmullRom      :: proc(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, thick: c.float, color: Color) --- // Draw spline segment: Catmull-Rom, 4 points
+	DrawSplineSegmentBezierQuadratic :: proc(p1: Vector2, c2: Vector2, p3: Vector2, thick: c.float, color: Color) --- // Draw spline segment: Quadratic Bezier, 2 points, 1 control point
+	DrawSplineSegmentBezierCubic     :: proc(p1: Vector2, c2: Vector2, c3: Vector2, p4: Vector2, thick: c.float, color: Color) --- // Draw spline segment: Cubic Bezier, 2 points, 2 control points
 
 	// Spline segment point evaluation functions, for a given t [0.0f .. 1.0f]
-	GetSplinePointLinear      :: proc(startPos: Vector2, endPos: Vector2, t: f32) -> Vector2 --- // Get (evaluate) spline point: Linear
-	GetSplinePointBasis       :: proc(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, t: f32) -> Vector2 --- // Get (evaluate) spline point: B-Spline
-	GetSplinePointCatmullRom  :: proc(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, t: f32) -> Vector2 --- // Get (evaluate) spline point: Catmull-Rom
-	GetSplinePointBezierQuad  :: proc(p1: Vector2, c2: Vector2, p3: Vector2, t: f32) -> Vector2 --- // Get (evaluate) spline point: Quadratic Bezier
-	GetSplinePointBezierCubic :: proc(p1: Vector2, c2: Vector2, c3: Vector2, p4: Vector2, t: f32) -> Vector2 --- // Get (evaluate) spline point: Cubic Bezier
+	GetSplinePointLinear      :: proc(startPos: Vector2, endPos: Vector2, t: c.float) -> Vector2 --- // Get (evaluate) spline point: Linear
+	GetSplinePointBasis       :: proc(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, t: c.float) -> Vector2 --- // Get (evaluate) spline point: B-Spline
+	GetSplinePointCatmullRom  :: proc(p1: Vector2, p2: Vector2, p3: Vector2, p4: Vector2, t: c.float) -> Vector2 --- // Get (evaluate) spline point: Catmull-Rom
+	GetSplinePointBezierQuad  :: proc(p1: Vector2, c2: Vector2, p3: Vector2, t: c.float) -> Vector2 --- // Get (evaluate) spline point: Quadratic Bezier
+	GetSplinePointBezierCubic :: proc(p1: Vector2, c2: Vector2, c3: Vector2, p4: Vector2, t: c.float) -> Vector2 --- // Get (evaluate) spline point: Cubic Bezier
 
 	// Basic shapes collision detection functions
-	CheckCollisionRecs          :: proc(rec1: Rectangle, rec2: Rectangle) -> bool ---      // Check collision between two rectangles
-	CheckCollisionCircles       :: proc(center1: Vector2, radius1: f32, center2: Vector2, radius2: f32) -> bool --- // Check collision between two circles
-	CheckCollisionCircleRec     :: proc(center: Vector2, radius: f32, rec: Rectangle) -> bool --- // Check collision between circle and rectangle
-	CheckCollisionCircleLine    :: proc(center: Vector2, radius: f32, p1: Vector2, p2: Vector2) -> bool --- // Check if circle collides with a line created betweeen two points [p1] and [p2]
-	CheckCollisionPointRec      :: proc(point: Vector2, rec: Rectangle) -> bool ---        // Check if point is inside rectangle
-	CheckCollisionPointCircle   :: proc(point: Vector2, center: Vector2, radius: f32) -> bool --- // Check if point is inside circle
-	CheckCollisionPointTriangle :: proc(point: Vector2, p1: Vector2, p2: Vector2, p3: Vector2) -> bool --- // Check if point is inside a triangle
-	CheckCollisionPointLine     :: proc(point: Vector2, p1: Vector2, p2: Vector2, threshold: i32) -> bool --- // Check if point belongs to line created between two points [p1] and [p2] with defined margin in pixels [threshold]
-	CheckCollisionPointPoly     :: proc(point: Vector2, points: ^Vector2, pointCount: i32) -> bool --- // Check if point is within a polygon described by array of vertices
-	CheckCollisionLines         :: proc(startPos1: Vector2, endPos1: Vector2, startPos2: Vector2, endPos2: Vector2, collisionPoint: ^Vector2) -> bool --- // Check the collision between two lines defined by two points each, returns collision point by reference
+	CheckCollisionRecs          :: proc(rec1: Rectangle, rec2: Rectangle) -> c.bool ---    // Check collision between two rectangles
+	CheckCollisionCircles       :: proc(center1: Vector2, radius1: c.float, center2: Vector2, radius2: c.float) -> c.bool --- // Check collision between two circles
+	CheckCollisionCircleRec     :: proc(center: Vector2, radius: c.float, rec: Rectangle) -> c.bool --- // Check collision between circle and rectangle
+	CheckCollisionCircleLine    :: proc(center: Vector2, radius: c.float, p1: Vector2, p2: Vector2) -> c.bool --- // Check if circle collides with a line created betweeen two points [p1] and [p2]
+	CheckCollisionPointRec      :: proc(point: Vector2, rec: Rectangle) -> c.bool ---      // Check if point is inside rectangle
+	CheckCollisionPointCircle   :: proc(point: Vector2, center: Vector2, radius: c.float) -> c.bool --- // Check if point is inside circle
+	CheckCollisionPointTriangle :: proc(point: Vector2, p1: Vector2, p2: Vector2, p3: Vector2) -> c.bool --- // Check if point is inside a triangle
+	CheckCollisionPointLine     :: proc(point: Vector2, p1: Vector2, p2: Vector2, threshold: c.int) -> c.bool --- // Check if point belongs to line created between two points [p1] and [p2] with defined margin in pixels [threshold]
+	CheckCollisionPointPoly     :: proc(point: Vector2, points: ^Vector2, pointCount: c.int) -> c.bool --- // Check if point is within a polygon described by array of vertices
+	CheckCollisionLines         :: proc(startPos1: Vector2, endPos1: Vector2, startPos2: Vector2, endPos2: Vector2, collisionPoint: ^Vector2) -> c.bool --- // Check the collision between two lines defined by two points each, returns collision point by reference
 	GetCollisionRec             :: proc(rec1: Rectangle, rec2: Rectangle) -> Rectangle --- // Get collision rectangle for two rectangles collision
 
 	// Image loading functions
 	// NOTE: These functions do not require GPU access
-	LoadImage               :: proc(fileName: cstring) -> Image ---               // Load image from file into CPU memory (RAM)
-	LoadImageRaw            :: proc(fileName: cstring, width: i32, height: i32, format: i32, headerSize: i32) -> Image --- // Load image from RAW file data
-	LoadImageAnim           :: proc(fileName: cstring, frames: ^i32) -> Image --- // Load image sequence from file (frames appended to image.data)
-	LoadImageAnimFromMemory :: proc(fileType: cstring, fileData: ^u8, dataSize: i32, frames: ^i32) -> Image --- // Load image sequence from memory buffer
-	LoadImageFromMemory     :: proc(fileType: cstring, fileData: ^u8, dataSize: i32) -> Image --- // Load image from memory buffer, fileType refers to extension: i.e. '.png'
-	LoadImageFromTexture    :: proc(texture: Texture2D) -> Image ---              // Load image from GPU texture data
-	LoadImageFromScreen     :: proc() -> Image ---                                // Load image from screen buffer and (screenshot)
-	IsImageValid            :: proc(image: Image) -> bool ---                     // Check if an image is valid (data and parameters)
-	UnloadImage             :: proc(image: Image) ---                             // Unload image from CPU memory (RAM)
-	ExportImage             :: proc(image: Image, fileName: cstring) -> bool ---  // Export image data to file, returns true on success
-	ExportImageToMemory     :: proc(image: Image, fileType: cstring, fileSize: ^i32) -> ^u8 --- // Export image to memory buffer
-	ExportImageAsCode       :: proc(image: Image, fileName: cstring) -> bool ---  // Export image as code file defining an array of bytes, returns true on success
+	LoadImage               :: proc(fileName: cstring) -> Image ---                 // Load image from file into CPU memory (RAM)
+	LoadImageRaw            :: proc(fileName: cstring, width: c.int, height: c.int, format: c.int, headerSize: c.int) -> Image --- // Load image from RAW file data
+	LoadImageAnim           :: proc(fileName: cstring, frames: ^c.int) -> Image --- // Load image sequence from file (frames appended to image.data)
+	LoadImageAnimFromMemory :: proc(fileType: cstring, fileData: ^c.uchar, dataSize: c.int, frames: ^c.int) -> Image --- // Load image sequence from memory buffer
+	LoadImageFromMemory     :: proc(fileType: cstring, fileData: ^c.uchar, dataSize: c.int) -> Image --- // Load image from memory buffer, fileType refers to extension: i.e. '.png'
+	LoadImageFromTexture    :: proc(texture: Texture2D) -> Image ---                // Load image from GPU texture data
+	LoadImageFromScreen     :: proc() -> Image ---                                  // Load image from screen buffer and (screenshot)
+	IsImageValid            :: proc(image: Image) -> c.bool ---                     // Check if an image is valid (data and parameters)
+	UnloadImage             :: proc(image: Image) ---                               // Unload image from CPU memory (RAM)
+	ExportImage             :: proc(image: Image, fileName: cstring) -> c.bool ---  // Export image data to file, returns true on success
+	ExportImageToMemory     :: proc(image: Image, fileType: cstring, fileSize: ^c.int) -> ^c.uchar --- // Export image to memory buffer
+	ExportImageAsCode       :: proc(image: Image, fileName: cstring) -> c.bool ---  // Export image as code file defining an array of bytes, returns true on success
 
 	// Image generation functions
-	GenImageColor          :: proc(width: i32, height: i32, color: Color) -> Image ---  // Generate image: plain color
-	GenImageGradientLinear :: proc(width: i32, height: i32, direction: i32, start: Color, end: Color) -> Image --- // Generate image: linear gradient, direction in degrees [0..360], 0=Vertical gradient
-	GenImageGradientRadial :: proc(width: i32, height: i32, density: f32, inner: Color, outer: Color) -> Image --- // Generate image: radial gradient
-	GenImageGradientSquare :: proc(width: i32, height: i32, density: f32, inner: Color, outer: Color) -> Image --- // Generate image: square gradient
-	GenImageChecked        :: proc(width: i32, height: i32, checksX: i32, checksY: i32, col1: Color, col2: Color) -> Image --- // Generate image: checked
-	GenImageWhiteNoise     :: proc(width: i32, height: i32, factor: f32) -> Image ---   // Generate image: white noise
-	GenImagePerlinNoise    :: proc(width: i32, height: i32, offsetX: i32, offsetY: i32, scale: f32) -> Image --- // Generate image: perlin noise
-	GenImageCellular       :: proc(width: i32, height: i32, tileSize: i32) -> Image --- // Generate image: cellular algorithm, bigger tileSize means bigger cells
-	GenImageText           :: proc(width: i32, height: i32, text: cstring) -> Image --- // Generate image: grayscale image from text data
+	GenImageColor          :: proc(width: c.int, height: c.int, color: Color) -> Image ---    // Generate image: plain color
+	GenImageGradientLinear :: proc(width: c.int, height: c.int, direction: c.int, start: Color, end: Color) -> Image --- // Generate image: linear gradient, direction in degrees [0..360], 0=Vertical gradient
+	GenImageGradientRadial :: proc(width: c.int, height: c.int, density: c.float, inner: Color, outer: Color) -> Image --- // Generate image: radial gradient
+	GenImageGradientSquare :: proc(width: c.int, height: c.int, density: c.float, inner: Color, outer: Color) -> Image --- // Generate image: square gradient
+	GenImageChecked        :: proc(width: c.int, height: c.int, checksX: c.int, checksY: c.int, col1: Color, col2: Color) -> Image --- // Generate image: checked
+	GenImageWhiteNoise     :: proc(width: c.int, height: c.int, factor: c.float) -> Image --- // Generate image: white noise
+	GenImagePerlinNoise    :: proc(width: c.int, height: c.int, offsetX: c.int, offsetY: c.int, scale: c.float) -> Image --- // Generate image: perlin noise
+	GenImageCellular       :: proc(width: c.int, height: c.int, tileSize: c.int) -> Image --- // Generate image: cellular algorithm, bigger tileSize means bigger cells
+	GenImageText           :: proc(width: c.int, height: c.int, text: cstring) -> Image ---   // Generate image: grayscale image from text data
 
 	// Image manipulation functions
-	ImageCopy              :: proc(image: Image) -> Image ---                               // Create an image duplicate (useful for transformations)
-	ImageFromImage         :: proc(image: Image, rec: Rectangle) -> Image ---               // Create an image from another image piece
-	ImageFromChannel       :: proc(image: Image, selectedChannel: i32) -> Image ---         // Create an image from a selected channel of another image (GRAYSCALE)
-	ImageText              :: proc(text: cstring, fontSize: i32, color: Color) -> Image --- // Create an image from text (default font)
-	ImageTextEx            :: proc(font: Font, text: cstring, fontSize: f32, spacing: f32, tint: Color) -> Image --- // Create an image from text (custom sprite font)
-	ImageFormat            :: proc(image: ^Image, newFormat: i32) ---                       // Convert image data to desired format
-	ImageToPOT             :: proc(image: ^Image, fill: Color) ---                          // Convert image to POT (power-of-two)
-	ImageCrop              :: proc(image: ^Image, crop: Rectangle) ---                      // Crop an image to a defined rectangle
-	ImageAlphaCrop         :: proc(image: ^Image, threshold: f32) ---                       // Crop image depending on alpha value
-	ImageAlphaClear        :: proc(image: ^Image, color: Color, threshold: f32) ---         // Clear alpha channel to desired color
-	ImageAlphaMask         :: proc(image: ^Image, alphaMask: Image) ---                     // Apply alpha mask to image
-	ImageAlphaPremultiply  :: proc(image: ^Image) ---                                       // Premultiply alpha channel
-	ImageBlurGaussian      :: proc(image: ^Image, blurSize: i32) ---                        // Apply Gaussian blur using a box blur approximation
-	ImageKernelConvolution :: proc(image: ^Image, kernel: ^f32, kernelSize: i32) ---        // Apply custom square convolution kernel to image
-	ImageResize            :: proc(image: ^Image, newWidth: i32, newHeight: i32) ---        // Resize image (Bicubic scaling algorithm)
-	ImageResizeNN          :: proc(image: ^Image, newWidth: i32, newHeight: i32) ---        // Resize image (Nearest-Neighbor scaling algorithm)
-	ImageResizeCanvas      :: proc(image: ^Image, newWidth: i32, newHeight: i32, offsetX: i32, offsetY: i32, fill: Color) --- // Resize canvas and fill with color
-	ImageMipmaps           :: proc(image: ^Image) ---                                       // Compute all mipmap levels for a provided image
-	ImageDither            :: proc(image: ^Image, rBpp: i32, gBpp: i32, bBpp: i32, aBpp: i32) --- // Dither image data to 16bpp or lower (Floyd-Steinberg dithering)
-	ImageFlipVertical      :: proc(image: ^Image) ---                                       // Flip image vertically
-	ImageFlipHorizontal    :: proc(image: ^Image) ---                                       // Flip image horizontally
-	ImageRotate            :: proc(image: ^Image, degrees: i32) ---                         // Rotate image by input angle in degrees (-359 to 359)
-	ImageRotateCW          :: proc(image: ^Image) ---                                       // Rotate image clockwise 90deg
-	ImageRotateCCW         :: proc(image: ^Image) ---                                       // Rotate image counter-clockwise 90deg
-	ImageColorTint         :: proc(image: ^Image, color: Color) ---                         // Modify image color: tint
-	ImageColorInvert       :: proc(image: ^Image) ---                                       // Modify image color: invert
-	ImageColorGrayscale    :: proc(image: ^Image) ---                                       // Modify image color: grayscale
-	ImageColorContrast     :: proc(image: ^Image, contrast: f32) ---                        // Modify image color: contrast (-100 to 100)
-	ImageColorBrightness   :: proc(image: ^Image, brightness: i32) ---                      // Modify image color: brightness (-255 to 255)
-	ImageColorReplace      :: proc(image: ^Image, color: Color, replace: Color) ---         // Modify image color: replace color
-	LoadImageColors        :: proc(image: Image) -> ^Color ---                              // Load color data from image as a Color array (RGBA - 32bit)
-	LoadImagePalette       :: proc(image: Image, maxPaletteSize: i32, colorCount: ^i32) -> ^Color --- // Load colors palette from image as a Color array (RGBA - 32bit)
-	UnloadImageColors      :: proc(colors: ^Color) ---                                      // Unload color data loaded with LoadImageColors()
-	UnloadImagePalette     :: proc(colors: ^Color) ---                                      // Unload colors palette loaded with LoadImagePalette()
-	GetImageAlphaBorder    :: proc(image: Image, threshold: f32) -> Rectangle ---           // Get image alpha border rectangle
-	GetImageColor          :: proc(image: Image, x: i32, y: i32) -> Color ---               // Get image pixel color at (x, y) position
+	ImageCopy              :: proc(image: Image) -> Image ---                                 // Create an image duplicate (useful for transformations)
+	ImageFromImage         :: proc(image: Image, rec: Rectangle) -> Image ---                 // Create an image from another image piece
+	ImageFromChannel       :: proc(image: Image, selectedChannel: c.int) -> Image ---         // Create an image from a selected channel of another image (GRAYSCALE)
+	ImageText              :: proc(text: cstring, fontSize: c.int, color: Color) -> Image --- // Create an image from text (default font)
+	ImageTextEx            :: proc(font: Font, text: cstring, fontSize: c.float, spacing: c.float, tint: Color) -> Image --- // Create an image from text (custom sprite font)
+	ImageFormat            :: proc(image: ^Image, newFormat: c.int) ---                       // Convert image data to desired format
+	ImageToPOT             :: proc(image: ^Image, fill: Color) ---                            // Convert image to POT (power-of-two)
+	ImageCrop              :: proc(image: ^Image, crop: Rectangle) ---                        // Crop an image to a defined rectangle
+	ImageAlphaCrop         :: proc(image: ^Image, threshold: c.float) ---                     // Crop image depending on alpha value
+	ImageAlphaClear        :: proc(image: ^Image, color: Color, threshold: c.float) ---       // Clear alpha channel to desired color
+	ImageAlphaMask         :: proc(image: ^Image, alphaMask: Image) ---                       // Apply alpha mask to image
+	ImageAlphaPremultiply  :: proc(image: ^Image) ---                                         // Premultiply alpha channel
+	ImageBlurGaussian      :: proc(image: ^Image, blurSize: c.int) ---                        // Apply Gaussian blur using a box blur approximation
+	ImageKernelConvolution :: proc(image: ^Image, kernel: ^c.float, kernelSize: c.int) ---    // Apply custom square convolution kernel to image
+	ImageResize            :: proc(image: ^Image, newWidth: c.int, newHeight: c.int) ---      // Resize image (Bicubic scaling algorithm)
+	ImageResizeNN          :: proc(image: ^Image, newWidth: c.int, newHeight: c.int) ---      // Resize image (Nearest-Neighbor scaling algorithm)
+	ImageResizeCanvas      :: proc(image: ^Image, newWidth: c.int, newHeight: c.int, offsetX: c.int, offsetY: c.int, fill: Color) --- // Resize canvas and fill with color
+	ImageMipmaps           :: proc(image: ^Image) ---                                         // Compute all mipmap levels for a provided image
+	ImageDither            :: proc(image: ^Image, rBpp: c.int, gBpp: c.int, bBpp: c.int, aBpp: c.int) --- // Dither image data to 16bpp or lower (Floyd-Steinberg dithering)
+	ImageFlipVertical      :: proc(image: ^Image) ---                                         // Flip image vertically
+	ImageFlipHorizontal    :: proc(image: ^Image) ---                                         // Flip image horizontally
+	ImageRotate            :: proc(image: ^Image, degrees: c.int) ---                         // Rotate image by input angle in degrees (-359 to 359)
+	ImageRotateCW          :: proc(image: ^Image) ---                                         // Rotate image clockwise 90deg
+	ImageRotateCCW         :: proc(image: ^Image) ---                                         // Rotate image counter-clockwise 90deg
+	ImageColorTint         :: proc(image: ^Image, color: Color) ---                           // Modify image color: tint
+	ImageColorInvert       :: proc(image: ^Image) ---                                         // Modify image color: invert
+	ImageColorGrayscale    :: proc(image: ^Image) ---                                         // Modify image color: grayscale
+	ImageColorContrast     :: proc(image: ^Image, contrast: c.float) ---                      // Modify image color: contrast (-100 to 100)
+	ImageColorBrightness   :: proc(image: ^Image, brightness: c.int) ---                      // Modify image color: brightness (-255 to 255)
+	ImageColorReplace      :: proc(image: ^Image, color: Color, replace: Color) ---           // Modify image color: replace color
+	LoadImageColors        :: proc(image: Image) -> ^Color ---                                // Load color data from image as a Color array (RGBA - 32bit)
+	LoadImagePalette       :: proc(image: Image, maxPaletteSize: c.int, colorCount: ^c.int) -> ^Color --- // Load colors palette from image as a Color array (RGBA - 32bit)
+	UnloadImageColors      :: proc(colors: ^Color) ---                                        // Unload color data loaded with LoadImageColors()
+	UnloadImagePalette     :: proc(colors: ^Color) ---                                        // Unload colors palette loaded with LoadImagePalette()
+	GetImageAlphaBorder    :: proc(image: Image, threshold: c.float) -> Rectangle ---         // Get image alpha border rectangle
+	GetImageColor          :: proc(image: Image, x: c.int, y: c.int) -> Color ---             // Get image pixel color at (x, y) position
 
 	// Image drawing functions
 	// NOTE: Image software-rendering functions (CPU)
-	ImageClearBackground    :: proc(dst: ^Image, color: Color) ---                       // Clear image background with given color
-	ImageDrawPixel          :: proc(dst: ^Image, posX: i32, posY: i32, color: Color) --- // Draw pixel within an image
-	ImageDrawPixelV         :: proc(dst: ^Image, position: Vector2, color: Color) ---    // Draw pixel within an image (Vector version)
-	ImageDrawLine           :: proc(dst: ^Image, startPosX: i32, startPosY: i32, endPosX: i32, endPosY: i32, color: Color) --- // Draw line within an image
+	ImageClearBackground    :: proc(dst: ^Image, color: Color) ---                           // Clear image background with given color
+	ImageDrawPixel          :: proc(dst: ^Image, posX: c.int, posY: c.int, color: Color) --- // Draw pixel within an image
+	ImageDrawPixelV         :: proc(dst: ^Image, position: Vector2, color: Color) ---        // Draw pixel within an image (Vector version)
+	ImageDrawLine           :: proc(dst: ^Image, startPosX: c.int, startPosY: c.int, endPosX: c.int, endPosY: c.int, color: Color) --- // Draw line within an image
 	ImageDrawLineV          :: proc(dst: ^Image, start: Vector2, end: Vector2, color: Color) --- // Draw line within an image (Vector version)
-	ImageDrawLineEx         :: proc(dst: ^Image, start: Vector2, end: Vector2, thick: i32, color: Color) --- // Draw a line defining thickness within an image
-	ImageDrawCircle         :: proc(dst: ^Image, centerX: i32, centerY: i32, radius: i32, color: Color) --- // Draw a filled circle within an image
-	ImageDrawCircleV        :: proc(dst: ^Image, center: Vector2, radius: i32, color: Color) --- // Draw a filled circle within an image (Vector version)
-	ImageDrawCircleLines    :: proc(dst: ^Image, centerX: i32, centerY: i32, radius: i32, color: Color) --- // Draw circle outline within an image
-	ImageDrawCircleLinesV   :: proc(dst: ^Image, center: Vector2, radius: i32, color: Color) --- // Draw circle outline within an image (Vector version)
-	ImageDrawRectangle      :: proc(dst: ^Image, posX: i32, posY: i32, width: i32, height: i32, color: Color) --- // Draw rectangle within an image
+	ImageDrawLineEx         :: proc(dst: ^Image, start: Vector2, end: Vector2, thick: c.int, color: Color) --- // Draw a line defining thickness within an image
+	ImageDrawCircle         :: proc(dst: ^Image, centerX: c.int, centerY: c.int, radius: c.int, color: Color) --- // Draw a filled circle within an image
+	ImageDrawCircleV        :: proc(dst: ^Image, center: Vector2, radius: c.int, color: Color) --- // Draw a filled circle within an image (Vector version)
+	ImageDrawCircleLines    :: proc(dst: ^Image, centerX: c.int, centerY: c.int, radius: c.int, color: Color) --- // Draw circle outline within an image
+	ImageDrawCircleLinesV   :: proc(dst: ^Image, center: Vector2, radius: c.int, color: Color) --- // Draw circle outline within an image (Vector version)
+	ImageDrawRectangle      :: proc(dst: ^Image, posX: c.int, posY: c.int, width: c.int, height: c.int, color: Color) --- // Draw rectangle within an image
 	ImageDrawRectangleV     :: proc(dst: ^Image, position: Vector2, size: Vector2, color: Color) --- // Draw rectangle within an image (Vector version)
-	ImageDrawRectangleRec   :: proc(dst: ^Image, rec: Rectangle, color: Color) ---       // Draw rectangle within an image
-	ImageDrawRectangleLines :: proc(dst: ^Image, rec: Rectangle, thick: i32, color: Color) --- // Draw rectangle lines within an image
+	ImageDrawRectangleRec   :: proc(dst: ^Image, rec: Rectangle, color: Color) ---           // Draw rectangle within an image
+	ImageDrawRectangleLines :: proc(dst: ^Image, rec: Rectangle, thick: c.int, color: Color) --- // Draw rectangle lines within an image
 	ImageDrawTriangle       :: proc(dst: ^Image, v1: Vector2, v2: Vector2, v3: Vector2, color: Color) --- // Draw triangle within an image
 	ImageDrawTriangleEx     :: proc(dst: ^Image, v1: Vector2, v2: Vector2, v3: Vector2, c1: Color, c2: Color, c3: Color) --- // Draw triangle with interpolated colors within an image
 	ImageDrawTriangleLines  :: proc(dst: ^Image, v1: Vector2, v2: Vector2, v3: Vector2, color: Color) --- // Draw triangle outline within an image
-	ImageDrawTriangleFan    :: proc(dst: ^Image, points: ^Vector2, pointCount: i32, color: Color) --- // Draw a triangle fan defined by points within an image (first vertex is the center)
-	ImageDrawTriangleStrip  :: proc(dst: ^Image, points: ^Vector2, pointCount: i32, color: Color) --- // Draw a triangle strip defined by points within an image
+	ImageDrawTriangleFan    :: proc(dst: ^Image, points: ^Vector2, pointCount: c.int, color: Color) --- // Draw a triangle fan defined by points within an image (first vertex is the center)
+	ImageDrawTriangleStrip  :: proc(dst: ^Image, points: ^Vector2, pointCount: c.int, color: Color) --- // Draw a triangle strip defined by points within an image
 	ImageDraw               :: proc(dst: ^Image, src: Image, srcRec: Rectangle, dstRec: Rectangle, tint: Color) --- // Draw a source image within a destination image (tint applied to source)
-	ImageDrawText           :: proc(dst: ^Image, text: cstring, posX: i32, posY: i32, fontSize: i32, color: Color) --- // Draw text (using default font) within an image (destination)
-	ImageDrawTextEx         :: proc(dst: ^Image, font: Font, text: cstring, position: Vector2, fontSize: f32, spacing: f32, tint: Color) --- // Draw text (custom sprite font) within an image (destination)
+	ImageDrawText           :: proc(dst: ^Image, text: cstring, posX: c.int, posY: c.int, fontSize: c.int, color: Color) --- // Draw text (using default font) within an image (destination)
+	ImageDrawTextEx         :: proc(dst: ^Image, font: Font, text: cstring, position: Vector2, fontSize: c.float, spacing: c.float, tint: Color) --- // Draw text (custom sprite font) within an image (destination)
 
 	// Texture loading functions
 	// NOTE: These functions require GPU access
 	LoadTexture          :: proc(fileName: cstring) -> Texture2D ---                     // Load texture from file into GPU memory (VRAM)
 	LoadTextureFromImage :: proc(image: Image) -> Texture2D ---                          // Load texture from image data
-	LoadTextureCubemap   :: proc(image: Image, layout: i32) -> TextureCubemap ---        // Load cubemap from image, multiple image cubemap layouts supported
-	LoadRenderTexture    :: proc(width: i32, height: i32) -> RenderTexture2D ---         // Load texture for rendering (framebuffer)
-	IsTextureValid       :: proc(texture: Texture2D) -> bool ---                         // Check if a texture is valid (loaded in GPU)
+	LoadTextureCubemap   :: proc(image: Image, layout: c.int) -> TextureCubemap ---      // Load cubemap from image, multiple image cubemap layouts supported
+	LoadRenderTexture    :: proc(width: c.int, height: c.int) -> RenderTexture2D ---     // Load texture for rendering (framebuffer)
+	IsTextureValid       :: proc(texture: Texture2D) -> c.bool ---                       // Check if a texture is valid (loaded in GPU)
 	UnloadTexture        :: proc(texture: Texture2D) ---                                 // Unload texture from GPU memory (VRAM)
-	IsRenderTextureValid :: proc(target: RenderTexture2D) -> bool ---                    // Check if a render texture is valid (loaded in GPU)
+	IsRenderTextureValid :: proc(target: RenderTexture2D) -> c.bool ---                  // Check if a render texture is valid (loaded in GPU)
 	UnloadRenderTexture  :: proc(target: RenderTexture2D) ---                            // Unload render texture from GPU memory (VRAM)
 	UpdateTexture        :: proc(texture: Texture2D, pixels: rawptr) ---                 // Update GPU texture with new data
 	UpdateTextureRec     :: proc(texture: Texture2D, rec: Rectangle, pixels: rawptr) --- // Update GPU texture rectangle with new data
 
 	// Texture configuration functions
-	GenTextureMipmaps :: proc(texture: ^Texture2D) ---             // Generate GPU mipmaps for a texture
-	SetTextureFilter  :: proc(texture: Texture2D, filter: i32) --- // Set texture scaling filter mode
-	SetTextureWrap    :: proc(texture: Texture2D, wrap: i32) ---   // Set texture wrapping mode
+	GenTextureMipmaps :: proc(texture: ^Texture2D) ---               // Generate GPU mipmaps for a texture
+	SetTextureFilter  :: proc(texture: Texture2D, filter: c.int) --- // Set texture scaling filter mode
+	SetTextureWrap    :: proc(texture: Texture2D, wrap: c.int) ---   // Set texture wrapping mode
 
 	// Texture drawing functions
-	DrawTexture       :: proc(texture: Texture2D, posX: i32, posY: i32, tint: Color) --- // Draw a Texture2D
-	DrawTextureV      :: proc(texture: Texture2D, position: Vector2, tint: Color) ---    // Draw a Texture2D with position defined as Vector2
-	DrawTextureEx     :: proc(texture: Texture2D, position: Vector2, rotation: f32, scale: f32, tint: Color) --- // Draw a Texture2D with extended parameters
+	DrawTexture       :: proc(texture: Texture2D, posX: c.int, posY: c.int, tint: Color) --- // Draw a Texture2D
+	DrawTextureV      :: proc(texture: Texture2D, position: Vector2, tint: Color) ---        // Draw a Texture2D with position defined as Vector2
+	DrawTextureEx     :: proc(texture: Texture2D, position: Vector2, rotation: c.float, scale: c.float, tint: Color) --- // Draw a Texture2D with extended parameters
 	DrawTextureRec    :: proc(texture: Texture2D, source: Rectangle, position: Vector2, tint: Color) --- // Draw a part of a texture defined by a rectangle
-	DrawTexturePro    :: proc(texture: Texture2D, source: Rectangle, dest: Rectangle, origin: Vector2, rotation: f32, tint: Color) --- // Draw a part of a texture defined by a rectangle with 'pro' parameters
-	DrawTextureNPatch :: proc(texture: Texture2D, nPatchInfo: NPatchInfo, dest: Rectangle, origin: Vector2, rotation: f32, tint: Color) --- // Draws a texture (or part of it) that stretches or shrinks nicely
+	DrawTexturePro    :: proc(texture: Texture2D, source: Rectangle, dest: Rectangle, origin: Vector2, rotation: c.float, tint: Color) --- // Draw a part of a texture defined by a rectangle with 'pro' parameters
+	DrawTextureNPatch :: proc(texture: Texture2D, nPatchInfo: NPatchInfo, dest: Rectangle, origin: Vector2, rotation: c.float, tint: Color) --- // Draws a texture (or part of it) that stretches or shrinks nicely
 
 	// Color/pixel related functions
-	ColorIsEqual        :: proc(col1: Color, col2: Color) -> bool ---                   // Check if two colors are equal
-	Fade                :: proc(color: Color, alpha: f32) -> Color ---                  // Get color with alpha applied, alpha goes from 0.0f to 1.0f
-	ColorToInt          :: proc(color: Color) -> i32 ---                                // Get hexadecimal value for a Color (0xRRGGBBAA)
-	ColorNormalize      :: proc(color: Color) -> Vector4 ---                            // Get Color normalized as float [0..1]
-	ColorFromNormalized :: proc(normalized: Vector4) -> Color ---                       // Get Color from normalized values [0..1]
-	ColorToHSV          :: proc(color: Color) -> Vector3 ---                            // Get HSV values for a Color, hue [0..360], saturation/value [0..1]
-	ColorFromHSV        :: proc(hue: f32, saturation: f32, value: f32) -> Color ---     // Get a Color from HSV values, hue [0..360], saturation/value [0..1]
-	ColorTint           :: proc(color: Color, tint: Color) -> Color ---                 // Get color multiplied with another color
-	ColorBrightness     :: proc(color: Color, factor: f32) -> Color ---                 // Get color with brightness correction, brightness factor goes from -1.0f to 1.0f
-	ColorContrast       :: proc(color: Color, contrast: f32) -> Color ---               // Get color with contrast correction, contrast values between -1.0f and 1.0f
-	ColorAlpha          :: proc(color: Color, alpha: f32) -> Color ---                  // Get color with alpha applied, alpha goes from 0.0f to 1.0f
-	ColorAlphaBlend     :: proc(dst: Color, src: Color, tint: Color) -> Color ---       // Get src alpha-blended into dst color with tint
-	ColorLerp           :: proc(color1: Color, color2: Color, factor: f32) -> Color --- // Get color lerp interpolation between two colors, factor [0.0f..1.0f]
-	GetColor            :: proc(hexValue: u32) -> Color ---                             // Get Color structure from hexadecimal value
-	GetPixelColor       :: proc(srcPtr: rawptr, format: i32) -> Color ---               // Get Color from a source pixel pointer of certain format
-	SetPixelColor       :: proc(dstPtr: rawptr, color: Color, format: i32) ---          // Set color formatted into destination pixel pointer
-	GetPixelDataSize    :: proc(width: i32, height: i32, format: i32) -> i32 ---        // Get pixel data size in bytes for certain format
+	ColorIsEqual        :: proc(col1: Color, col2: Color) -> c.bool ---                     // Check if two colors are equal
+	Fade                :: proc(color: Color, alpha: c.float) -> Color ---                  // Get color with alpha applied, alpha goes from 0.0f to 1.0f
+	ColorToInt          :: proc(color: Color) -> c.int ---                                  // Get hexadecimal value for a Color (0xRRGGBBAA)
+	ColorNormalize      :: proc(color: Color) -> Vector4 ---                                // Get Color normalized as float [0..1]
+	ColorFromNormalized :: proc(normalized: Vector4) -> Color ---                           // Get Color from normalized values [0..1]
+	ColorToHSV          :: proc(color: Color) -> Vector3 ---                                // Get HSV values for a Color, hue [0..360], saturation/value [0..1]
+	ColorFromHSV        :: proc(hue: c.float, saturation: c.float, value: c.float) -> Color --- // Get a Color from HSV values, hue [0..360], saturation/value [0..1]
+	ColorTint           :: proc(color: Color, tint: Color) -> Color ---                     // Get color multiplied with another color
+	ColorBrightness     :: proc(color: Color, factor: c.float) -> Color ---                 // Get color with brightness correction, brightness factor goes from -1.0f to 1.0f
+	ColorContrast       :: proc(color: Color, contrast: c.float) -> Color ---               // Get color with contrast correction, contrast values between -1.0f and 1.0f
+	ColorAlpha          :: proc(color: Color, alpha: c.float) -> Color ---                  // Get color with alpha applied, alpha goes from 0.0f to 1.0f
+	ColorAlphaBlend     :: proc(dst: Color, src: Color, tint: Color) -> Color ---           // Get src alpha-blended into dst color with tint
+	ColorLerp           :: proc(color1: Color, color2: Color, factor: c.float) -> Color --- // Get color lerp interpolation between two colors, factor [0.0f..1.0f]
+	GetColor            :: proc(hexValue: c.uint) -> Color ---                              // Get Color structure from hexadecimal value
+	GetPixelColor       :: proc(srcPtr: rawptr, format: c.int) -> Color ---                 // Get Color from a source pixel pointer of certain format
+	SetPixelColor       :: proc(dstPtr: rawptr, color: Color, format: c.int) ---            // Set color formatted into destination pixel pointer
+	GetPixelDataSize    :: proc(width: c.int, height: c.int, format: c.int) -> c.int ---    // Get pixel data size in bytes for certain format
 
 	// Font loading/unloading functions
-	GetFontDefault     :: proc() -> Font ---                                         // Get the default Font
-	LoadFont           :: proc(fileName: cstring) -> Font ---                        // Load font from file into GPU memory (VRAM)
-	LoadFontEx         :: proc(fileName: cstring, fontSize: i32, codepoints: ^i32, codepointCount: i32) -> Font --- // Load font from file with extended parameters, use NULL for codepoints and 0 for codepointCount to load the default character set, font size is provided in pixels height
-	LoadFontFromImage  :: proc(image: Image, key: Color, firstChar: i32) -> Font --- // Load font from Image (XNA style)
-	LoadFontFromMemory :: proc(fileType: cstring, fileData: ^u8, dataSize: i32, fontSize: i32, codepoints: ^i32, codepointCount: i32) -> Font --- // Load font from memory buffer, fileType refers to extension: i.e. '.ttf'
-	IsFontValid        :: proc(font: Font) -> bool ---                               // Check if a font is valid (font data loaded, WARNING: GPU texture not checked)
-	LoadFontData       :: proc(fileData: ^u8, dataSize: i32, fontSize: i32, codepoints: ^i32, codepointCount: i32, type: i32) -> ^GlyphInfo --- // Load font data for further use
-	GenImageFontAtlas  :: proc(glyphs: ^GlyphInfo, glyphRecs: ^^Rectangle, glyphCount: i32, fontSize: i32, padding: i32, packMethod: i32) -> Image --- // Generate image font atlas using chars info
-	UnloadFontData     :: proc(glyphs: ^GlyphInfo, glyphCount: i32) ---              // Unload font chars info data (RAM)
-	UnloadFont         :: proc(font: Font) ---                                       // Unload font from GPU memory (VRAM)
-	ExportFontAsCode   :: proc(font: Font, fileName: cstring) -> bool ---            // Export font as code file, returns true on success
+	GetFontDefault     :: proc() -> Font ---                                           // Get the default Font
+	LoadFont           :: proc(fileName: cstring) -> Font ---                          // Load font from file into GPU memory (VRAM)
+	LoadFontEx         :: proc(fileName: cstring, fontSize: c.int, codepoints: ^c.int, codepointCount: c.int) -> Font --- // Load font from file with extended parameters, use NULL for codepoints and 0 for codepointCount to load the default character set, font size is provided in pixels height
+	LoadFontFromImage  :: proc(image: Image, key: Color, firstChar: c.int) -> Font --- // Load font from Image (XNA style)
+	LoadFontFromMemory :: proc(fileType: cstring, fileData: ^c.uchar, dataSize: c.int, fontSize: c.int, codepoints: ^c.int, codepointCount: c.int) -> Font --- // Load font from memory buffer, fileType refers to extension: i.e. '.ttf'
+	IsFontValid        :: proc(font: Font) -> c.bool ---                               // Check if a font is valid (font data loaded, WARNING: GPU texture not checked)
+	LoadFontData       :: proc(fileData: ^c.uchar, dataSize: c.int, fontSize: c.int, codepoints: ^c.int, codepointCount: c.int, type: c.int) -> ^GlyphInfo --- // Load font data for further use
+	GenImageFontAtlas  :: proc(glyphs: ^GlyphInfo, glyphRecs: ^^Rectangle, glyphCount: c.int, fontSize: c.int, padding: c.int, packMethod: c.int) -> Image --- // Generate image font atlas using chars info
+	UnloadFontData     :: proc(glyphs: ^GlyphInfo, glyphCount: c.int) ---              // Unload font chars info data (RAM)
+	UnloadFont         :: proc(font: Font) ---                                         // Unload font from GPU memory (VRAM)
+	ExportFontAsCode   :: proc(font: Font, fileName: cstring) -> c.bool ---            // Export font as code file, returns true on success
 
 	// Text drawing functions
-	DrawFPS            :: proc(posX: i32, posY: i32) --- // Draw current FPS
-	DrawText           :: proc(text: cstring, posX: i32, posY: i32, fontSize: i32, color: Color) --- // Draw text (using default font)
-	DrawTextEx         :: proc(font: Font, text: cstring, position: Vector2, fontSize: f32, spacing: f32, tint: Color) --- // Draw text using font and additional parameters
-	DrawTextPro        :: proc(font: Font, text: cstring, position: Vector2, origin: Vector2, rotation: f32, fontSize: f32, spacing: f32, tint: Color) --- // Draw text using Font and pro parameters (rotation)
-	DrawTextCodepoint  :: proc(font: Font, codepoint: i32, position: Vector2, fontSize: f32, tint: Color) --- // Draw one character (codepoint)
-	DrawTextCodepoints :: proc(font: Font, codepoints: ^i32, codepointCount: i32, position: Vector2, fontSize: f32, spacing: f32, tint: Color) --- // Draw multiple character (codepoint)
+	DrawFPS            :: proc(posX: c.int, posY: c.int) --- // Draw current FPS
+	DrawText           :: proc(text: cstring, posX: c.int, posY: c.int, fontSize: c.int, color: Color) --- // Draw text (using default font)
+	DrawTextEx         :: proc(font: Font, text: cstring, position: Vector2, fontSize: c.float, spacing: c.float, tint: Color) --- // Draw text using font and additional parameters
+	DrawTextPro        :: proc(font: Font, text: cstring, position: Vector2, origin: Vector2, rotation: c.float, fontSize: c.float, spacing: c.float, tint: Color) --- // Draw text using Font and pro parameters (rotation)
+	DrawTextCodepoint  :: proc(font: Font, codepoint: c.int, position: Vector2, fontSize: c.float, tint: Color) --- // Draw one character (codepoint)
+	DrawTextCodepoints :: proc(font: Font, codepoints: ^c.int, codepointCount: c.int, position: Vector2, fontSize: c.float, spacing: c.float, tint: Color) --- // Draw multiple character (codepoint)
 
 	// Text font info functions
-	SetTextLineSpacing :: proc(spacing: i32) ---                            // Set vertical line spacing when drawing with line-breaks
-	MeasureText        :: proc(text: cstring, fontSize: i32) -> i32 ---     // Measure string width for default font
-	MeasureTextEx      :: proc(font: Font, text: cstring, fontSize: f32, spacing: f32) -> Vector2 --- // Measure string size for Font
-	GetGlyphIndex      :: proc(font: Font, codepoint: i32) -> i32 ---       // Get glyph index position in font for a codepoint (unicode character), fallback to '?' if not found
-	GetGlyphInfo       :: proc(font: Font, codepoint: i32) -> GlyphInfo --- // Get glyph font info data for a codepoint (unicode character), fallback to '?' if not found
-	GetGlyphAtlasRec   :: proc(font: Font, codepoint: i32) -> Rectangle --- // Get glyph rectangle in font atlas for a codepoint (unicode character), fallback to '?' if not found
+	SetTextLineSpacing :: proc(spacing: c.int) ---                            // Set vertical line spacing when drawing with line-breaks
+	MeasureText        :: proc(text: cstring, fontSize: c.int) -> c.int ---   // Measure string width for default font
+	MeasureTextEx      :: proc(font: Font, text: cstring, fontSize: c.float, spacing: c.float) -> Vector2 --- // Measure string size for Font
+	GetGlyphIndex      :: proc(font: Font, codepoint: c.int) -> c.int ---     // Get glyph index position in font for a codepoint (unicode character), fallback to '?' if not found
+	GetGlyphInfo       :: proc(font: Font, codepoint: c.int) -> GlyphInfo --- // Get glyph font info data for a codepoint (unicode character), fallback to '?' if not found
+	GetGlyphAtlasRec   :: proc(font: Font, codepoint: c.int) -> Rectangle --- // Get glyph rectangle in font atlas for a codepoint (unicode character), fallback to '?' if not found
 
 	// Text codepoints management functions (unicode characters)
-	LoadUTF8             :: proc(codepoints: ^i32, length: i32) -> cstring ---  // Load UTF-8 text encoded from codepoints array
-	UnloadUTF8           :: proc(text: cstring) ---                             // Unload UTF-8 text encoded from codepoints array
-	LoadCodepoints       :: proc(text: cstring, count: ^i32) -> ^i32 ---        // Load all codepoints from a UTF-8 text string, codepoints count returned by parameter
-	UnloadCodepoints     :: proc(codepoints: ^i32) ---                          // Unload codepoints data from memory
-	GetCodepointCount    :: proc(text: cstring) -> i32 ---                      // Get total number of codepoints in a UTF-8 encoded string
-	GetCodepoint         :: proc(text: cstring, codepointSize: ^i32) -> i32 --- // Get next codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
-	GetCodepointNext     :: proc(text: cstring, codepointSize: ^i32) -> i32 --- // Get next codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
-	GetCodepointPrevious :: proc(text: cstring, codepointSize: ^i32) -> i32 --- // Get previous codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
-	CodepointToUTF8      :: proc(codepoint: i32, utf8Size: ^i32) -> cstring --- // Encode one codepoint into UTF-8 byte array (array length returned as parameter)
+	LoadUTF8             :: proc(codepoints: ^c.int, length: c.int) -> cstring ---  // Load UTF-8 text encoded from codepoints array
+	UnloadUTF8           :: proc(text: cstring) ---                                 // Unload UTF-8 text encoded from codepoints array
+	LoadCodepoints       :: proc(text: cstring, count: ^c.int) -> ^c.int ---        // Load all codepoints from a UTF-8 text string, codepoints count returned by parameter
+	UnloadCodepoints     :: proc(codepoints: ^c.int) ---                            // Unload codepoints data from memory
+	GetCodepointCount    :: proc(text: cstring) -> c.int ---                        // Get total number of codepoints in a UTF-8 encoded string
+	GetCodepoint         :: proc(text: cstring, codepointSize: ^c.int) -> c.int --- // Get next codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
+	GetCodepointNext     :: proc(text: cstring, codepointSize: ^c.int) -> c.int --- // Get next codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
+	GetCodepointPrevious :: proc(text: cstring, codepointSize: ^c.int) -> c.int --- // Get previous codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
+	CodepointToUTF8      :: proc(codepoint: c.int, utf8Size: ^c.int) -> cstring --- // Encode one codepoint into UTF-8 byte array (array length returned as parameter)
 
 	// Text strings management functions (no UTF-8 strings, only byte chars)
 	// WARNING 1: Most of these functions use internal static buffers, it's recommended to store returned data on user-side for re-use
 	// WARNING 2: Some strings allocate memory internally for the returned strings, those strings must be free by user using MemFree()
-	TextCopy      :: proc(dst: cstring, src: cstring) -> i32 ---                         // Copy one string to another, returns bytes copied
-	TextIsEqual   :: proc(text1: cstring, text2: cstring) -> bool ---                    // Check if two text string are equal
-	TextLength    :: proc(text: cstring) -> u32 ---                                      // Get text length, checks for '\0' ending
-	TextFormat    :: proc(text: cstring) -> cstring ---                                  // Text formatting with variables (sprintf() style)
-	TextSubtext   :: proc(text: cstring, position: i32, length: i32) -> cstring ---      // Get a piece of a text string
-	TextReplace   :: proc(text: cstring, replace: cstring, by: cstring) -> cstring ---   // Replace text string (WARNING: memory must be freed!)
-	TextInsert    :: proc(text: cstring, insert: cstring, position: i32) -> cstring ---  // Insert text in a position (WARNING: memory must be freed!)
-	TextJoin      :: proc(textList: ^^u8, count: i32, delimiter: cstring) -> cstring --- // Join text strings with delimiter
-	TextSplit     :: proc(text: cstring, delimiter: u8, count: ^i32) -> ^^u8 ---         // Split text into multiple strings
-	TextAppend    :: proc(text: cstring, append: cstring, position: ^i32) ---            // Append text at specific position and move cursor!
-	TextFindIndex :: proc(text: cstring, find: cstring) -> i32 ---                       // Find first text occurrence within a string
-	TextToUpper   :: proc(text: cstring) -> cstring ---                                  // Get upper case version of provided string
-	TextToLower   :: proc(text: cstring) -> cstring ---                                  // Get lower case version of provided string
-	TextToPascal  :: proc(text: cstring) -> cstring ---                                  // Get Pascal case notation version of provided string
-	TextToSnake   :: proc(text: cstring) -> cstring ---                                  // Get Snake case notation version of provided string
-	TextToCamel   :: proc(text: cstring) -> cstring ---                                  // Get Camel case notation version of provided string
-	TextToInteger :: proc(text: cstring) -> i32 ---                                      // Get integer value from text
-	TextToFloat   :: proc(text: cstring) -> f32 ---                                      // Get float value from text
+	TextCopy      :: proc(dst: cstring, src: cstring) -> c.int ---                         // Copy one string to another, returns bytes copied
+	TextIsEqual   :: proc(text1: cstring, text2: cstring) -> c.bool ---                    // Check if two text string are equal
+	TextLength    :: proc(text: cstring) -> c.uint ---                                     // Get text length, checks for '\0' ending
+	TextFormat    :: proc(text: cstring) -> cstring ---                                    // Text formatting with variables (sprintf() style)
+	TextSubtext   :: proc(text: cstring, position: c.int, length: c.int) -> cstring ---    // Get a piece of a text string
+	TextReplace   :: proc(text: cstring, replace: cstring, by: cstring) -> cstring ---     // Replace text string (WARNING: memory must be freed!)
+	TextInsert    :: proc(text: cstring, insert: cstring, position: c.int) -> cstring ---  // Insert text in a position (WARNING: memory must be freed!)
+	TextJoin      :: proc(textList: ^^c.char, count: c.int, delimiter: cstring) -> cstring --- // Join text strings with delimiter
+	TextSplit     :: proc(text: cstring, delimiter: c.char, count: ^c.int) -> ^^c.char --- // Split text into multiple strings
+	TextAppend    :: proc(text: cstring, append: cstring, position: ^c.int) ---            // Append text at specific position and move cursor!
+	TextFindIndex :: proc(text: cstring, find: cstring) -> c.int ---                       // Find first text occurrence within a string
+	TextToUpper   :: proc(text: cstring) -> cstring ---                                    // Get upper case version of provided string
+	TextToLower   :: proc(text: cstring) -> cstring ---                                    // Get lower case version of provided string
+	TextToPascal  :: proc(text: cstring) -> cstring ---                                    // Get Pascal case notation version of provided string
+	TextToSnake   :: proc(text: cstring) -> cstring ---                                    // Get Snake case notation version of provided string
+	TextToCamel   :: proc(text: cstring) -> cstring ---                                    // Get Camel case notation version of provided string
+	TextToInteger :: proc(text: cstring) -> c.int ---                                      // Get integer value from text
+	TextToFloat   :: proc(text: cstring) -> c.float ---                                    // Get float value from text
 
 	// Basic geometric 3D shapes drawing functions
 	DrawLine3D          :: proc(startPos: Vector3, endPos: Vector3, color: Color) ---    // Draw a line in 3D world space
 	DrawPoint3D         :: proc(position: Vector3, color: Color) ---                     // Draw a point in 3D space, actually a small line
-	DrawCircle3D        :: proc(center: Vector3, radius: f32, rotationAxis: Vector3, rotationAngle: f32, color: Color) --- // Draw a circle in 3D world space
+	DrawCircle3D        :: proc(center: Vector3, radius: c.float, rotationAxis: Vector3, rotationAngle: c.float, color: Color) --- // Draw a circle in 3D world space
 	DrawTriangle3D      :: proc(v1: Vector3, v2: Vector3, v3: Vector3, color: Color) --- // Draw a color-filled triangle (vertex in counter-clockwise order!)
-	DrawTriangleStrip3D :: proc(points: ^Vector3, pointCount: i32, color: Color) ---     // Draw a triangle strip defined by points
-	DrawCube            :: proc(position: Vector3, width: f32, height: f32, length: f32, color: Color) --- // Draw cube
+	DrawTriangleStrip3D :: proc(points: ^Vector3, pointCount: c.int, color: Color) ---   // Draw a triangle strip defined by points
+	DrawCube            :: proc(position: Vector3, width: c.float, height: c.float, length: c.float, color: Color) --- // Draw cube
 	DrawCubeV           :: proc(position: Vector3, size: Vector3, color: Color) ---      // Draw cube (Vector version)
-	DrawCubeWires       :: proc(position: Vector3, width: f32, height: f32, length: f32, color: Color) --- // Draw cube wires
+	DrawCubeWires       :: proc(position: Vector3, width: c.float, height: c.float, length: c.float, color: Color) --- // Draw cube wires
 	DrawCubeWiresV      :: proc(position: Vector3, size: Vector3, color: Color) ---      // Draw cube wires (Vector version)
-	DrawSphere          :: proc(centerPos: Vector3, radius: f32, color: Color) ---       // Draw sphere
-	DrawSphereEx        :: proc(centerPos: Vector3, radius: f32, rings: i32, slices: i32, color: Color) --- // Draw sphere with extended parameters
-	DrawSphereWires     :: proc(centerPos: Vector3, radius: f32, rings: i32, slices: i32, color: Color) --- // Draw sphere wires
-	DrawCylinder        :: proc(position: Vector3, radiusTop: f32, radiusBottom: f32, height: f32, slices: i32, color: Color) --- // Draw a cylinder/cone
-	DrawCylinderEx      :: proc(startPos: Vector3, endPos: Vector3, startRadius: f32, endRadius: f32, sides: i32, color: Color) --- // Draw a cylinder with base at startPos and top at endPos
-	DrawCylinderWires   :: proc(position: Vector3, radiusTop: f32, radiusBottom: f32, height: f32, slices: i32, color: Color) --- // Draw a cylinder/cone wires
-	DrawCylinderWiresEx :: proc(startPos: Vector3, endPos: Vector3, startRadius: f32, endRadius: f32, sides: i32, color: Color) --- // Draw a cylinder wires with base at startPos and top at endPos
-	DrawCapsule         :: proc(startPos: Vector3, endPos: Vector3, radius: f32, slices: i32, rings: i32, color: Color) --- // Draw a capsule with the center of its sphere caps at startPos and endPos
-	DrawCapsuleWires    :: proc(startPos: Vector3, endPos: Vector3, radius: f32, slices: i32, rings: i32, color: Color) --- // Draw capsule wireframe with the center of its sphere caps at startPos and endPos
+	DrawSphere          :: proc(centerPos: Vector3, radius: c.float, color: Color) ---   // Draw sphere
+	DrawSphereEx        :: proc(centerPos: Vector3, radius: c.float, rings: c.int, slices: c.int, color: Color) --- // Draw sphere with extended parameters
+	DrawSphereWires     :: proc(centerPos: Vector3, radius: c.float, rings: c.int, slices: c.int, color: Color) --- // Draw sphere wires
+	DrawCylinder        :: proc(position: Vector3, radiusTop: c.float, radiusBottom: c.float, height: c.float, slices: c.int, color: Color) --- // Draw a cylinder/cone
+	DrawCylinderEx      :: proc(startPos: Vector3, endPos: Vector3, startRadius: c.float, endRadius: c.float, sides: c.int, color: Color) --- // Draw a cylinder with base at startPos and top at endPos
+	DrawCylinderWires   :: proc(position: Vector3, radiusTop: c.float, radiusBottom: c.float, height: c.float, slices: c.int, color: Color) --- // Draw a cylinder/cone wires
+	DrawCylinderWiresEx :: proc(startPos: Vector3, endPos: Vector3, startRadius: c.float, endRadius: c.float, sides: c.int, color: Color) --- // Draw a cylinder wires with base at startPos and top at endPos
+	DrawCapsule         :: proc(startPos: Vector3, endPos: Vector3, radius: c.float, slices: c.int, rings: c.int, color: Color) --- // Draw a capsule with the center of its sphere caps at startPos and endPos
+	DrawCapsuleWires    :: proc(startPos: Vector3, endPos: Vector3, radius: c.float, slices: c.int, rings: c.int, color: Color) --- // Draw capsule wireframe with the center of its sphere caps at startPos and endPos
 	DrawPlane           :: proc(centerPos: Vector3, size: Vector2, color: Color) ---     // Draw a plane XZ
 	DrawRay             :: proc(ray: Ray, color: Color) ---                              // Draw a ray line
-	DrawGrid            :: proc(slices: i32, spacing: f32) ---                           // Draw a grid (centered at (0, 0, 0))
+	DrawGrid            :: proc(slices: c.int, spacing: c.float) ---                     // Draw a grid (centered at (0, 0, 0))
 
 	// Model management functions
 	LoadModel           :: proc(fileName: cstring) -> Model ---  // Load model from files (meshes and materials)
 	LoadModelFromMesh   :: proc(mesh: Mesh) -> Model ---         // Load model from generated mesh (default material)
-	IsModelValid        :: proc(model: Model) -> bool ---        // Check if a model is valid (loaded in GPU, VAO/VBOs)
+	IsModelValid        :: proc(model: Model) -> c.bool ---      // Check if a model is valid (loaded in GPU, VAO/VBOs)
 	UnloadModel         :: proc(model: Model) ---                // Unload model (including meshes) from memory (RAM and/or VRAM)
 	GetModelBoundingBox :: proc(model: Model) -> BoundingBox --- // Compute model bounding box limits (considers all meshes)
 
 	// Model drawing functions
-	DrawModel         :: proc(model: Model, position: Vector3, scale: f32, tint: Color) --- // Draw a model (with texture if set)
-	DrawModelEx       :: proc(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: f32, scale: Vector3, tint: Color) --- // Draw a model with extended parameters
-	DrawModelWires    :: proc(model: Model, position: Vector3, scale: f32, tint: Color) --- // Draw a model wires (with texture if set)
-	DrawModelWiresEx  :: proc(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: f32, scale: Vector3, tint: Color) --- // Draw a model wires (with texture if set) with extended parameters
-	DrawModelPoints   :: proc(model: Model, position: Vector3, scale: f32, tint: Color) --- // Draw a model as points
-	DrawModelPointsEx :: proc(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: f32, scale: Vector3, tint: Color) --- // Draw a model as points with extended parameters
-	DrawBoundingBox   :: proc(box: BoundingBox, color: Color) ---                           // Draw bounding box (wires)
-	DrawBillboard     :: proc(camera: Camera, texture: Texture2D, position: Vector3, scale: f32, tint: Color) --- // Draw a billboard texture
+	DrawModel         :: proc(model: Model, position: Vector3, scale: c.float, tint: Color) --- // Draw a model (with texture if set)
+	DrawModelEx       :: proc(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: c.float, scale: Vector3, tint: Color) --- // Draw a model with extended parameters
+	DrawModelWires    :: proc(model: Model, position: Vector3, scale: c.float, tint: Color) --- // Draw a model wires (with texture if set)
+	DrawModelWiresEx  :: proc(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: c.float, scale: Vector3, tint: Color) --- // Draw a model wires (with texture if set) with extended parameters
+	DrawModelPoints   :: proc(model: Model, position: Vector3, scale: c.float, tint: Color) --- // Draw a model as points
+	DrawModelPointsEx :: proc(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: c.float, scale: Vector3, tint: Color) --- // Draw a model as points with extended parameters
+	DrawBoundingBox   :: proc(box: BoundingBox, color: Color) --- // Draw bounding box (wires)
+	DrawBillboard     :: proc(camera: Camera, texture: Texture2D, position: Vector3, scale: c.float, tint: Color) --- // Draw a billboard texture
 	DrawBillboardRec  :: proc(camera: Camera, texture: Texture2D, source: Rectangle, position: Vector3, size: Vector2, tint: Color) --- // Draw a billboard texture defined by source
-	DrawBillboardPro  :: proc(camera: Camera, texture: Texture2D, source: Rectangle, position: Vector3, up: Vector3, size: Vector2, origin: Vector2, rotation: f32, tint: Color) --- // Draw a billboard texture defined by source and rotation
+	DrawBillboardPro  :: proc(camera: Camera, texture: Texture2D, source: Rectangle, position: Vector3, up: Vector3, size: Vector2, origin: Vector2, rotation: c.float, tint: Color) --- // Draw a billboard texture defined by source and rotation
 
 	// Mesh management functions
-	UploadMesh         :: proc(mesh: ^Mesh, _dynamic: bool) ---                       // Upload mesh vertex data in GPU and provide VAO/VBO ids
-	UpdateMeshBuffer   :: proc(mesh: Mesh, index: i32, data: rawptr, dataSize: i32, offset: i32) --- // Update mesh vertex data in GPU for a specific buffer index
+	UploadMesh         :: proc(mesh: ^Mesh, _dynamic: c.bool) ---                     // Upload mesh vertex data in GPU and provide VAO/VBO ids
+	UpdateMeshBuffer   :: proc(mesh: Mesh, index: c.int, data: rawptr, dataSize: c.int, offset: c.int) --- // Update mesh vertex data in GPU for a specific buffer index
 	UnloadMesh         :: proc(mesh: Mesh) ---                                        // Unload mesh data from CPU and GPU
 	DrawMesh           :: proc(mesh: Mesh, material: Material, transform: Matrix) --- // Draw a 3d mesh with material and transform
-	DrawMeshInstanced  :: proc(mesh: Mesh, material: Material, transforms: ^Matrix, instances: i32) --- // Draw multiple mesh instances with material and different transforms
+	DrawMeshInstanced  :: proc(mesh: Mesh, material: Material, transforms: ^Matrix, instances: c.int) --- // Draw multiple mesh instances with material and different transforms
 	GetMeshBoundingBox :: proc(mesh: Mesh) -> BoundingBox ---                         // Compute mesh bounding box limits
 	GenMeshTangents    :: proc(mesh: ^Mesh) ---                                       // Compute mesh tangents
-	ExportMesh         :: proc(mesh: Mesh, fileName: cstring) -> bool ---             // Export mesh data to file, returns true on success
-	ExportMeshAsCode   :: proc(mesh: Mesh, fileName: cstring) -> bool ---             // Export mesh as code file (.h) defining multiple arrays of vertex attributes
+	ExportMesh         :: proc(mesh: Mesh, fileName: cstring) -> c.bool ---           // Export mesh data to file, returns true on success
+	ExportMeshAsCode   :: proc(mesh: Mesh, fileName: cstring) -> c.bool ---           // Export mesh as code file (.h) defining multiple arrays of vertex attributes
 
 	// Mesh generation functions
-	GenMeshPoly       :: proc(sides: i32, radius: f32) -> Mesh ---                         // Generate polygonal mesh
-	GenMeshPlane      :: proc(width: f32, length: f32, resX: i32, resZ: i32) -> Mesh ---   // Generate plane mesh (with subdivisions)
-	GenMeshCube       :: proc(width: f32, height: f32, length: f32) -> Mesh ---            // Generate cuboid mesh
-	GenMeshSphere     :: proc(radius: f32, rings: i32, slices: i32) -> Mesh ---            // Generate sphere mesh (standard sphere)
-	GenMeshHemiSphere :: proc(radius: f32, rings: i32, slices: i32) -> Mesh ---            // Generate half-sphere mesh (no bottom cap)
-	GenMeshCylinder   :: proc(radius: f32, height: f32, slices: i32) -> Mesh ---           // Generate cylinder mesh
-	GenMeshCone       :: proc(radius: f32, height: f32, slices: i32) -> Mesh ---           // Generate cone/pyramid mesh
-	GenMeshTorus      :: proc(radius: f32, size: f32, radSeg: i32, sides: i32) -> Mesh --- // Generate torus mesh
-	GenMeshKnot       :: proc(radius: f32, size: f32, radSeg: i32, sides: i32) -> Mesh --- // Generate trefoil knot mesh
-	GenMeshHeightmap  :: proc(heightmap: Image, size: Vector3) -> Mesh ---                 // Generate heightmap mesh from image data
-	GenMeshCubicmap   :: proc(cubicmap: Image, cubeSize: Vector3) -> Mesh ---              // Generate cubes-based map mesh from image data
+	GenMeshPoly       :: proc(sides: c.int, radius: c.float) -> Mesh ---                    // Generate polygonal mesh
+	GenMeshPlane      :: proc(width: c.float, length: c.float, resX: c.int, resZ: c.int) -> Mesh --- // Generate plane mesh (with subdivisions)
+	GenMeshCube       :: proc(width: c.float, height: c.float, length: c.float) -> Mesh --- // Generate cuboid mesh
+	GenMeshSphere     :: proc(radius: c.float, rings: c.int, slices: c.int) -> Mesh ---     // Generate sphere mesh (standard sphere)
+	GenMeshHemiSphere :: proc(radius: c.float, rings: c.int, slices: c.int) -> Mesh ---     // Generate half-sphere mesh (no bottom cap)
+	GenMeshCylinder   :: proc(radius: c.float, height: c.float, slices: c.int) -> Mesh ---  // Generate cylinder mesh
+	GenMeshCone       :: proc(radius: c.float, height: c.float, slices: c.int) -> Mesh ---  // Generate cone/pyramid mesh
+	GenMeshTorus      :: proc(radius: c.float, size: c.float, radSeg: c.int, sides: c.int) -> Mesh --- // Generate torus mesh
+	GenMeshKnot       :: proc(radius: c.float, size: c.float, radSeg: c.int, sides: c.int) -> Mesh --- // Generate trefoil knot mesh
+	GenMeshHeightmap  :: proc(heightmap: Image, size: Vector3) -> Mesh ---                  // Generate heightmap mesh from image data
+	GenMeshCubicmap   :: proc(cubicmap: Image, cubeSize: Vector3) -> Mesh ---               // Generate cubes-based map mesh from image data
 
 	// Material loading/unloading functions
-	LoadMaterials        :: proc(fileName: cstring, materialCount: ^i32) -> ^Material ---   // Load materials from model file
-	LoadMaterialDefault  :: proc() -> Material ---                                          // Load default material (Supports: DIFFUSE, SPECULAR, NORMAL maps)
-	IsMaterialValid      :: proc(material: Material) -> bool ---                            // Check if a material is valid (shader assigned, map textures loaded in GPU)
-	UnloadMaterial       :: proc(material: Material) ---                                    // Unload material from GPU memory (VRAM)
-	SetMaterialTexture   :: proc(material: ^Material, mapType: i32, texture: Texture2D) --- // Set texture for a material map type (MATERIAL_MAP_DIFFUSE, MATERIAL_MAP_SPECULAR...)
-	SetModelMeshMaterial :: proc(model: ^Model, meshId: i32, materialId: i32) ---           // Set material for a mesh
+	LoadMaterials        :: proc(fileName: cstring, materialCount: ^c.int) -> ^Material ---   // Load materials from model file
+	LoadMaterialDefault  :: proc() -> Material ---                                            // Load default material (Supports: DIFFUSE, SPECULAR, NORMAL maps)
+	IsMaterialValid      :: proc(material: Material) -> c.bool ---                            // Check if a material is valid (shader assigned, map textures loaded in GPU)
+	UnloadMaterial       :: proc(material: Material) ---                                      // Unload material from GPU memory (VRAM)
+	SetMaterialTexture   :: proc(material: ^Material, mapType: c.int, texture: Texture2D) --- // Set texture for a material map type (MATERIAL_MAP_DIFFUSE, MATERIAL_MAP_SPECULAR...)
+	SetModelMeshMaterial :: proc(model: ^Model, meshId: c.int, materialId: c.int) ---         // Set material for a mesh
 
 	// Model animations loading/unloading functions
-	LoadModelAnimations       :: proc(fileName: cstring, animCount: ^i32) -> ^ModelAnimation --- // Load model animations from file
-	UpdateModelAnimation      :: proc(model: Model, anim: ModelAnimation, frame: i32) --- // Update model animation pose (CPU)
-	UpdateModelAnimationBones :: proc(model: Model, anim: ModelAnimation, frame: i32) --- // Update model animation mesh bone matrices (GPU skinning)
-	UnloadModelAnimation      :: proc(anim: ModelAnimation) ---                           // Unload animation data
-	UnloadModelAnimations     :: proc(animations: ^ModelAnimation, animCount: i32) ---    // Unload animation array data
-	IsModelAnimationValid     :: proc(model: Model, anim: ModelAnimation) -> bool ---     // Check model animation skeleton match
+	LoadModelAnimations       :: proc(fileName: cstring, animCount: ^c.int) -> ^ModelAnimation --- // Load model animations from file
+	UpdateModelAnimation      :: proc(model: Model, anim: ModelAnimation, frame: c.int) --- // Update model animation pose (CPU)
+	UpdateModelAnimationBones :: proc(model: Model, anim: ModelAnimation, frame: c.int) --- // Update model animation mesh bone matrices (GPU skinning)
+	UnloadModelAnimation      :: proc(anim: ModelAnimation) ---                             // Unload animation data
+	UnloadModelAnimations     :: proc(animations: ^ModelAnimation, animCount: c.int) ---    // Unload animation array data
+	IsModelAnimationValid     :: proc(model: Model, anim: ModelAnimation) -> c.bool ---     // Check model animation skeleton match
 
 	// Collision detection functions
-	CheckCollisionSpheres   :: proc(center1: Vector3, radius1: f32, center2: Vector3, radius2: f32) -> bool --- // Check collision between two spheres
-	CheckCollisionBoxes     :: proc(box1: BoundingBox, box2: BoundingBox) -> bool --- // Check collision between two bounding boxes
-	CheckCollisionBoxSphere :: proc(box: BoundingBox, center: Vector3, radius: f32) -> bool --- // Check collision between box and sphere
-	GetRayCollisionSphere   :: proc(ray: Ray, center: Vector3, radius: f32) -> RayCollision --- // Get collision info between ray and sphere
-	GetRayCollisionBox      :: proc(ray: Ray, box: BoundingBox) -> RayCollision ---   // Get collision info between ray and box
+	CheckCollisionSpheres   :: proc(center1: Vector3, radius1: c.float, center2: Vector3, radius2: c.float) -> c.bool --- // Check collision between two spheres
+	CheckCollisionBoxes     :: proc(box1: BoundingBox, box2: BoundingBox) -> c.bool --- // Check collision between two bounding boxes
+	CheckCollisionBoxSphere :: proc(box: BoundingBox, center: Vector3, radius: c.float) -> c.bool --- // Check collision between box and sphere
+	GetRayCollisionSphere   :: proc(ray: Ray, center: Vector3, radius: c.float) -> RayCollision --- // Get collision info between ray and sphere
+	GetRayCollisionBox      :: proc(ray: Ray, box: BoundingBox) -> RayCollision ---     // Get collision info between ray and box
 	GetRayCollisionMesh     :: proc(ray: Ray, mesh: Mesh, transform: Matrix) -> RayCollision --- // Get collision info between ray and mesh
 	GetRayCollisionTriangle :: proc(ray: Ray, p1: Vector3, p2: Vector3, p3: Vector3) -> RayCollision --- // Get collision info between ray and triangle
 	GetRayCollisionQuad     :: proc(ray: Ray, p1: Vector3, p2: Vector3, p3: Vector3, p4: Vector3) -> RayCollision --- // Get collision info between ray and quad
 
 	// Audio device management functions
-	InitAudioDevice    :: proc() ---            // Initialize audio device and context
-	CloseAudioDevice   :: proc() ---            // Close the audio device and context
-	IsAudioDeviceReady :: proc() -> bool ---    // Check if audio device has been initialized successfully
-	SetMasterVolume    :: proc(volume: f32) --- // Set master volume (listener)
-	GetMasterVolume    :: proc() -> f32 ---     // Get master volume (listener)
+	InitAudioDevice    :: proc() ---                // Initialize audio device and context
+	CloseAudioDevice   :: proc() ---                // Close the audio device and context
+	IsAudioDeviceReady :: proc() -> c.bool ---      // Check if audio device has been initialized successfully
+	SetMasterVolume    :: proc(volume: c.float) --- // Set master volume (listener)
+	GetMasterVolume    :: proc() -> c.float ---     // Get master volume (listener)
 
 	// Wave/Sound loading/unloading functions
-	LoadWave           :: proc(fileName: cstring) -> Wave ---                               // Load wave data from file
-	LoadWaveFromMemory :: proc(fileType: cstring, fileData: ^u8, dataSize: i32) -> Wave --- // Load wave from memory buffer, fileType refers to extension: i.e. '.wav'
-	IsWaveValid        :: proc(wave: Wave) -> bool ---                                      // Checks if wave data is valid (data loaded and parameters)
-	LoadSound          :: proc(fileName: cstring) -> Sound ---                              // Load sound from file
-	LoadSoundFromWave  :: proc(wave: Wave) -> Sound ---                                     // Load sound from wave data
-	LoadSoundAlias     :: proc(source: Sound) -> Sound ---                                  // Create a new sound that shares the same sample data as the source sound, does not own the sound data
-	IsSoundValid       :: proc(sound: Sound) -> bool ---                                    // Checks if a sound is valid (data loaded and buffers initialized)
-	UpdateSound        :: proc(sound: Sound, data: rawptr, sampleCount: i32) ---            // Update sound buffer with new data
-	UnloadWave         :: proc(wave: Wave) ---                                              // Unload wave data
-	UnloadSound        :: proc(sound: Sound) ---                                            // Unload sound
-	UnloadSoundAlias   :: proc(alias: Sound) ---                                            // Unload a sound alias (does not deallocate sample data)
-	ExportWave         :: proc(wave: Wave, fileName: cstring) -> bool ---                   // Export wave data to file, returns true on success
-	ExportWaveAsCode   :: proc(wave: Wave, fileName: cstring) -> bool ---                   // Export wave sample data to code (.h), returns true on success
+	LoadWave           :: proc(fileName: cstring) -> Wave ---                      // Load wave data from file
+	LoadWaveFromMemory :: proc(fileType: cstring, fileData: ^c.uchar, dataSize: c.int) -> Wave --- // Load wave from memory buffer, fileType refers to extension: i.e. '.wav'
+	IsWaveValid        :: proc(wave: Wave) -> c.bool ---                           // Checks if wave data is valid (data loaded and parameters)
+	LoadSound          :: proc(fileName: cstring) -> Sound ---                     // Load sound from file
+	LoadSoundFromWave  :: proc(wave: Wave) -> Sound ---                            // Load sound from wave data
+	LoadSoundAlias     :: proc(source: Sound) -> Sound ---                         // Create a new sound that shares the same sample data as the source sound, does not own the sound data
+	IsSoundValid       :: proc(sound: Sound) -> c.bool ---                         // Checks if a sound is valid (data loaded and buffers initialized)
+	UpdateSound        :: proc(sound: Sound, data: rawptr, sampleCount: c.int) --- // Update sound buffer with new data
+	UnloadWave         :: proc(wave: Wave) ---                                     // Unload wave data
+	UnloadSound        :: proc(sound: Sound) ---                                   // Unload sound
+	UnloadSoundAlias   :: proc(alias: Sound) ---                                   // Unload a sound alias (does not deallocate sample data)
+	ExportWave         :: proc(wave: Wave, fileName: cstring) -> c.bool ---        // Export wave data to file, returns true on success
+	ExportWaveAsCode   :: proc(wave: Wave, fileName: cstring) -> c.bool ---        // Export wave sample data to code (.h), returns true on success
 
 	// Wave/Sound management functions
-	PlaySound         :: proc(sound: Sound) ---                                 // Play a sound
-	StopSound         :: proc(sound: Sound) ---                                 // Stop playing a sound
-	PauseSound        :: proc(sound: Sound) ---                                 // Pause a sound
-	ResumeSound       :: proc(sound: Sound) ---                                 // Resume a paused sound
-	IsSoundPlaying    :: proc(sound: Sound) -> bool ---                         // Check if a sound is currently playing
-	SetSoundVolume    :: proc(sound: Sound, volume: f32) ---                    // Set volume for a sound (1.0 is max level)
-	SetSoundPitch     :: proc(sound: Sound, pitch: f32) ---                     // Set pitch for a sound (1.0 is base level)
-	SetSoundPan       :: proc(sound: Sound, pan: f32) ---                       // Set pan for a sound (0.5 is center)
-	WaveCopy          :: proc(wave: Wave) -> Wave ---                           // Copy a wave to a new wave
-	WaveCrop          :: proc(wave: ^Wave, initFrame: i32, finalFrame: i32) --- // Crop a wave to defined frames range
-	WaveFormat        :: proc(wave: ^Wave, sampleRate: i32, sampleSize: i32, channels: i32) --- // Convert wave data to desired format
-	LoadWaveSamples   :: proc(wave: Wave) -> ^f32 ---                           // Load samples data from wave as a 32bit float data array
-	UnloadWaveSamples :: proc(samples: ^f32) ---                                // Unload samples data loaded with LoadWaveSamples()
+	PlaySound         :: proc(sound: Sound) ---                                     // Play a sound
+	StopSound         :: proc(sound: Sound) ---                                     // Stop playing a sound
+	PauseSound        :: proc(sound: Sound) ---                                     // Pause a sound
+	ResumeSound       :: proc(sound: Sound) ---                                     // Resume a paused sound
+	IsSoundPlaying    :: proc(sound: Sound) -> c.bool ---                           // Check if a sound is currently playing
+	SetSoundVolume    :: proc(sound: Sound, volume: c.float) ---                    // Set volume for a sound (1.0 is max level)
+	SetSoundPitch     :: proc(sound: Sound, pitch: c.float) ---                     // Set pitch for a sound (1.0 is base level)
+	SetSoundPan       :: proc(sound: Sound, pan: c.float) ---                       // Set pan for a sound (0.5 is center)
+	WaveCopy          :: proc(wave: Wave) -> Wave ---                               // Copy a wave to a new wave
+	WaveCrop          :: proc(wave: ^Wave, initFrame: c.int, finalFrame: c.int) --- // Crop a wave to defined frames range
+	WaveFormat        :: proc(wave: ^Wave, sampleRate: c.int, sampleSize: c.int, channels: c.int) --- // Convert wave data to desired format
+	LoadWaveSamples   :: proc(wave: Wave) -> ^c.float ---                           // Load samples data from wave as a 32bit float data array
+	UnloadWaveSamples :: proc(samples: ^c.float) ---                                // Unload samples data loaded with LoadWaveSamples()
 
 	// Music management functions
-	LoadMusicStream           :: proc(fileName: cstring) -> Music ---  // Load music stream from file
-	LoadMusicStreamFromMemory :: proc(fileType: cstring, data: ^u8, dataSize: i32) -> Music --- // Load music stream from data
-	IsMusicValid              :: proc(music: Music) -> bool ---        // Checks if a music stream is valid (context and buffers initialized)
-	UnloadMusicStream         :: proc(music: Music) ---                // Unload music stream
-	PlayMusicStream           :: proc(music: Music) ---                // Start music playing
-	IsMusicStreamPlaying      :: proc(music: Music) -> bool ---        // Check if music is playing
-	UpdateMusicStream         :: proc(music: Music) ---                // Updates buffers for music streaming
-	StopMusicStream           :: proc(music: Music) ---                // Stop music playing
-	PauseMusicStream          :: proc(music: Music) ---                // Pause music playing
-	ResumeMusicStream         :: proc(music: Music) ---                // Resume playing paused music
-	SeekMusicStream           :: proc(music: Music, position: f32) --- // Seek music to a position (in seconds)
-	SetMusicVolume            :: proc(music: Music, volume: f32) ---   // Set volume for music (1.0 is max level)
-	SetMusicPitch             :: proc(music: Music, pitch: f32) ---    // Set pitch for a music (1.0 is base level)
-	SetMusicPan               :: proc(music: Music, pan: f32) ---      // Set pan for a music (0.5 is center)
-	GetMusicTimeLength        :: proc(music: Music) -> f32 ---         // Get music time length (in seconds)
-	GetMusicTimePlayed        :: proc(music: Music) -> f32 ---         // Get current music time played (in seconds)
+	LoadMusicStream           :: proc(fileName: cstring) -> Music ---      // Load music stream from file
+	LoadMusicStreamFromMemory :: proc(fileType: cstring, data: ^c.uchar, dataSize: c.int) -> Music --- // Load music stream from data
+	IsMusicValid              :: proc(music: Music) -> c.bool ---          // Checks if a music stream is valid (context and buffers initialized)
+	UnloadMusicStream         :: proc(music: Music) ---                    // Unload music stream
+	PlayMusicStream           :: proc(music: Music) ---                    // Start music playing
+	IsMusicStreamPlaying      :: proc(music: Music) -> c.bool ---          // Check if music is playing
+	UpdateMusicStream         :: proc(music: Music) ---                    // Updates buffers for music streaming
+	StopMusicStream           :: proc(music: Music) ---                    // Stop music playing
+	PauseMusicStream          :: proc(music: Music) ---                    // Pause music playing
+	ResumeMusicStream         :: proc(music: Music) ---                    // Resume playing paused music
+	SeekMusicStream           :: proc(music: Music, position: c.float) --- // Seek music to a position (in seconds)
+	SetMusicVolume            :: proc(music: Music, volume: c.float) ---   // Set volume for music (1.0 is max level)
+	SetMusicPitch             :: proc(music: Music, pitch: c.float) ---    // Set pitch for a music (1.0 is base level)
+	SetMusicPan               :: proc(music: Music, pan: c.float) ---      // Set pan for a music (0.5 is center)
+	GetMusicTimeLength        :: proc(music: Music) -> c.float ---         // Get music time length (in seconds)
+	GetMusicTimePlayed        :: proc(music: Music) -> c.float ---         // Get current music time played (in seconds)
 
 	// AudioStream management functions
-	LoadAudioStream                 :: proc(sampleRate: u32, sampleSize: u32, channels: u32) -> AudioStream --- // Load audio stream (to stream raw audio pcm data)
-	IsAudioStreamValid              :: proc(stream: AudioStream) -> bool ---                  // Checks if an audio stream is valid (buffers initialized)
+	LoadAudioStream                 :: proc(sampleRate: c.uint, sampleSize: c.uint, channels: c.uint) -> AudioStream --- // Load audio stream (to stream raw audio pcm data)
+	IsAudioStreamValid              :: proc(stream: AudioStream) -> c.bool ---                // Checks if an audio stream is valid (buffers initialized)
 	UnloadAudioStream               :: proc(stream: AudioStream) ---                          // Unload audio stream and free memory
-	UpdateAudioStream               :: proc(stream: AudioStream, data: rawptr, frameCount: i32) --- // Update audio stream buffers with data
-	IsAudioStreamProcessed          :: proc(stream: AudioStream) -> bool ---                  // Check if any audio stream buffers requires refill
+	UpdateAudioStream               :: proc(stream: AudioStream, data: rawptr, frameCount: c.int) --- // Update audio stream buffers with data
+	IsAudioStreamProcessed          :: proc(stream: AudioStream) -> c.bool ---                // Check if any audio stream buffers requires refill
 	PlayAudioStream                 :: proc(stream: AudioStream) ---                          // Play audio stream
 	PauseAudioStream                :: proc(stream: AudioStream) ---                          // Pause audio stream
 	ResumeAudioStream               :: proc(stream: AudioStream) ---                          // Resume audio stream
-	IsAudioStreamPlaying            :: proc(stream: AudioStream) -> bool ---                  // Check if audio stream is playing
+	IsAudioStreamPlaying            :: proc(stream: AudioStream) -> c.bool ---                // Check if audio stream is playing
 	StopAudioStream                 :: proc(stream: AudioStream) ---                          // Stop audio stream
-	SetAudioStreamVolume            :: proc(stream: AudioStream, volume: f32) ---             // Set volume for audio stream (1.0 is max level)
-	SetAudioStreamPitch             :: proc(stream: AudioStream, pitch: f32) ---              // Set pitch for audio stream (1.0 is base level)
-	SetAudioStreamPan               :: proc(stream: AudioStream, pan: f32) ---                // Set pan for audio stream (0.5 is centered)
-	SetAudioStreamBufferSizeDefault :: proc(size: i32) ---                                    // Default size for new audio streams
+	SetAudioStreamVolume            :: proc(stream: AudioStream, volume: c.float) ---         // Set volume for audio stream (1.0 is max level)
+	SetAudioStreamPitch             :: proc(stream: AudioStream, pitch: c.float) ---          // Set pitch for audio stream (1.0 is base level)
+	SetAudioStreamPan               :: proc(stream: AudioStream, pan: c.float) ---            // Set pan for audio stream (0.5 is centered)
+	SetAudioStreamBufferSizeDefault :: proc(size: c.int) ---                                  // Default size for new audio streams
 	SetAudioStreamCallback          :: proc(stream: AudioStream, callback: AudioCallback) --- // Audio thread callback to request new data
 	AttachAudioStreamProcessor      :: proc(stream: AudioStream, processor: AudioCallback) --- // Attach audio stream processor to stream, receives the samples as 'float'
 	DetachAudioStreamProcessor      :: proc(stream: AudioStream, processor: AudioCallback) --- // Detach audio stream processor from stream

--- a/examples/ufbx/ufbx/ufbx.odin
+++ b/examples/ufbx/ufbx/ufbx.odin
@@ -20,7 +20,7 @@ CPP11 :: 0
 
 // ufbx_abi_data :: Extern
 
-REAL_TYPE :: c.float
+REAL_TYPE :: f32
 
 // Limits for embedded arrays within structures.
 ERROR_STACK_MAX_DEPTH :: 8
@@ -39,14 +39,14 @@ HAS_FORCE_32BIT :: 1
 // `ufbx_source_version` contains the version of the corresponding source file.
 // HINT: The version can be compared numerically to the result of `ufbx_pack_version()`,
 // for example `#if UFBX_VERSION >= ufbx_pack_version(0, 12, 0)`.
-HEADER_VERSION :: (c.uint32_t)(0)*1000000 + (c.uint32_t)(18)*1000 + (c.uint32_t)(0)
+HEADER_VERSION :: (u32)(0)*1000000 + (u32)(18)*1000 + (u32)(0)
 // VERSION :: Ufbx_Header_Version
 
 // Main floating point type used everywhere in ufbx, defaults to `double`.
 // If you define `UFBX_REAL_IS_FLOAT` to any value, `ufbx_real` will be defined
 // as `float` instead.
 // You can also manually define `UFBX_REAL_TYPE` to any floating point type.
-Real :: c.float
+Real :: f32
 
 // Null-terminated UTF-8 encoded string within an FBX file
 String :: struct {
@@ -118,12 +118,12 @@ Void_List :: struct {
 }
 
 Bool_List :: struct {
-	data:  ^c.bool,
+	data:  ^bool,
 	count: c.size_t,
 }
 
 Uint32_List :: struct {
-	data:  [^]c.uint32_t,
+	data:  [^]u32,
 	count: c.size_t,
 }
 
@@ -153,7 +153,7 @@ String_List :: struct {
 }
 
 // Sentinel value used to represent a missing index.
-// NO_INDEX :: (c.uint32_t)~0
+// NO_INDEX :: (u32)~0
 
 // -- Document object model
 Dom_Value_Type :: enum c.int {
@@ -175,8 +175,8 @@ Dom_Value :: struct {
 	type:        Dom_Value_Type,
 	value_str:   String,
 	value_blob:  Blob,
-	value_int:   c.int64_t,
-	value_float: c.double,
+	value_int:   i64,
+	value_float: f64,
 }
 
 Dom_Node_List :: struct {
@@ -324,12 +324,12 @@ PROP_FLAGS_FORCE_32BIT :: Prop_Flags { .ANIMATABLE, .USER_DEFINED, .HIDDEN, .LOC
 // Single property with name/type/value.
 Prop :: struct {
 	name:          String,
-	_internal_key: c.uint32_t,
+	_internal_key: u32,
 	type:          Prop_Type,
 	flags:         Prop_Flag,
 	value_str:     String,
 	value_blob:    Blob,
-	value_int:     c.int64_t,
+	value_int:     i64,
 	using _: struct #raw_union {
 		value_real_arr: [4]Real,
 		value_real:     Real,
@@ -641,8 +641,8 @@ Connection_List :: struct {
 Element :: struct {
 	name:            String,
 	props:           Props,
-	element_id:      c.uint32_t,
-	typed_id:        c.uint32_t,
+	element_id:      u32,
+	typed_id:        u32,
 	instances:       Node_List,
 	type:            Element_Type,
 	connections_src: Connection_List,
@@ -659,8 +659,8 @@ Unknown :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 
@@ -725,8 +725,8 @@ Node :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 
@@ -834,36 +834,36 @@ Node :: struct {
 	bind_pose: ^Pose,
 
 	// Visibility state.
-	visible: c.bool,
+	visible: bool,
 
 	// True if this node is the implicit root node of the scene.
-	is_root: c.bool,
+	is_root: bool,
 
 	// True if the node has a non-identity `geometry_transform`.
-	has_geometry_transform: c.bool,
+	has_geometry_transform: bool,
 
 	// If `true` the transform is adjusted by ufbx, not enabled by default.
 	// See `adjust_pre_rotation`, `adjust_pre_scale`, `adjust_post_rotation`,
 	// and `adjust_post_scale`.
-	has_adjust_transform: c.bool,
+	has_adjust_transform: bool,
 
 	// Scale is adjusted by root scale.
-	has_root_adjust_transform: c.bool,
+	has_root_adjust_transform: bool,
 
 	// True if this node is a synthetic geometry transform helper.
 	// See `UFBX_GEOMETRY_TRANSFORM_HANDLING_HELPER_NODES`.
-	is_geometry_transform_helper: c.bool,
+	is_geometry_transform_helper: bool,
 
 	// True if the node is a synthetic scale compensation helper.
 	// See `UFBX_INHERIT_MODE_HANDLING_HELPER_NODES`.
-	is_scale_helper: c.bool,
+	is_scale_helper: bool,
 
 	// Parent node to children that can compensate for parent scale.
-	is_scale_compensate_parent: c.bool,
+	is_scale_compensate_parent: bool,
 
 	// How deep is this node in the parent hierarchy. Root node is at depth `0`
 	// and the immediate children of root at `1`.
-	node_depth: c.uint32_t,
+	node_depth: u32,
 }
 
 // Vertex attribute: All attributes are stored in a consistent indexed format
@@ -877,7 +877,7 @@ Node :: struct {
 //   attrib.values.data[attrib.indices.data[mesh->vertex_first_index[vertex_ix]]
 Vertex_Attrib :: struct {
 	// Is this attribute defined by the mesh.
-	exists: c.bool,
+	exists: bool,
 
 	// List of values the attribute uses.
 	values: Void_List,
@@ -889,7 +889,7 @@ Vertex_Attrib :: struct {
 	value_reals: c.size_t,
 
 	// `true` if this attribute is defined per vertex, instead of per index.
-	unique_per_vertex: c.bool,
+	unique_per_vertex: bool,
 
 	// Optional 4th 'W' component for the attribute.
 	// May be defined for the following:
@@ -902,48 +902,48 @@ Vertex_Attrib :: struct {
 
 // 1D vertex attribute, see `ufbx_vertex_attrib` for information
 Vertex_Real :: struct {
-	exists:            c.bool,
+	exists:            bool,
 	values:            Real_List,
 	indices:           Uint32_List,
 	value_reals:       c.size_t,
-	unique_per_vertex: c.bool,
+	unique_per_vertex: bool,
 	values_w:          Real_List,
 }
 
 // 2D vertex attribute, see `ufbx_vertex_attrib` for information
 Vertex_Vec2 :: struct {
-	exists:            c.bool,
+	exists:            bool,
 	values:            Vec2_List,
 	indices:           Uint32_List,
 	value_reals:       c.size_t,
-	unique_per_vertex: c.bool,
+	unique_per_vertex: bool,
 	values_w:          Real_List,
 }
 
 // 3D vertex attribute, see `ufbx_vertex_attrib` for information
 Vertex_Vec3 :: struct {
-	exists:            c.bool,
+	exists:            bool,
 	values:            Vec3_List,
 	indices:           Uint32_List,
 	value_reals:       c.size_t,
-	unique_per_vertex: c.bool,
+	unique_per_vertex: bool,
 	values_w:          Real_List,
 }
 
 // 4D vertex attribute, see `ufbx_vertex_attrib` for information
 Vertex_Vec4 :: struct {
-	exists:            c.bool,
+	exists:            bool,
 	values:            Vec4_List,
 	indices:           Uint32_List,
 	value_reals:       c.size_t,
-	unique_per_vertex: c.bool,
+	unique_per_vertex: bool,
 	values_w:          Real_List,
 }
 
 // Vertex UV set/layer
 Uv_Set :: struct {
 	name:             String,
-	index:            c.uint32_t,
+	index:            u32,
 	vertex_uv:        Vertex_Vec2, // < UV / texture coordinates
 	vertex_tangent:   Vertex_Vec3, // < (optional) Tangent vector in UV.x direction
 	vertex_bitangent: Vertex_Vec3, // < (optional) Tangent vector in UV.y direction
@@ -952,7 +952,7 @@ Uv_Set :: struct {
 // Vertex color set/layer
 Color_Set :: struct {
 	name:         String,
-	index:        c.uint32_t,
+	index:        u32,
 	vertex_color: Vertex_Vec4, // < Per-vertex RGBA color
 }
 
@@ -970,9 +970,9 @@ Color_Set_List :: struct {
 Edge :: struct {
 	using _: struct #raw_union {
 		using _: struct {
-			a, b: c.uint32_t,
+			a, b: u32,
 		},
-		indices: [2]c.uint32_t,
+		indices: [2]u32,
 	},
 }
 
@@ -987,8 +987,8 @@ Edge_List :: struct {
 // NOTE: `num_indices` maybe less than 3 in which case the face is invalid!
 // [TODO #23: should probably remove the bad faces at load time]
 Face :: struct {
-	index_begin: c.uint32_t,
-	num_indices: c.uint32_t,
+	index_begin: u32,
+	num_indices: u32,
 }
 
 Face_List :: struct {
@@ -999,7 +999,7 @@ Face_List :: struct {
 // Subset of mesh faces used by a single material or group.
 Mesh_Part :: struct {
 	// Index of the mesh part.
-	index: c.uint32_t,
+	index: u32,
 	num_faces:       c.size_t, // < Number of faces (polygons)
 	num_triangles:   c.size_t, // < Number of triangles if triangulated
 	num_empty_faces: c.size_t, // < Number of faces with zero vertices
@@ -1017,8 +1017,8 @@ Mesh_Part_List :: struct {
 }
 
 Face_Group :: struct {
-	id:   c.int32_t, // < Numerical ID for this group.
-	name: String,    // < Name for the face group.
+	id:   i32,    // < Numerical ID for this group.
+	name: String, // < Name for the face group.
 }
 
 Face_Group_List :: struct {
@@ -1027,8 +1027,8 @@ Face_Group_List :: struct {
 }
 
 Subdivision_Weight_Range :: struct {
-	weight_begin: c.uint32_t,
-	num_weights:  c.uint32_t,
+	weight_begin: u32,
+	num_weights:  u32,
 }
 
 Subdivision_Weight_Range_List :: struct {
@@ -1038,7 +1038,7 @@ Subdivision_Weight_Range_List :: struct {
 
 Subdivision_Weight :: struct {
 	weight: Real,
-	index:  c.uint32_t,
+	index:  u32,
 }
 
 Subdivision_Weight_List :: struct {
@@ -1146,8 +1146,8 @@ Mesh :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 			instances:  Node_List,
 		},
 	},
@@ -1217,7 +1217,7 @@ Mesh :: struct {
 	// same as the static ones for non-skinned meshes and `skinned_is_local`
 	// is set to true meaning you need to transform them manually using
 	// `ufbx_transform_position(&node->geometry_to_world, skinned_pos)`!
-	skinned_is_local: c.bool,
+	skinned_is_local: bool,
 	skinned_position:          Vertex_Vec3,
 	skinned_normal:            Vertex_Vec3,
 
@@ -1228,26 +1228,26 @@ Mesh :: struct {
 	all_deformers:             Element_List,
 
 	// Subdivision
-	subdivision_preview_levels: c.uint32_t,
-	subdivision_render_levels: c.uint32_t,
+	subdivision_preview_levels: u32,
+	subdivision_render_levels: u32,
 	subdivision_display_mode:  Subdivision_Display_Mode,
 	subdivision_boundary:      Subdivision_Boundary,
 	subdivision_uv_boundary:   Subdivision_Boundary,
 
 	// The winding of the faces has been reversed.
-	reversed_winding: c.bool,
+	reversed_winding: bool,
 
 	// Normals have been generated instead of evaluated.
 	// Either from missing normals (via `ufbx_load_opts.generate_missing_normals`), skinning,
 	// tessellation, or subdivision.
-	generated_normals: c.bool,
+	generated_normals: bool,
 
 	// Subdivision (result)
-	subdivision_evaluated: c.bool,
+	subdivision_evaluated: bool,
 	subdivision_result:        ^Subdivision_Result,
 
 	// Tessellation (result)
-	from_tessellated_nurbs: c.bool,
+	from_tessellated_nurbs: bool,
 }
 
 // The kind of light source
@@ -1302,8 +1302,8 @@ Light :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 			instances:  Node_List,
 		},
 	},
@@ -1323,8 +1323,8 @@ Light :: struct {
 	area_shape:   Light_Area_Shape,
 	inner_angle:  Real,
 	outer_angle:  Real,
-	cast_light:   c.bool,
-	cast_shadows: c.bool,
+	cast_light:   bool,
+	cast_shadows: bool,
 }
 
 Projection_Mode :: enum c.int {
@@ -1454,8 +1454,8 @@ Camera :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 			instances:  Node_List,
 		},
 	},
@@ -1465,7 +1465,7 @@ Camera :: struct {
 
 	// If set to `true`, `resolution` represents actual pixel values, otherwise
 	// it's only useful for its aspect ratio.
-	resolution_is_pixels: c.bool,
+	resolution_is_pixels: bool,
 
 	// Render resolution, either in pixels or arbitrary units, depending on above
 	resolution: Vec2,
@@ -1524,8 +1524,8 @@ Bone :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 			instances:  Node_List,
 		},
 	},
@@ -1537,7 +1537,7 @@ Bone :: struct {
 	relative_length: Real,
 
 	// Is the bone a root bone
-	is_root: c.bool,
+	is_root: bool,
 }
 
 // Empty/NULL/locator connected to a node, actual details in `ufbx_node`
@@ -1547,8 +1547,8 @@ Empty :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 			instances:  Node_List,
 		},
 	},
@@ -1556,8 +1556,8 @@ Empty :: struct {
 
 // Segment of a `ufbx_line_curve`, indices refer to `ufbx_line_curve.point_indices[]`
 Line_Segment :: struct {
-	index_begin: c.uint32_t,
-	num_indices: c.uint32_t,
+	index_begin: u32,
+	num_indices: u32,
 }
 
 Line_Segment_List :: struct {
@@ -1571,8 +1571,8 @@ Line_Curve :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 			instances:  Node_List,
 		},
 	},
@@ -1582,7 +1582,7 @@ Line_Curve :: struct {
 	segments:       Line_Segment_List,
 
 	// Tessellation (result)
-	from_tessellated_nurbs: c.bool,
+	from_tessellated_nurbs: bool,
 }
 
 Nurbs_Topology :: enum c.int {
@@ -1603,7 +1603,7 @@ NURBS_TOPOLOGY_COUNT :: 3
 Nurbs_Basis :: struct {
 	// Number of control points influencing a point on the curve/surface.
 	// Equal to the degree plus one.
-	order: c.uint32_t,
+	order: u32,
 
 	// Topology (periodicity) of the dimension.
 	topology: Nurbs_Topology,
@@ -1619,7 +1619,7 @@ Nurbs_Basis :: struct {
 	spans: Real_List,
 
 	// `true` if this axis is two-dimensional.
-	is_2d: c.bool,
+	is_2d: bool,
 
 	// Number of control points that need to be copied to the end.
 	// This is just for convenience as it could be derived from `topology` and
@@ -1630,7 +1630,7 @@ Nurbs_Basis :: struct {
 	num_wrap_control_points: c.size_t,
 
 	// `true` if the parametrization is well defined.
-	valid: c.bool,
+	valid: bool,
 }
 
 Nurbs_Curve :: struct {
@@ -1639,8 +1639,8 @@ Nurbs_Curve :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 			instances:  Node_List,
 		},
 	},
@@ -1660,8 +1660,8 @@ Nurbs_Surface :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 			instances:  Node_List,
 		},
 	},
@@ -1681,11 +1681,11 @@ Nurbs_Surface :: struct {
 	control_points: Vec4_List,
 
 	// How many segments tessellate each span in `ufbx_nurbs_basis.spans`.
-	span_subdivision_u: c.uint32_t,
-	span_subdivision_v:   c.uint32_t,
+	span_subdivision_u: u32,
+	span_subdivision_v:   u32,
 
 	// If `true` the resulting normals should be flipped when evaluated.
-	flip_normals: c.bool,
+	flip_normals: bool,
 
 	// Material for the whole surface.
 	// NOTE: May be `NULL`!
@@ -1698,8 +1698,8 @@ Nurbs_Trim_Surface :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 			instances:  Node_List,
 		},
 	},
@@ -1711,8 +1711,8 @@ Nurbs_Trim_Boundary :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 			instances:  Node_List,
 		},
 	},
@@ -1725,8 +1725,8 @@ Procedural_Geometry :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 			instances:  Node_List,
 		},
 	},
@@ -1738,8 +1738,8 @@ Stereo_Camera :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 			instances:  Node_List,
 		},
 	},
@@ -1753,8 +1753,8 @@ Camera_Switcher :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 			instances:  Node_List,
 		},
 	},
@@ -1776,8 +1776,8 @@ Marker :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 			instances:  Node_List,
 		},
 	},
@@ -1823,24 +1823,24 @@ Lod_Group :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 			instances:  Node_List,
 		},
 	},
 
 	// If set to `true`, `ufbx_lod_level.distance` represents a screen size percentage.
-	relative_distances: c.bool,
+	relative_distances: bool,
 
 	// LOD levels matching in order to `ufbx_node.children`.
 	lod_levels: Lod_Level_List,
 
 	// If set to `true` don't account for parent transform when computing the distance.
-	ignore_parent_transform: c.bool,
+	ignore_parent_transform: bool,
 
 	// If `use_distance_limit` is enabled hide the group if the distance is not between
 	// `distance_limit_min` and `distance_limit_max`.
-	use_distance_limit: c.bool,
+	use_distance_limit: bool,
 	distance_limit_min: Real,
 	distance_limit_max: Real,
 }
@@ -1869,8 +1869,8 @@ SKINNING_METHOD_COUNT :: 4
 
 // Skin weight information for a single mesh vertex
 Skin_Vertex :: struct {
-	weight_begin: c.uint32_t, // < Index to start from in the `weights[]` array
-	num_weights:  c.uint32_t, // < Number of weights influencing the vertex
+	weight_begin: u32, // < Index to start from in the `weights[]` array
+	num_weights:  u32, // < Number of weights influencing the vertex
 
 	// Blend weight between Linear Blend Skinning (0.0) and Dual Quaternion (1.0).
 	// Should be used if `skinning_method == UFBX_SKINNING_METHOD_BLENDED_DQ_LINEAR`
@@ -1884,8 +1884,8 @@ Skin_Vertex_List :: struct {
 
 // Single per-vertex per-cluster weight, see `ufbx_skin_vertex`
 Skin_Weight :: struct {
-	cluster_index: c.uint32_t, // < Index into `ufbx_skin_deformer.clusters[]`
-	weight:        Real,       // < Amount this bone influence the vertex
+	cluster_index: u32,  // < Index into `ufbx_skin_deformer.clusters[]`
+	weight:        Real, // < Amount this bone influence the vertex
 }
 
 Skin_Weight_List :: struct {
@@ -1902,8 +1902,8 @@ Skin_Deformer :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 	skinning_method: Skinning_Method,
@@ -1933,8 +1933,8 @@ Skin_Cluster :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 
@@ -1971,8 +1971,8 @@ Blend_Deformer :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 
@@ -2005,8 +2005,8 @@ Blend_Channel :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 
@@ -2028,8 +2028,8 @@ Blend_Shape :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 	num_offsets:      c.size_t,    // < Number of vertex offsets in the following arrays
@@ -2091,7 +2091,7 @@ Cache_Frame :: struct {
 	channel: String,
 
 	// Time of this frame in seconds.
-	time: c.double,
+	time: f64,
 
 	// Name of the file containing the data.
 	// The specified file may contain multiple frames, use `data_offset` etc. to
@@ -2108,10 +2108,10 @@ Cache_Frame :: struct {
 	scale_factor: Real,
 	data_format:        Cache_Data_Format,   // < Format of the data in the file
 	data_encoding:      Cache_Data_Encoding, // < Binary encoding of the data
-	data_offset:        c.uint64_t,          // < Byte offset into the file
-	data_count:         c.uint32_t,          // < Number of data elements
-	data_element_bytes: c.uint32_t,          // < Size of a single data element in bytes
-	data_total_bytes:   c.uint64_t,          // < Size of the whole data blob in bytes
+	data_offset:        u64,                 // < Byte offset into the file
+	data_count:         u32,                 // < Number of data elements
+	data_element_bytes: u32,                 // < Size of a single data element in bytes
+	data_total_bytes:   u64,                 // < Size of the whole data blob in bytes
 }
 
 Cache_Frame_List :: struct {
@@ -2159,8 +2159,8 @@ Cache_Deformer :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 	channel:          String,
@@ -2177,8 +2177,8 @@ Cache_File :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 
@@ -2222,7 +2222,7 @@ Material_Map :: struct {
 		value_vec3: Vec3,
 		value_vec4: Vec4,
 	},
-	value_int: c.int64_t,
+	value_int: i64,
 
 	// Texture if connected, otherwise `NULL`.
 	// May be valid but "disabled" (application specific) if `texture_enabled == false`.
@@ -2231,27 +2231,27 @@ Material_Map :: struct {
 	// `true` if the file has specified any of the values above.
 	// NOTE: The value may be set to a non-zero default even if `has_value == false`,
 	// for example missing factors are set to `1.0` if a color is defined.
-	has_value: c.bool,
+	has_value: bool,
 
 	// Controls whether shading should use `texture`.
 	// NOTE: Some shading models allow this to be `true` even if `texture == NULL`.
-	texture_enabled: c.bool,
+	texture_enabled: bool,
 
 	// Set to `true` if this feature should be disabled (specific to shader type).
-	feature_disabled: c.bool,
+	feature_disabled: bool,
 
 	// Number of components in the value from 1 to 4 if defined, 0 if not.
-	value_components: c.uint8_t,
+	value_components: u8,
 }
 
 // Material feature
 Material_Feature_Info :: struct {
 	// Whether the material model uses this feature or not.
 	// NOTE: The feature can be enabled but still not used if eg. the corresponding factor is at zero!
-	enabled: c.bool,
+	enabled: bool,
 
 	// Explicitly enabled/disabled by the material.
-	is_explicit: c.bool,
+	is_explicit: bool,
 }
 
 // Texture attached to an FBX property
@@ -2574,8 +2574,8 @@ Material :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 
@@ -2714,7 +2714,7 @@ Shader_Texture_Input :: struct {
 		value_vec3: Vec3,
 		value_vec4: Vec4,
 	},
-	value_int:  c.int64_t,
+	value_int:  i64,
 	value_str:  String,
 	value_blob: Blob,
 
@@ -2722,11 +2722,11 @@ Shader_Texture_Input :: struct {
 	texture: ^Texture,
 
 	// Index of the output to use if `texture` is a multi-output shader node.
-	texture_output_index: c.int64_t,
+	texture_output_index: i64,
 
 	// Controls whether shading should use `texture`.
 	// NOTE: Some shading models allow this to be `true` even if `texture == NULL`.
-	texture_enabled: c.bool,
+	texture_enabled: bool,
 
 	// Property representing this input.
 	prop: ^Prop,
@@ -2758,7 +2758,7 @@ Shader_Texture :: struct {
 	shader_name: String,
 
 	// 64-bit opaque identifier for the shader type.
-	shader_type_id: c.uint64_t,
+	shader_type_id: u64,
 
 	// Input values/textures (possibly further shader textures) to the shader.
 	// Sorted by `ufbx_shader_texture_input.name`.
@@ -2774,7 +2774,7 @@ Shader_Texture :: struct {
 	main_texture: ^Texture,
 
 	// Output index of `main_texture` if it is a multi-output shader.
-	main_texture_output_index: c.int64_t,
+	main_texture_output_index: i64,
 
 	// Prefix for properties related to this shader in `ufbx_texture`.
 	// NOTE: Contains the trailing '|' if not empty.
@@ -2784,7 +2784,7 @@ Shader_Texture :: struct {
 // Unique texture within the file.
 Texture_File :: struct {
 	// Index in `ufbx_scene.texture_files[]`.
-	index: c.uint32_t,
+	index: u32,
 
 	// Filename relative to the currently loaded file.
 	// HINT: If using functions other than `ufbx_load_file()`, you can provide
@@ -2826,8 +2826,8 @@ Texture :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 
@@ -2865,10 +2865,10 @@ Texture :: struct {
 	video: ^Video,
 
 	// FILE: Index into `ufbx_scene.texture_files[]` or `UFBX_NO_INDEX`.
-	file_index: c.uint32_t,
+	file_index: u32,
 
 	// FILE: True if `file_index` has a valid value.
-	has_file: c.bool,
+	has_file: bool,
 
 	// LAYERED: Inner texture layers, ordered from _bottom_ to _top_
 	layers: Texture_Layer_List,
@@ -2888,7 +2888,7 @@ Texture :: struct {
 	// Wrapping mode
 	wrap_u: Wrap_Mode,
 	wrap_v:           Wrap_Mode,
-	has_uv_transform: c.bool,    // < Has a non-identity `transform` and derived matrices.
+	has_uv_transform: bool,      // < Has a non-identity `transform` and derived matrices.
 	uv_transform:     Transform, // < Texture transformation in UV space
 	texture_to_uv:    Matrix,    // < Matrix representation of `transform`
 	uv_to_texture:    Matrix,    // < UV coordinate to normalized texture coordinate matrix
@@ -2901,8 +2901,8 @@ Video :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 
@@ -2942,8 +2942,8 @@ Shader :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 
@@ -2973,8 +2973,8 @@ Shader_Binding :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 	prop_bindings: Shader_Prop_Binding_List, // < Sorted by `shader_prop`
@@ -2982,12 +2982,12 @@ Shader_Binding :: struct {
 
 // -- Animation
 Prop_Override :: struct {
-	element_id:    c.uint32_t,
-	_internal_key: c.uint32_t,
+	element_id:    u32,
+	_internal_key: u32,
 	prop_name:     String,
 	value:         Vec4,
 	value_str:     String,
-	value_int:     c.int64_t,
+	value_int:     i64,
 }
 
 Prop_Override_List :: struct {
@@ -2996,7 +2996,7 @@ Prop_Override_List :: struct {
 }
 
 Transform_Override :: struct {
-	node_id:   c.uint32_t,
+	node_id:   u32,
 	transform: Transform,
 }
 
@@ -3013,8 +3013,8 @@ Transform_Override_List :: struct {
 // with custom layers, property overrides, special flags, etc.
 Anim :: struct {
 	// Time begin/end for the animation, both may be zero if absent.
-	time_begin: c.double,
-	time_end: c.double,
+	time_begin: f64,
+	time_end: f64,
 
 	// List of layers in the animation.
 	layers: Anim_Layer_List,
@@ -3029,10 +3029,10 @@ Anim :: struct {
 	transform_overrides: Transform_Override_List,
 
 	// Evaluate connected properties as if they would not be connected.
-	ignore_connections: c.bool,
+	ignore_connections: bool,
 
 	// Custom `ufbx_anim` created by `ufbx_create_anim()`.
-	custom: c.bool,
+	custom: bool,
 }
 
 Anim_Stack :: struct {
@@ -3041,19 +3041,19 @@ Anim_Stack :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
-	time_begin: c.double,
-	time_end:   c.double,
+	time_begin: f64,
+	time_end:   f64,
 	layers:     Anim_Layer_List,
 	anim:       ^Anim,
 }
 
 Anim_Prop :: struct {
 	element:       ^Element,
-	_internal_key: c.uint32_t,
+	_internal_key: u32,
 	prop_name:     String,
 	anim_value:    ^Anim_Value,
 }
@@ -3069,22 +3069,22 @@ Anim_Layer :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 	weight:              Real,
-	weight_is_animated:  c.bool,
-	blended:             c.bool,
-	additive:            c.bool,
-	compose_rotation:    c.bool,
-	compose_scale:       c.bool,
+	weight_is_animated:  bool,
+	blended:             bool,
+	additive:            bool,
+	compose_rotation:    bool,
+	compose_scale:       bool,
 	anim_values:         Anim_Value_List,
 	anim_props:          Anim_Prop_List, // < Sorted by `element,prop_name`
 	anim:                ^Anim,
-	_min_element_id:     c.uint32_t,
-	_max_element_id:     c.uint32_t,
-	_element_id_bitmask: [4]c.uint32_t,
+	_min_element_id:     u32,
+	_max_element_id:     u32,
+	_element_id_bitmask: [4]u32,
 }
 
 Anim_Value :: struct {
@@ -3093,8 +3093,8 @@ Anim_Value :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 	default_value: Vec3,
@@ -3128,13 +3128,13 @@ Extrapolation :: struct {
 
 	// Count used for repeating modes.
 	// Negative values mean infinite repetition.
-	repeat_count: c.int32_t,
+	repeat_count: i32,
 }
 
 // Tangent vector at a keyframe, may be split into left/right
 Tangent :: struct {
-	dx: c.float, // < Derivative in the time axis
-	dy: c.float, // < Derivative in the (curve specific) value axis
+	dx: f32, // < Derivative in the time axis
+	dy: f32, // < Derivative in the (curve specific) value axis
 }
 
 // Single real `value` at a specified `time`, interpolation between two keyframes
@@ -3150,7 +3150,7 @@ Tangent :: struct {
 // HINT: You can use `ufbx_evaluate_curve(ufbx_anim_curve *curve, double time)`
 // rather than trying to manually handle all the interpolation modes.
 Keyframe :: struct {
-	time:          c.double,
+	time:          f64,
 	value:         Real,
 	interpolation: Interpolation,
 	left:          Tangent,
@@ -3168,8 +3168,8 @@ Anim_Curve :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 
@@ -3187,8 +3187,8 @@ Anim_Curve :: struct {
 	max_value: Real,
 
 	// Time range for all the keyframes.
-	min_time: c.double,
-	max_time:  c.double,
+	min_time: f64,
+	max_time:  f64,
 }
 
 // Collection of nodes to hide/freeze
@@ -3198,16 +3198,16 @@ Display_Layer :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 
 	// Nodes included in the layer (exclusively at most one layer per node)
 	nodes: Node_List,
-	visible:  c.bool, // < Contained nodes are visible
-	frozen:   c.bool, // < Contained nodes cannot be edited
-	ui_color: Vec3,   // < Visual color for UI
+	visible:  bool, // < Contained nodes are visible
+	frozen:   bool, // < Contained nodes cannot be edited
+	ui_color: Vec3, // < Visual color for UI
 }
 
 // Named set of nodes/geometry features to select.
@@ -3217,8 +3217,8 @@ Selection_Set :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 
@@ -3233,15 +3233,15 @@ Selection_Node :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 
 	// Selection targets, possibly `NULL`
 	target_node: ^Node,
 	target_mesh:  ^Mesh,
-	include_node: c.bool,      // < Is `target_node` included in the selection
+	include_node: bool,        // < Is `target_node` included in the selection
 	vertices:     Uint32_List, // < Indices to `ufbx_mesh.vertices`
 	edges:        Uint32_List, // < Indices to `ufbx_mesh.edges`
 	faces:        Uint32_List, // < Indices to `ufbx_mesh.faces`
@@ -3254,8 +3254,8 @@ Character :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 }
@@ -3317,8 +3317,8 @@ Constraint :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 
@@ -3334,12 +3334,12 @@ Constraint :: struct {
 
 	// State of the constraint
 	weight: Real,
-	active:             c.bool,
+	active:             bool,
 
 	// Translation/rotation/scale axes the constraint is applied to
-	constrain_translation: [3]c.bool,
-	constrain_rotation: [3]c.bool,
-	constrain_scale:    [3]c.bool,
+	constrain_translation: [3]bool,
+	constrain_rotation: [3]bool,
+	constrain_scale:    [3]bool,
 
 	// Offset from the constrained position
 	transform_offset: Transform,
@@ -3363,8 +3363,8 @@ Audio_Layer :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 
@@ -3378,8 +3378,8 @@ Audio_Clip :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 
@@ -3436,13 +3436,13 @@ Pose :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 
 	// Set if this pose is marked as a bind pose.
-	is_bind_pose: c.bool,
+	is_bind_pose: bool,
 
 	// List of bone poses.
 	// Sorted by `ufbx_node.typed_id`.
@@ -3455,8 +3455,8 @@ Metadata_Object :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: c.uint32_t,
-			typed_id:   c.uint32_t,
+			element_id: u32,
+			typed_id:   u32,
 		},
 	},
 }
@@ -3465,7 +3465,7 @@ Metadata_Object :: struct {
 Name_Element :: struct {
 	name:          String,
 	type:          Element_Type,
-	_internal_key: c.uint32_t,
+	_internal_key: u32,
 	element:       ^Element,
 }
 
@@ -3574,7 +3574,7 @@ Warning :: struct {
 	description: String,
 
 	// The element related to this warning or `UFBX_NO_INDEX` if not related to a specific element.
-	element_id: c.uint32_t,
+	element_id: u32,
 
 	// Number of times this warning was encountered.
 	count: c.size_t,
@@ -3624,8 +3624,8 @@ Thumbnail :: struct {
 	props:  Props,
 
 	// Extents of the thumbnail
-	width: c.uint32_t,
-	height: c.uint32_t,
+	width: u32,
+	height: u32,
 
 	// Format of `ufbx_thumbnail.data`.
 	format: Thumbnail_Format,
@@ -3643,48 +3643,48 @@ Metadata :: struct {
 	warnings: Warning_List,
 
 	// FBX ASCII file format.
-	ascii: c.bool,
+	ascii: bool,
 
 	// FBX version in integer format, eg. 7400 for 7.4.
-	version: c.uint32_t,
+	version: u32,
 
 	// File format of the source file.
 	file_format: File_Format,
 
 	// Index arrays may contain `UFBX_NO_INDEX` instead of a valid index
 	// to indicate gaps.
-	may_contain_no_index: c.bool,
+	may_contain_no_index: bool,
 
 	// May contain meshes with no defined vertex position.
 	// NOTE: `ufbx_mesh.vertex_position.exists` may be `false`!
-	may_contain_missing_vertex_position: c.bool,
+	may_contain_missing_vertex_position: bool,
 
 	// Arrays may contain items with `NULL` element references.
 	// See `ufbx_load_opts.connect_broken_elements`.
-	may_contain_broken_elements: c.bool,
+	may_contain_broken_elements: bool,
 
 	// Some API guarantees do not apply (depending on unsafe options used).
 	// Loaded with `ufbx_load_opts.allow_unsafe` enabled.
-	is_unsafe: c.bool,
+	is_unsafe: bool,
 
 	// Flag for each possible warning type.
 	// See `ufbx_metadata.warnings[]` for detailed warning information.
-	has_warning: [15]c.bool,
+	has_warning: [15]bool,
 	creator:                        String,
-	big_endian:                     c.bool,
+	big_endian:                     bool,
 	filename:                       String,
 	relative_root:                  String,
 	raw_filename:                   Blob,
 	raw_relative_root:              Blob,
 	exporter:                       Exporter,
-	exporter_version:               c.uint32_t,
+	exporter_version:               u32,
 	scene_props:                    Props,
 	original_application:           Application,
 	latest_application:             Application,
 	thumbnail:                      Thumbnail,
-	geometry_ignored:               c.bool,
-	animation_ignored:              c.bool,
-	embedded_ignored:               c.bool,
+	geometry_ignored:               bool,
+	animation_ignored:              bool,
+	embedded_ignored:               bool,
 	max_face_triangles:             c.size_t,
 	result_memory_used:             c.size_t,
 	temp_memory_used:               c.size_t,
@@ -3693,9 +3693,9 @@ Metadata :: struct {
 	element_buffer_size:            c.size_t,
 	num_shader_textures:            c.size_t,
 	bone_prop_size_unit:            Real,
-	bone_prop_limb_length_relative: c.bool,
+	bone_prop_limb_length_relative: bool,
 	ortho_size_unit:                Real,
-	ktime_second:                   c.int64_t, // < One second in internal KTime units
+	ktime_second:                   i64, // < One second in internal KTime units
 	original_file_path:             String,
 	raw_original_file_path:         Blob,
 
@@ -3773,7 +3773,7 @@ Scene_Settings :: struct {
 	unit_meters: Real,
 
 	// Frames per second the animation is defined at.
-	frames_per_second: c.double,
+	frames_per_second: f64,
 	ambient_color:        Vec3,
 	default_camera:       String,
 
@@ -3884,13 +3884,13 @@ Scene :: struct {
 
 // -- Curves
 Curve_Point :: struct {
-	valid:      c.bool,
+	valid:      bool,
 	position:   Vec3,
 	derivative: Vec3,
 }
 
 Surface_Point :: struct {
-	valid:        c.bool,
+	valid:        bool,
 	position:     Vec3,
 	derivative_u: Vec3,
 	derivative_v: Vec3,
@@ -3903,12 +3903,12 @@ Topo_Flags :: enum c.int {
 }
 
 Topo_Edge :: struct {
-	index: c.uint32_t, // < Starting index of the edge, always defined
-	next:  c.uint32_t, // < Ending index of the edge / next per-face `ufbx_topo_edge`, always defined
-	prev:  c.uint32_t, // < Previous per-face `ufbx_topo_edge`, always defined
-	twin:  c.uint32_t, // < `ufbx_topo_edge` on the opposite side, `UFBX_NO_INDEX` if not found
-	face:  c.uint32_t, // < Index into `mesh->faces[]`, always defined
-	edge:  c.uint32_t, // < Index into `mesh->edges[]`, `UFBX_NO_INDEX` if not found
+	index: u32, // < Starting index of the edge, always defined
+	next:  u32, // < Ending index of the edge / next per-face `ufbx_topo_edge`, always defined
+	prev:  u32, // < Previous per-face `ufbx_topo_edge`, always defined
+	twin:  u32, // < `ufbx_topo_edge` on the opposite side, `UFBX_NO_INDEX` if not found
+	face:  u32, // < Index into `mesh->faces[]`, always defined
+	edge:  u32, // < Index into `mesh->edges[]`, `UFBX_NO_INDEX` if not found
 	flags: Topo_Flags,
 }
 
@@ -3983,11 +3983,11 @@ Allocator_Opts :: struct {
 Read_Fn :: proc "c" (rawptr, rawptr, c.size_t) -> c.size_t
 
 // Skip `size` bytes in the file.
-Skip_Fn :: proc "c" (rawptr, c.size_t) -> c.bool
+Skip_Fn :: proc "c" (rawptr, c.size_t) -> bool
 
 // Get the size of the file.
 // Return `0` if unknown, `UINT64_MAX` if error.
-Size_Fn :: proc "c" (rawptr) -> c.uint64_t
+Size_Fn :: proc "c" (rawptr) -> u64
 
 // Close the file
 Close_Fn :: proc "c" (rawptr)
@@ -4028,7 +4028,7 @@ Open_File_Info :: struct {
 }
 
 // Callback for opening an external file from the filesystem
-Open_File_Fn :: proc "c" (rawptr, ^Stream, cstring, c.size_t, ^Open_File_Info) -> c.bool
+Open_File_Fn :: proc "c" (rawptr, ^Stream, cstring, c.size_t, ^Open_File_Info) -> bool
 
 Open_File_Cb :: struct {
 	fn:   Open_File_Fn,
@@ -4037,14 +4037,14 @@ Open_File_Cb :: struct {
 
 // Options for `ufbx_open_file()`.
 Open_File_Opts :: struct {
-	_begin_zero: c.uint32_t,
+	_begin_zero: u32,
 
 	// Allocator to allocate the memory with.
 	allocator: Allocator_Opts,
 
 	// The filename is guaranteed to be NULL-terminated.
-	filename_null_terminated: c.bool,
-	_end_zero:   c.uint32_t,
+	filename_null_terminated: bool,
+	_end_zero:   u32,
 }
 
 // Memory stream options
@@ -4057,7 +4057,7 @@ Close_Memory_Cb :: struct {
 
 // Options for `ufbx_open_memory()`.
 Open_Memory_Opts :: struct {
-	_begin_zero: c.uint32_t,
+	_begin_zero: u32,
 
 	// Allocator to allocate the memory with.
 	// NOTE: Used even if no copy is made to allocate a small metadata block.
@@ -4067,17 +4067,17 @@ Open_Memory_Opts :: struct {
 	// You can use `close_cb` to free the memory when the stream is closed.
 	// NOTE: This means the provided data pointer is referenced after creating
 	// the memory stream, make sure the data stays valid until the stream is closed!
-	no_copy: c.bool,
+	no_copy: bool,
 
 	// Callback to free the memory blob.
 	close_cb: Close_Memory_Cb,
-	_end_zero:   c.uint32_t,
+	_end_zero:   u32,
 }
 
 // Detailed error stack frame.
 // NOTE: You must compile `ufbx.c` with `UFBX_ENABLE_ERROR_STACK` to enable the error stack.
 Error_Frame :: struct {
-	source_line: c.uint32_t,
+	source_line: u32,
 	function:    String,
 	description: String,
 }
@@ -4184,7 +4184,7 @@ Error :: struct {
 
 	// Internal error stack.
 	// NOTE: You must compile `ufbx.c` with `UFBX_ENABLE_ERROR_STACK` to enable the error stack.
-	stack_size: c.uint32_t,
+	stack_size: u32,
 	stack: [8]Error_Frame,
 
 	// Additional error information, such as missing file filename.
@@ -4195,8 +4195,8 @@ Error :: struct {
 
 // Loading progress information.
 Progress :: struct {
-	bytes_read:  c.uint64_t,
-	bytes_total: c.uint64_t,
+	bytes_read:  u64,
+	bytes_total: u64,
 }
 
 // Progress result returned from `ufbx_progress_fn()` callback.
@@ -4238,17 +4238,17 @@ Inflate_Input :: struct {
 
 	// (optional) Progress reporting
 	progress_cb: Progress_Cb,
-	progress_interval_hint: c.uint64_t, // < Bytes between progress report calls
+	progress_interval_hint: u64, // < Bytes between progress report calls
 
 	// (optional) Change the progress scope
-	progress_size_before: c.uint64_t,
-	progress_size_after:    c.uint64_t,
+	progress_size_before: u64,
+	progress_size_after:    u64,
 
 	// (optional) No the DEFLATE header
-	no_header: c.bool,
+	no_header: bool,
 
 	// (optional) No the Adler32 checksum
-	no_checksum: c.bool,
+	no_checksum: bool,
 
 	// (optional) Force internal fast lookup bit amount
 	internal_fast_bits: c.size_t,
@@ -4257,8 +4257,8 @@ Inflate_Input :: struct {
 // Persistent data between `ufbx_inflate()` calls
 // NOTE: You must set `initialized` to `false`, but `data` may be uninitialized
 Inflate_Retain :: struct {
-	initialized: c.bool,
-	data:        [1024]c.uint64_t,
+	initialized: bool,
+	data:        [1024]u64,
 }
 
 Index_Error_Handling :: enum c.int {
@@ -4424,7 +4424,7 @@ Baked_Key_Flags :: distinct bit_set[Baked_Key_Flag; c.int]
 BAKED_KEY_FORCE_32BIT :: Baked_Key_Flags { .STEP_LEFT, .STEP_RIGHT, .STEP_KEY, .KEYFRAME, .REDUCED }
 
 Baked_Vec3 :: struct {
-	time:  c.double,       // < Time of the keyframe, in seconds
+	time:  f64,            // < Time of the keyframe, in seconds
 	value: Vec3,           // < Value at `time`, can be linearly interpolated
 	flags: Baked_Key_Flag, // < Additional information about the keyframe
 }
@@ -4435,7 +4435,7 @@ Baked_Vec3_List :: struct {
 }
 
 Baked_Quat :: struct {
-	time:  c.double,       // < Time of the keyframe, in seconds
+	time:  f64,            // < Time of the keyframe, in seconds
 	value: Quat,           // < Value at `time`, can be (spherically) linearly interpolated
 	flags: Baked_Key_Flag, // < Additional information about the keyframe
 }
@@ -4448,19 +4448,19 @@ Baked_Quat_List :: struct {
 // Baked transform animation for a single node.
 Baked_Node :: struct {
 	// Typed ID of the node, maps to `ufbx_scene.nodes[]`.
-	typed_id: c.uint32_t,
+	typed_id: u32,
 
 	// Element ID of the element, maps to `ufbx_scene.elements[]`.
-	element_id: c.uint32_t,
+	element_id: u32,
 
 	// The translation channel has constant values for the whole animation.
-	constant_translation: c.bool,
+	constant_translation: bool,
 
 	// The rotation channel has constant values for the whole animation.
-	constant_rotation: c.bool,
+	constant_rotation: bool,
 
 	// The scale channel has constant values for the whole animation.
-	constant_scale: c.bool,
+	constant_scale: bool,
 
 	// Translation keys for the animation, maps to `ufbx_node.local_transform.translation`.
 	translation_keys: Baked_Vec3_List,
@@ -4483,7 +4483,7 @@ Baked_Prop :: struct {
 	name: String,
 
 	// The value of the property is constant for the whole animation.
-	constant_value: c.bool,
+	constant_value: bool,
 
 	// Property value keys.
 	keys: Baked_Vec3_List,
@@ -4497,7 +4497,7 @@ Baked_Prop_List :: struct {
 // Baked property animation for a single element.
 Baked_Element :: struct {
 	// Element ID of the element, maps to `ufbx_scene.elements[]`.
-	element_id: c.uint32_t,
+	element_id: u32,
 
 	// List of properties the animation modifies.
 	props: Baked_Prop_List,
@@ -4529,13 +4529,13 @@ Baked_Anim :: struct {
 	elements: Baked_Element_List,
 
 	// Playback time range for the animation.
-	playback_time_begin: c.double,
-	playback_time_end: c.double,
-	playback_duration: c.double,
+	playback_time_begin: f64,
+	playback_time_end: f64,
+	playback_duration: f64,
 
 	// Keyframe time range.
-	key_time_min: c.double,
-	key_time_max:      c.double,
+	key_time_min: f64,
+	key_time_max:      f64,
 
 	// Additional bake information.
 	metadata: Baked_Anim_Metadata,
@@ -4548,22 +4548,22 @@ Thread_Pool_Context :: c.uintptr_t
 
 // Thread pool creation information from ufbx.
 Thread_Pool_Info :: struct {
-	max_concurrent_tasks: c.uint32_t,
+	max_concurrent_tasks: u32,
 }
 
 // Initialize the thread pool.
 // Return `true` on success.
-Thread_Pool_Init_Fn :: proc "c" (rawptr, Thread_Pool_Context, ^Thread_Pool_Info) -> c.bool
+Thread_Pool_Init_Fn :: proc "c" (rawptr, Thread_Pool_Context, ^Thread_Pool_Info) -> bool
 
 // Run tasks `count` tasks in threads.
 // You must call `ufbx_thread_pool_run_task()` with indices `[start_index, start_index + count)`.
 // The threads are launched in batches indicated by `group`, see `UFBX_THREAD_GROUP_COUNT` for more information.
 // Ideally, you should run all the task indices in parallel within each `ufbx_thread_pool_run_fn()` call.
-Thread_Pool_Run_Fn :: proc "c" (rawptr, Thread_Pool_Context, c.uint32_t, c.uint32_t, c.uint32_t)
+Thread_Pool_Run_Fn :: proc "c" (rawptr, Thread_Pool_Context, u32, u32, u32)
 
 // Wait for previous tasks spawned in `ufbx_thread_pool_run_fn()` to finish.
 // `group` specifies the batch to wait for, `max_index` contains `start_index + count` from that group instance.
-Thread_Pool_Wait_Fn :: proc "c" (rawptr, Thread_Pool_Context, c.uint32_t, c.uint32_t)
+Thread_Pool_Wait_Fn :: proc "c" (rawptr, Thread_Pool_Context, u32, u32)
 
 // Free the thread pool.
 Thread_Pool_Free_Fn :: proc "c" (rawptr, Thread_Pool_Context)
@@ -4614,16 +4614,16 @@ Evaluate_Flags :: enum c.int {
 // Options for `ufbx_load_file/memory/stream/stdio()`
 // NOTE: Initialize to zero with `{ 0 }` (C) or `{ }` (C++)
 Load_Opts :: struct {
-	_begin_zero:            c.uint32_t,
+	_begin_zero:            u32,
 	temp_allocator:         Allocator_Opts, // < Allocator used during loading
 	result_allocator:       Allocator_Opts, // < Allocator used for the final scene
 	thread_opts:            Thread_Opts,    // < Threading options
-	ignore_geometry:        c.bool,         // < Do not load geometry datsa (vertices, indices, etc)
-	ignore_animation:       c.bool,         // < Do not load animation curves
-	ignore_embedded:        c.bool,         // < Do not load embedded content
-	ignore_all_content:     c.bool,         // < Do not load any content (geometry, animation, embedded)
-	evaluate_skinning:      c.bool,         // < Evaluate skinning (see ufbx_mesh.skinned_vertices)
-	evaluate_caches:        c.bool,         // < Evaluate vertex caches (see ufbx_mesh.skinned_vertices)
+	ignore_geometry:        bool,           // < Do not load geometry datsa (vertices, indices, etc)
+	ignore_animation:       bool,           // < Do not load animation curves
+	ignore_embedded:        bool,           // < Do not load embedded content
+	ignore_all_content:     bool,           // < Do not load any content (geometry, animation, embedded)
+	evaluate_skinning:      bool,           // < Evaluate skinning (see ufbx_mesh.skinned_vertices)
+	evaluate_caches:        bool,           // < Evaluate vertex caches (see ufbx_mesh.skinned_vertices)
 
 	// Try to open external files referenced by the main file automatically.
 	// Applies to geometry caches and .mtl files for OBJ.
@@ -4635,41 +4635,41 @@ Load_Opts :: struct {
 	// NOTE: Will fail loading if any external files are not found by default, use
 	// `ufbx_load_opts.ignore_missing_external_files` to suppress this, in this case
 	// you can find the errors at `ufbx_metadata.warnings[]` as `UFBX_WARNING_MISSING_EXTERNAL_FILE`.
-	load_external_files: c.bool,
+	load_external_files: bool,
 
 	// Don't fail loading if external files are not found.
-	ignore_missing_external_files: c.bool,
+	ignore_missing_external_files: bool,
 
 	// Don't compute `ufbx_skin_deformer` `vertices` and `weights` arrays saving
 	// a bit of memory and time if not needed
-	skip_skin_vertices: c.bool,
+	skip_skin_vertices: bool,
 
 	// Skip computing `ufbx_mesh.material_parts[]` and `ufbx_mesh.face_group_parts[]`.
-	skip_mesh_parts: c.bool,
+	skip_mesh_parts: bool,
 
 	// Clean-up skin weights by removing negative, zero and NAN weights.
-	clean_skin_weights: c.bool,
+	clean_skin_weights: bool,
 
 	// Read Blender materials as PBR values.
 	// Blender converts PBR materials to legacy FBX Phong materials in a deterministic way.
 	// If this setting is enabled, such materials will be read as `UFBX_SHADER_BLENDER_PHONG`,
 	// which means ufbx will be able to parse roughness and metallic textures.
-	use_blender_pbr_material: c.bool,
+	use_blender_pbr_material: bool,
 
 	// Don't adjust reading the FBX file depending on the detected exporter
-	disable_quirks: c.bool,
+	disable_quirks: bool,
 
 	// Don't allow partially broken FBX files to load
-	strict: c.bool,
+	strict: bool,
 
 	// Force ASCII parsing to use a single thread.
 	// The multi-threaded ASCII parsing is slightly more lenient as it ignores
 	// the self-reported size of ASCII arrays, that threaded parsing depends on.
-	force_single_thread_ascii_parsing: c.bool,
+	force_single_thread_ascii_parsing: bool,
 
 	// UNSAFE: If enabled allows using unsafe options that may fundamentally
 	// break the API guarantees.
-	allow_unsafe: c.bool,
+	allow_unsafe: bool,
 
 	// Specify how to handle broken indices.
 	index_error_handling: Index_Error_Handling,
@@ -4677,25 +4677,25 @@ Load_Opts :: struct {
 	// Connect related elements even if they are broken. If `false` (default)
 	// `ufbx_skin_cluster` with a missing `bone` field are _not_ included in
 	// the `ufbx_skin_deformer.clusters[]` array for example.
-	connect_broken_elements: c.bool,
+	connect_broken_elements: bool,
 
 	// Allow nodes that are not connected in any way to the root. Conversely if
 	// disabled, all lone nodes will be parented under `ufbx_scene.root_node`.
-	allow_nodes_out_of_root: c.bool,
+	allow_nodes_out_of_root: bool,
 
 	// Allow meshes with no vertex position attribute.
 	// NOTE: If this is set `ufbx_mesh.vertex_position.exists` may be `false`.
-	allow_missing_vertex_position: c.bool,
+	allow_missing_vertex_position: bool,
 
 	// Allow faces with zero indices.
-	allow_empty_faces: c.bool,
+	allow_empty_faces: bool,
 
 	// Generate vertex normals for a meshes that are missing normals.
 	// You can see if the normals have been generated from `ufbx_mesh.generated_normals`.
-	generate_missing_normals: c.bool,
+	generate_missing_normals: bool,
 
 	// Ignore `open_file_cb` when loading the main file.
-	open_main_file_with_default: c.bool,
+	open_main_file_with_default: bool,
 
 	// Path separator character, defaults to '\' on Windows and '/' otherwise.
 	path_separator: c.char,
@@ -4704,10 +4704,10 @@ Load_Opts :: struct {
 	// Will fail with `UFBX_ERROR_NODE_DEPTH_LIMIT` if a node is deeper than this limit.
 	// NOTE: The default of 0 allows arbitrarily deep hierarchies. Be careful if using
 	// recursive algorithms without setting this limit.
-	node_depth_limit: c.uint32_t,
+	node_depth_limit: u32,
 
 	// Estimated file size for progress reporting
-	file_size_estimate: c.uint64_t,
+	file_size_estimate: u64,
 
 	// Buffer size in bytes to use for reading from files or IO callbacks
 	read_buffer_size: c.size_t,
@@ -4723,7 +4723,7 @@ Load_Opts :: struct {
 
 	// Progress reporting
 	progress_cb: Progress_Cb,
-	progress_interval_hint: c.uint64_t,     // < Bytes between progress report calls
+	progress_interval_hint: u64,            // < Bytes between progress report calls
 
 	// External file callbacks (defaults to stdio.h)
 	open_file_cb: Open_File_Cb,
@@ -4748,12 +4748,12 @@ Load_Opts :: struct {
 	handedness_conversion_axis: Mirror_Axis,
 
 	// Do not change winding of faces when converting handedness.
-	handedness_conversion_retain_winding: c.bool,
+	handedness_conversion_retain_winding: bool,
 
 	// Reverse winding of all faces.
 	// If `handedness_conversion_retain_winding` is not specified, mirrored meshes
 	// will retain their original winding.
-	reverse_winding: c.bool,
+	reverse_winding: bool,
 
 	// Apply an implicit root transformation to match axes.
 	// Used if `ufbx_coordinate_axes_valid(target_axes)`.
@@ -4782,27 +4782,27 @@ Load_Opts :: struct {
 	scale_helper_name: String,
 
 	// Normalize vertex normals.
-	normalize_normals: c.bool,
+	normalize_normals: bool,
 
 	// Normalize tangents and bitangents.
-	normalize_tangents: c.bool,
+	normalize_tangents: bool,
 
 	// Override for the root transform
-	use_root_transform: c.bool,
+	use_root_transform: bool,
 	root_transform:         Transform,
 
 	// Animation keyframe clamp threshold, only applies to specific interpolation modes.
-	key_clamp_threshold: c.double,
+	key_clamp_threshold: f64,
 
 	// Specify how to handle Unicode errors in strings.
 	unicode_error_handling: Unicode_Error_Handling,
 
 	// Retain the 'W' component of mesh normal/tangent/bitangent.
 	// See `ufbx_vertex_attrib.values_w`.
-	retain_vertex_attrib_w: c.bool,
+	retain_vertex_attrib_w: bool,
 
 	// Retain the raw document structure using `ufbx_dom_node`.
-	retain_dom: c.bool,
+	retain_dom: bool,
 
 	// Force a specific file format instead of detecting it.
 	file_format: File_Format,
@@ -4812,27 +4812,27 @@ Load_Opts :: struct {
 	file_format_lookahead: c.size_t,
 
 	// Do not attempt to detect file format from file content.
-	no_format_from_content: c.bool,
+	no_format_from_content: bool,
 
 	// Do not attempt to detect file format from filename extension.
 	// ufbx primarily detects file format from the file header,
 	// this is just used as a fallback.
-	no_format_from_extension: c.bool,
+	no_format_from_extension: bool,
 
 	// (.obj) Try to find .mtl file with matching filename as the .obj file.
 	// Used if the file specified `mtllib` line is not found, eg. for a file called
 	// `model.obj` that contains the line `usemtl materials.mtl`, ufbx would first
 	// try to open `materials.mtl` and if that fails it tries to open `model.mtl`.
-	obj_search_mtl_by_filename: c.bool,
+	obj_search_mtl_by_filename: bool,
 
 	// (.obj) Don't split geometry into meshes by object.
-	obj_merge_objects: c.bool,
+	obj_merge_objects: bool,
 
 	// (.obj) Don't split geometry into meshes by groups.
-	obj_merge_groups: c.bool,
+	obj_merge_groups: bool,
 
 	// (.obj) Force splitting groups even on object boundaries.
-	obj_split_groups: c.bool,
+	obj_split_groups: bool,
 
 	// (.obj) Path to the .mtl file.
 	// Use `length = SIZE_MAX` for NULL-terminated strings.
@@ -4852,32 +4852,32 @@ Load_Opts :: struct {
 	// .obj files do not define the coordinate space they use. By default no
 	// coordinate space is assumed and no conversion is performed.
 	obj_axes: Coordinate_Axes,
-	_end_zero:              c.uint32_t,
+	_end_zero:              u32,
 }
 
 // Options for `ufbx_evaluate_scene()`
 // NOTE: Initialize to zero with `{ 0 }` (C) or `{ }` (C++)
 Evaluate_Opts :: struct {
-	_begin_zero:       c.uint32_t,
+	_begin_zero:       u32,
 	temp_allocator:    Allocator_Opts, // < Allocator used during evaluation
 	result_allocator:  Allocator_Opts, // < Allocator used for the final scene
-	evaluate_skinning: c.bool,         // < Evaluate skinning (see ufbx_mesh.skinned_vertices)
-	evaluate_caches:   c.bool,         // < Evaluate vertex caches (see ufbx_mesh.skinned_vertices)
+	evaluate_skinning: bool,           // < Evaluate skinning (see ufbx_mesh.skinned_vertices)
+	evaluate_caches:   bool,           // < Evaluate vertex caches (see ufbx_mesh.skinned_vertices)
 
 	// Evaluation flags.
 	// See `ufbx_evaluate_flags` for information.
-	evaluate_flags: c.uint32_t,
+	evaluate_flags: u32,
 
 	// WARNING: Potentially unsafe! Try to open external files such as geometry caches
-	load_external_files: c.bool,
+	load_external_files: bool,
 
 	// External file callbacks (defaults to stdio.h)
 	open_file_cb: Open_File_Cb,
-	_end_zero:         c.uint32_t,
+	_end_zero:         u32,
 }
 
 Const_Uint32_List :: struct {
-	data:  ^c.uint32_t,
+	data:  ^u32,
 	count: c.size_t,
 }
 
@@ -4888,7 +4888,7 @@ Const_Real_List :: struct {
 
 Prop_Override_Desc :: struct {
 	// Element (`ufbx_element.element_id`) to override the property from
-	element_id: c.uint32_t,
+	element_id: u32,
 
 	// Property name to override.
 	prop_name: String,
@@ -4897,7 +4897,7 @@ Prop_Override_Desc :: struct {
 	// from `value.x` if zero so keep `value` zeroed even if you don't need it!
 	value: Vec4,
 	value_str: String,
-	value_int: c.int64_t,
+	value_int: i64,
 }
 
 Const_Prop_Override_Desc_List :: struct {
@@ -4911,7 +4911,7 @@ Const_Transform_Override_List :: struct {
 }
 
 Anim_Opts :: struct {
-	_begin_zero:      c.uint32_t,
+	_begin_zero:      u32,
 
 	// Animation layers indices.
 	// Corresponding to `ufbx_scene.anim_layers[]`, aka `ufbx_anim_layer.typed_id`.
@@ -4929,9 +4929,9 @@ Anim_Opts :: struct {
 	transform_overrides: Const_Transform_Override_List,
 
 	// Ignore connected properties
-	ignore_connections: c.bool,
+	ignore_connections: bool,
 	result_allocator: Allocator_Opts, // < Allocator used to create the `ufbx_anim`
-	_end_zero:        c.uint32_t,
+	_end_zero:        u32,
 }
 
 // Specifies how to handle stepped tangents.
@@ -4963,7 +4963,7 @@ Bake_Step_Handling :: enum c.int {
 BAKE_STEP_HANDLING_COUNT :: 5
 
 Bake_Opts :: struct {
-	_begin_zero:      c.uint32_t,
+	_begin_zero:      u32,
 	temp_allocator:   Allocator_Opts, // < Allocator used during loading
 	result_allocator: Allocator_Opts, // < Allocator used for the final baked animation
 
@@ -4972,34 +4972,34 @@ Bake_Opts :: struct {
 	// [0, 30] in the baked animation.
 	// NOTE: This is in general not equivalent to subtracting `ufbx_anim.time_begin`
 	// from each keyframe, as this trimming is done exactly using internal FBX ticks.
-	trim_start_time: c.bool,
+	trim_start_time: bool,
 
 	// Samples per second to use for resampling non-linear animation.
 	// Default: 30
-	resample_rate: c.double,
+	resample_rate: f64,
 
 	// Minimum sample rate to not resample.
 	// Many exporters resample animation by default. To avoid double-resampling
 	// keyframe rates higher or equal to this will not be resampled.
 	// Default: 19.5
-	minimum_sample_rate: c.double,
+	minimum_sample_rate: f64,
 
 	// Maximum sample rate to use, this will remove keys if they are too close together.
 	// Default: unlimited
-	maximum_sample_rate: c.double,
+	maximum_sample_rate: f64,
 
 	// Bake the raw versions of properties related to transforms.
-	bake_transform_props: c.bool,
+	bake_transform_props: bool,
 
 	// Do not bake node transforms.
-	skip_node_transforms: c.bool,
+	skip_node_transforms: bool,
 
 	// Do not resample linear rotation keyframes.
 	// FBX interpolates rotation in Euler angles, so this might cause incorrect interpolation.
-	no_resample_rotation: c.bool,
+	no_resample_rotation: bool,
 
 	// Ignore layer weight animation.
-	ignore_layer_weight_animation: c.bool,
+	ignore_layer_weight_animation: bool,
 
 	// Maximum number of segments to generate from one keyframe.
 	// Default: 32
@@ -5009,51 +5009,51 @@ Bake_Opts :: struct {
 	step_handling: Bake_Step_Handling,
 
 	// Interpolation duration used by `UFBX_BAKE_STEP_HANDLING_CUSTOM_DURATION`.
-	step_custom_duration: c.double,
+	step_custom_duration: f64,
 
 	// Interpolation epsilon used by `UFBX_BAKE_STEP_HANDLING_CUSTOM_DURATION`.
 	// Defined as the minimum fractional decrease/increase in key time, ie.
 	// `time / (1.0 + step_custom_epsilon)` and `time * (1.0 + step_custom_epsilon)`.
-	step_custom_epsilon: c.double,
+	step_custom_epsilon: f64,
 
 	// Flags passed to animation evaluation functions.
 	// See `ufbx_evaluate_flags`.
-	evaluate_flags: c.uint32_t,
+	evaluate_flags: u32,
 
 	// Enable key reduction.
-	key_reduction_enabled: c.bool,
+	key_reduction_enabled: bool,
 
 	// Enable key reduction for non-constant rotations.
 	// Assumes rotations will be interpolated using a spherical linear interpolation at runtime.
-	key_reduction_rotation: c.bool,
+	key_reduction_rotation: bool,
 
 	// Threshold for reducing keys for linear segments.
 	// Default `0.000001`, use negative to disable.
-	key_reduction_threshold: c.double,
+	key_reduction_threshold: f64,
 
 	// Maximum passes over the keys to reduce.
 	// Every pass can potentially halve the the amount of keys.
 	// Default: `4`
 	key_reduction_passes: c.size_t,
-	_end_zero:        c.uint32_t,
+	_end_zero:        u32,
 }
 
 // Options for `ufbx_tessellate_nurbs_curve()`
 // NOTE: Initialize to zero with `{ 0 }` (C) or `{ }` (C++)
 Tessellate_Curve_Opts :: struct {
-	_begin_zero:      c.uint32_t,
+	_begin_zero:      u32,
 	temp_allocator:   Allocator_Opts, // < Allocator used during tessellation
 	result_allocator: Allocator_Opts, // < Allocator used for the final line curve
 
 	// How many segments tessellate each span in `ufbx_nurbs_basis.spans`.
 	span_subdivision: c.size_t,
-	_end_zero:        c.uint32_t,
+	_end_zero:        u32,
 }
 
 // Options for `ufbx_tessellate_nurbs_surface()`
 // NOTE: Initialize to zero with `{ 0 }` (C) or `{ }` (C++)
 Tessellate_Surface_Opts :: struct {
-	_begin_zero:        c.uint32_t,
+	_begin_zero:        u32,
 	temp_allocator:     Allocator_Opts, // < Allocator used during tessellation
 	result_allocator:   Allocator_Opts, // < Allocator used for the final mesh
 
@@ -5066,52 +5066,52 @@ Tessellate_Surface_Opts :: struct {
 	span_subdivision_v: c.size_t,
 
 	// Skip computing `ufbx_mesh.material_parts[]`
-	skip_mesh_parts: c.bool,
-	_end_zero:          c.uint32_t,
+	skip_mesh_parts: bool,
+	_end_zero:          u32,
 }
 
 // Options for `ufbx_subdivide_mesh()`
 // NOTE: Initialize to zero with `{ 0 }` (C) or `{ }` (C++)
 Subdivide_Opts :: struct {
-	_begin_zero:      c.uint32_t,
+	_begin_zero:      u32,
 	temp_allocator:   Allocator_Opts, // < Allocator used during subdivision
 	result_allocator: Allocator_Opts, // < Allocator used for the final mesh
 	boundary:         Subdivision_Boundary,
 	uv_boundary:      Subdivision_Boundary,
 
 	// Do not generate normals
-	ignore_normals: c.bool,
+	ignore_normals: bool,
 
 	// Interpolate existing normals using the subdivision rules
 	// instead of generating new normals
-	interpolate_normals: c.bool,
+	interpolate_normals: bool,
 
 	// Subdivide also tangent attributes
-	interpolate_tangents: c.bool,
+	interpolate_tangents: bool,
 
 	// Map subdivided vertices into weighted original vertices.
 	// NOTE: May be O(n^2) if `max_source_vertices` is not specified!
-	evaluate_source_vertices: c.bool,
+	evaluate_source_vertices: bool,
 
 	// Limit source vertices per subdivided vertex.
 	max_source_vertices: c.size_t,
 
 	// Calculate bone influences over subdivided vertices (if applicable).
 	// NOTE: May be O(n^2) if `max_skin_weights` is not specified!
-	evaluate_skin_weights: c.bool,
+	evaluate_skin_weights: bool,
 
 	// Limit bone influences per subdivided vertex.
 	max_skin_weights: c.size_t,
 
 	// Index of the skin deformer to use for `evaluate_skin_weights`.
 	skin_deformer_index: c.size_t,
-	_end_zero:        c.uint32_t,
+	_end_zero:        u32,
 }
 
 // Options for `ufbx_load_geometry_cache()`
 // NOTE: Initialize to zero with `{ 0 }` (C) or `{ }` (C++)
 Geometry_Cache_Opts :: struct {
-	_begin_zero:      c.uint32_t,
+	_begin_zero:      u32,
 	temp_allocator:   Allocator_Opts, // < Allocator used during loading
 	result_allocator: Allocator_Opts, // < Allocator used for the final scene
 
@@ -5119,37 +5119,37 @@ Geometry_Cache_Opts :: struct {
 	open_file_cb: Open_File_Cb,
 
 	// FPS value for converting frame times to seconds
-	frames_per_second: c.double,
+	frames_per_second: f64,
 
 	// Axis to mirror the geometry by.
 	mirror_axis: Mirror_Axis,
 
 	// Enable scaling `scale_factor` all geometry by.
-	use_scale_factor: c.bool,
+	use_scale_factor: bool,
 
 	// Factor to scale the geometry by.
 	scale_factor: Real,
-	_end_zero:        c.uint32_t,
+	_end_zero:        u32,
 }
 
 // Options for `ufbx_read_geometry_cache_TYPE()`
 // NOTE: Initialize to zero with `{ 0 }` (C) or `{ }` (C++)
 Geometry_Cache_Data_Opts :: struct {
-	_begin_zero: c.uint32_t,
+	_begin_zero: u32,
 
 	// External file callbacks (defaults to stdio.h)
 	open_file_cb: Open_File_Cb,
-	additive:    c.bool,
-	use_weight:  c.bool,
+	additive:    bool,
+	use_weight:  bool,
 	weight:      Real,
 
 	// Ignore scene transform.
-	ignore_transform: c.bool,
-	_end_zero:   c.uint32_t,
+	ignore_transform: bool,
+	_end_zero:   u32,
 }
 
 Panic :: struct {
-	did_panic:      c.bool,
+	did_panic:      bool,
 	message_length: c.size_t,
 	message:        [128]c.char,
 }
@@ -5261,7 +5261,7 @@ foreign lib {
 	//   ufbx_subdivide_mesh()
 	//   ufbx_tessellate_nurbs_surface()
 	//   ufbx_free_mesh()
-	is_thread_safe :: proc() -> c.bool ---
+	is_thread_safe :: proc() -> bool ---
 
 	// Load a scene from a `size` byte memory buffer at `data`
 	load_memory :: proc(data: rawptr, data_size: c.size_t, opts: ^Load_Opts, error: ^Error) -> ^Scene ---
@@ -5307,10 +5307,10 @@ foreign lib {
 	find_real       :: proc(props: ^Props, name: cstring, def: Real) -> Real ---
 	find_vec3_len   :: proc(props: ^Props, name: cstring, name_len: c.size_t, def: Vec3) -> Vec3 ---
 	find_vec3       :: proc(props: ^Props, name: cstring, def: Vec3) -> Vec3 ---
-	find_int_len    :: proc(props: ^Props, name: cstring, name_len: c.size_t, def: c.int64_t) -> c.int64_t ---
-	find_int        :: proc(props: ^Props, name: cstring, def: c.int64_t) -> c.int64_t ---
-	find_bool_len   :: proc(props: ^Props, name: cstring, name_len: c.size_t, def: c.bool) -> c.bool ---
-	find_bool       :: proc(props: ^Props, name: cstring, def: c.bool) -> c.bool ---
+	find_int_len    :: proc(props: ^Props, name: cstring, name_len: c.size_t, def: i64) -> i64 ---
+	find_int        :: proc(props: ^Props, name: cstring, def: i64) -> i64 ---
+	find_bool_len   :: proc(props: ^Props, name: cstring, name_len: c.size_t, def: bool) -> bool ---
+	find_bool       :: proc(props: ^Props, name: cstring, def: bool) -> bool ---
 	find_string_len :: proc(props: ^Props, name: cstring, name_len: c.size_t, def: String) -> String ---
 	find_string     :: proc(props: ^Props, name: cstring, def: String) -> String ---
 	find_blob_len   :: proc(props: ^Props, name: cstring, name_len: c.size_t, def: Blob) -> Blob ---
@@ -5366,51 +5366,51 @@ foreign lib {
 
 	// Same as `ufbx_open_file()` but compatible with the callback in `ufbx_open_file_fn`.
 	// The `user` parameter is actually not used here.
-	default_open_file :: proc(user: rawptr, stream: ^Stream, path: cstring, path_len: c.size_t, info: ^Open_File_Info) -> c.bool ---
+	default_open_file :: proc(user: rawptr, stream: ^Stream, path: cstring, path_len: c.size_t, info: ^Open_File_Info) -> bool ---
 
 	// Open a `ufbx_stream` from a file.
 	// Use `path_len == SIZE_MAX` for NULL terminated string.
-	open_file     :: proc(stream: ^Stream, path: cstring, path_len: c.size_t, opts: ^Open_File_Opts, error: ^Error) -> c.bool ---
-	open_file_ctx :: proc(stream: ^Stream, ctx: Open_File_Context, path: cstring, path_len: c.size_t, opts: ^Open_File_Opts, error: ^Error) -> c.bool ---
+	open_file     :: proc(stream: ^Stream, path: cstring, path_len: c.size_t, opts: ^Open_File_Opts, error: ^Error) -> bool ---
+	open_file_ctx :: proc(stream: ^Stream, ctx: Open_File_Context, path: cstring, path_len: c.size_t, opts: ^Open_File_Opts, error: ^Error) -> bool ---
 
 	// NOTE: Uses the default ufbx allocator!
-	open_memory     :: proc(stream: ^Stream, data: rawptr, data_size: c.size_t, opts: ^Open_Memory_Opts, error: ^Error) -> c.bool ---
-	open_memory_ctx :: proc(stream: ^Stream, ctx: Open_File_Context, data: rawptr, data_size: c.size_t, opts: ^Open_Memory_Opts, error: ^Error) -> c.bool ---
+	open_memory     :: proc(stream: ^Stream, data: rawptr, data_size: c.size_t, opts: ^Open_Memory_Opts, error: ^Error) -> bool ---
+	open_memory_ctx :: proc(stream: ^Stream, ctx: Open_File_Context, data: rawptr, data_size: c.size_t, opts: ^Open_Memory_Opts, error: ^Error) -> bool ---
 
 	// Evaluate a single animation `curve` at a `time`.
 	// Returns `default_value` only if `curve == NULL` or it has no keyframes.
-	evaluate_curve       :: proc(curve: ^Anim_Curve, time: c.double, default_value: Real) -> Real ---
-	evaluate_curve_flags :: proc(curve: ^Anim_Curve, time: c.double, default_value: Real, flags: c.uint32_t) -> Real ---
+	evaluate_curve       :: proc(curve: ^Anim_Curve, time: f64, default_value: Real) -> Real ---
+	evaluate_curve_flags :: proc(curve: ^Anim_Curve, time: f64, default_value: Real, flags: u32) -> Real ---
 
 	// Evaluate a value from bundled animation curves.
-	evaluate_anim_value_real       :: proc(anim_value: ^Anim_Value, time: c.double) -> Real ---
-	evaluate_anim_value_vec3       :: proc(anim_value: ^Anim_Value, time: c.double) -> Vec3 ---
-	evaluate_anim_value_real_flags :: proc(anim_value: ^Anim_Value, time: c.double, flags: c.uint32_t) -> Real ---
-	evaluate_anim_value_vec3_flags :: proc(anim_value: ^Anim_Value, time: c.double, flags: c.uint32_t) -> Vec3 ---
+	evaluate_anim_value_real       :: proc(anim_value: ^Anim_Value, time: f64) -> Real ---
+	evaluate_anim_value_vec3       :: proc(anim_value: ^Anim_Value, time: f64) -> Vec3 ---
+	evaluate_anim_value_real_flags :: proc(anim_value: ^Anim_Value, time: f64, flags: u32) -> Real ---
+	evaluate_anim_value_vec3_flags :: proc(anim_value: ^Anim_Value, time: f64, flags: u32) -> Vec3 ---
 
 	// Evaluate an animated property `name` from `element` at `time`.
 	// NOTE: If the property is not found it will have the flag `UFBX_PROP_FLAG_NOT_FOUND`.
-	evaluate_prop_len       :: proc(anim: ^Anim, element: ^Element, name: cstring, name_len: c.size_t, time: c.double) -> Prop ---
-	evaluate_prop           :: proc(anim: ^Anim, element: ^Element, name: cstring, time: c.double) -> Prop ---
-	evaluate_prop_len_flags :: proc(anim: ^Anim, element: ^Element, name: cstring, name_len: c.size_t, time: c.double, flags: c.uint32_t) -> Prop ---
-	evaluate_prop_flags     :: proc(anim: ^Anim, element: ^Element, name: cstring, time: c.double, flags: c.uint32_t) -> Prop ---
+	evaluate_prop_len       :: proc(anim: ^Anim, element: ^Element, name: cstring, name_len: c.size_t, time: f64) -> Prop ---
+	evaluate_prop           :: proc(anim: ^Anim, element: ^Element, name: cstring, time: f64) -> Prop ---
+	evaluate_prop_len_flags :: proc(anim: ^Anim, element: ^Element, name: cstring, name_len: c.size_t, time: f64, flags: u32) -> Prop ---
+	evaluate_prop_flags     :: proc(anim: ^Anim, element: ^Element, name: cstring, time: f64, flags: u32) -> Prop ---
 
 	// Evaluate all _animated_ properties of `element`.
 	// HINT: This function returns an `ufbx_props` structure with the original properties as
 	// `ufbx_props.defaults`. This lets you use `ufbx_find_prop/value()` for the results.
-	evaluate_props       :: proc(anim: ^Anim, element: ^Element, time: c.double, buffer: ^Prop, buffer_size: c.size_t) -> Props ---
-	evaluate_props_flags :: proc(anim: ^Anim, element: ^Element, time: c.double, buffer: ^Prop, buffer_size: c.size_t, flags: c.uint32_t) -> Props ---
+	evaluate_props       :: proc(anim: ^Anim, element: ^Element, time: f64, buffer: ^Prop, buffer_size: c.size_t) -> Props ---
+	evaluate_props_flags :: proc(anim: ^Anim, element: ^Element, time: f64, buffer: ^Prop, buffer_size: c.size_t, flags: u32) -> Props ---
 
 	// Evaluate the animated transform of a node given a time.
 	// The returned transform is the local transform of the node (ie. relative to the parent),
 	// comparable to `ufbx_node.local_transform`.
-	evaluate_transform       :: proc(anim: ^Anim, node: ^Node, time: c.double) -> Transform ---
-	evaluate_transform_flags :: proc(anim: ^Anim, node: ^Node, time: c.double, flags: c.uint32_t) -> Transform ---
+	evaluate_transform       :: proc(anim: ^Anim, node: ^Node, time: f64) -> Transform ---
+	evaluate_transform_flags :: proc(anim: ^Anim, node: ^Node, time: f64, flags: u32) -> Transform ---
 
 	// Evaluate the blend shape weight of a blend channel.
 	// NOTE: Return value uses `1.0` for full weight, instead of `100.0` that the internal property `UFBX_Weight` uses.
-	evaluate_blend_weight       :: proc(anim: ^Anim, channel: ^Blend_Channel, time: c.double) -> Real ---
-	evaluate_blend_weight_flags :: proc(anim: ^Anim, channel: ^Blend_Channel, time: c.double, flags: c.uint32_t) -> Real ---
+	evaluate_blend_weight       :: proc(anim: ^Anim, channel: ^Blend_Channel, time: f64) -> Real ---
+	evaluate_blend_weight_flags :: proc(anim: ^Anim, channel: ^Blend_Channel, time: f64, flags: u32) -> Real ---
 
 	// Evaluate the whole `scene` at a specific `time` in the animation `anim`.
 	// The returned scene behaves as if it had been exported at a specific time
@@ -5419,7 +5419,7 @@ foreign lib {
 	//
 	// NOTE: The returned scene refers to the original `scene` so the original
 	// scene cannot be freed until all evaluated scenes are freed.
-	evaluate_scene :: proc(scene: ^Scene, anim: ^Anim, time: c.double, opts: ^Evaluate_Opts, error: ^Error) -> ^Scene ---
+	evaluate_scene :: proc(scene: ^Scene, anim: ^Anim, time: f64, opts: ^Evaluate_Opts, error: ^Error) -> ^Scene ---
 
 	// Create a custom animation descriptor.
 	// `ufbx_anim_opts` is used to specify animation layers and weights.
@@ -5438,20 +5438,20 @@ foreign lib {
 	bake_anim                        :: proc(scene: ^Scene, anim: ^Anim, opts: ^Bake_Opts, error: ^Error) -> ^Baked_Anim ---
 	retain_baked_anim                :: proc(bake: ^Baked_Anim) ---
 	free_baked_anim                  :: proc(bake: ^Baked_Anim) ---
-	find_baked_node_by_typed_id      :: proc(bake: ^Baked_Anim, typed_id: c.uint32_t) -> ^Baked_Node ---
+	find_baked_node_by_typed_id      :: proc(bake: ^Baked_Anim, typed_id: u32) -> ^Baked_Node ---
 	find_baked_node                  :: proc(bake: ^Baked_Anim, node: ^Node) -> ^Baked_Node ---
-	find_baked_element_by_element_id :: proc(bake: ^Baked_Anim, element_id: c.uint32_t) -> ^Baked_Element ---
+	find_baked_element_by_element_id :: proc(bake: ^Baked_Anim, element_id: u32) -> ^Baked_Element ---
 	find_baked_element               :: proc(bake: ^Baked_Anim, element: ^Element) -> ^Baked_Element ---
 
 	// Evaluate baked animation `keyframes` at `time`.
 	// Internally linearly interpolates between two adjacent keyframes.
 	// Handles stepped tangents cleanly, which is not strictly necessary for custom interpolation.
-	evaluate_baked_vec3 :: proc(keyframes: Baked_Vec3_List, time: c.double) -> Vec3 ---
+	evaluate_baked_vec3 :: proc(keyframes: Baked_Vec3_List, time: f64) -> Vec3 ---
 
 	// Evaluate baked animation `keyframes` at `time`.
 	// Internally spherically interpolates (`ufbx_quat_slerp()`) between two adjacent keyframes.
 	// Handles stepped tangents cleanly, which is not strictly necessary for custom interpolation.
-	evaluate_baked_quat :: proc(keyframes: Baked_Quat_List, time: c.double) -> Quat ---
+	evaluate_baked_quat :: proc(keyframes: Baked_Quat_List, time: f64) -> Quat ---
 
 	// Retrieve the bone pose for `node`.
 	// Returns `NULL` if the pose does not contain `node`.
@@ -5474,7 +5474,7 @@ foreign lib {
 	find_shader_texture_input     :: proc(shader: ^Shader_Texture, name: cstring) -> ^Shader_Texture_Input ---
 
 	// Returns `true` if `axes` forms a valid coordinate space.
-	coordinate_axes_valid :: proc(axes: Coordinate_Axes) -> c.bool ---
+	coordinate_axes_valid :: proc(axes: Coordinate_Axes) -> bool ---
 
 	// Vector math utility functions.
 	vec3_normalize :: proc(v: Vec3) -> Vec3 ---
@@ -5515,7 +5515,7 @@ foreign lib {
 
 	// Resolve the index into `ufbx_blend_shape.position_offsets[]` given a vertex.
 	// Returns `UFBX_NO_INDEX` if the vertex is not included in the blend shape.
-	get_blend_shape_offset_index :: proc(shape: ^Blend_Shape, vertex: c.size_t) -> c.uint32_t ---
+	get_blend_shape_offset_index :: proc(shape: ^Blend_Shape, vertex: c.size_t) -> u32 ---
 
 	// Get the offset for a given vertex in the blend shape.
 	// Returns `ufbx_zero_vec3` if the vertex is not a included in the blend shape.
@@ -5555,25 +5555,25 @@ foreign lib {
 
 	// Find the face that contains a given `index`.
 	// Returns `UFBX_NO_INDEX` if out of bounds.
-	find_face_index :: proc(mesh: ^Mesh, index: c.size_t) -> c.uint32_t ---
+	find_face_index :: proc(mesh: ^Mesh, index: c.size_t) -> u32 ---
 
 	// Triangulate a mesh face, returning the number of triangles.
 	// NOTE: You need to space for `(face.num_indices - 2) * 3 - 1` indices!
 	// HINT: Using `ufbx_mesh.max_face_triangles * 3` is always safe.
-	catch_triangulate_face :: proc(panic: ^Panic, indices: ^c.uint32_t, num_indices: c.size_t, mesh: ^Mesh, face: Face) -> c.uint32_t ---
-	triangulate_face       :: proc(indices: ^c.uint32_t, num_indices: c.size_t, mesh: ^Mesh, face: Face) -> c.uint32_t ---
+	catch_triangulate_face :: proc(panic: ^Panic, indices: ^u32, num_indices: c.size_t, mesh: ^Mesh, face: Face) -> u32 ---
+	triangulate_face       :: proc(indices: ^u32, num_indices: c.size_t, mesh: ^Mesh, face: Face) -> u32 ---
 
 	// Generate the half-edge representation of `mesh` to `topo[mesh->num_indices]`
 	catch_compute_topology :: proc(panic: ^Panic, mesh: ^Mesh, topo: ^Topo_Edge, num_topo: c.size_t) ---
 	compute_topology       :: proc(mesh: ^Mesh, topo: ^Topo_Edge, num_topo: c.size_t) ---
 
 	// Get the next half-edge in `topo`.
-	catch_topo_next_vertex_edge :: proc(panic: ^Panic, topo: ^Topo_Edge, num_topo: c.size_t, index: c.uint32_t) -> c.uint32_t ---
-	topo_next_vertex_edge       :: proc(topo: ^Topo_Edge, num_topo: c.size_t, index: c.uint32_t) -> c.uint32_t ---
+	catch_topo_next_vertex_edge :: proc(panic: ^Panic, topo: ^Topo_Edge, num_topo: c.size_t, index: u32) -> u32 ---
+	topo_next_vertex_edge       :: proc(topo: ^Topo_Edge, num_topo: c.size_t, index: u32) -> u32 ---
 
 	// Get the previous half-edge in `topo`.
-	catch_topo_prev_vertex_edge :: proc(panic: ^Panic, topo: ^Topo_Edge, num_topo: c.size_t, index: c.uint32_t) -> c.uint32_t ---
-	topo_prev_vertex_edge       :: proc(topo: ^Topo_Edge, num_topo: c.size_t, index: c.uint32_t) -> c.uint32_t ---
+	catch_topo_prev_vertex_edge :: proc(panic: ^Panic, topo: ^Topo_Edge, num_topo: c.size_t, index: u32) -> u32 ---
+	topo_prev_vertex_edge       :: proc(topo: ^Topo_Edge, num_topo: c.size_t, index: u32) -> u32 ---
 
 	// Calculate a normal for a given face.
 	// The returned normal is weighted by face area.
@@ -5582,13 +5582,13 @@ foreign lib {
 
 	// Generate indices for normals from the topology.
 	// Respects smoothing groups.
-	catch_generate_normal_mapping :: proc(panic: ^Panic, mesh: ^Mesh, topo: ^Topo_Edge, num_topo: c.size_t, normal_indices: ^c.uint32_t, num_normal_indices: c.size_t, assume_smooth: c.bool) -> c.size_t ---
-	generate_normal_mapping       :: proc(mesh: ^Mesh, topo: ^Topo_Edge, num_topo: c.size_t, normal_indices: ^c.uint32_t, num_normal_indices: c.size_t, assume_smooth: c.bool) -> c.size_t ---
+	catch_generate_normal_mapping :: proc(panic: ^Panic, mesh: ^Mesh, topo: ^Topo_Edge, num_topo: c.size_t, normal_indices: ^u32, num_normal_indices: c.size_t, assume_smooth: bool) -> c.size_t ---
+	generate_normal_mapping       :: proc(mesh: ^Mesh, topo: ^Topo_Edge, num_topo: c.size_t, normal_indices: ^u32, num_normal_indices: c.size_t, assume_smooth: bool) -> c.size_t ---
 
 	// Compute normals given normal indices.
 	// You can use `ufbx_generate_normal_mapping()` to generate the normal indices.
-	catch_compute_normals :: proc(panic: ^Panic, mesh: ^Mesh, positions: ^Vertex_Vec3, normal_indices: ^c.uint32_t, num_normal_indices: c.size_t, normals: ^Vec3, num_normals: c.size_t) ---
-	compute_normals       :: proc(mesh: ^Mesh, positions: ^Vertex_Vec3, normal_indices: ^c.uint32_t, num_normal_indices: c.size_t, normals: ^Vec3, num_normals: c.size_t) ---
+	catch_compute_normals :: proc(panic: ^Panic, mesh: ^Mesh, positions: ^Vertex_Vec3, normal_indices: ^u32, num_normal_indices: c.size_t, normals: ^Vec3, num_normals: c.size_t) ---
+	compute_normals       :: proc(mesh: ^Mesh, positions: ^Vertex_Vec3, normal_indices: ^u32, num_normal_indices: c.size_t, normals: ^Vec3, num_normals: c.size_t) ---
 
 	// Subdivide a mesh using the Catmull-Clark subdivision `level` times.
 	subdivide_mesh :: proc(mesh: ^Mesh, level: c.size_t, opts: ^Subdivide_Opts, error: ^Error) -> ^Mesh ---
@@ -5616,8 +5616,8 @@ foreign lib {
 	read_geometry_cache_vec3 :: proc(frame: ^Cache_Frame, data: ^Vec3, num_data: c.size_t, opts: ^Geometry_Cache_Data_Opts) -> c.size_t ---
 
 	// Sample the a geometry cache channel, linearly blending between adjacent frames.
-	sample_geometry_cache_real :: proc(channel: ^Cache_Channel, time: c.double, data: ^Real, num_data: c.size_t, opts: ^Geometry_Cache_Data_Opts) -> c.size_t ---
-	sample_geometry_cache_vec3 :: proc(channel: ^Cache_Channel, time: c.double, data: ^Vec3, num_data: c.size_t, opts: ^Geometry_Cache_Data_Opts) -> c.size_t ---
+	sample_geometry_cache_real :: proc(channel: ^Cache_Channel, time: f64, data: ^Real, num_data: c.size_t, opts: ^Geometry_Cache_Data_Opts) -> c.size_t ---
+	sample_geometry_cache_vec3 :: proc(channel: ^Cache_Channel, time: f64, data: ^Vec3, num_data: c.size_t, opts: ^Geometry_Cache_Data_Opts) -> c.size_t ---
 
 	// Find a DOM node given a name.
 	dom_find_len :: proc(parent: ^Dom_Node, name: cstring, name_len: c.size_t) -> ^Dom_Node ---
@@ -5626,11 +5626,11 @@ foreign lib {
 	// Generate an index buffer for a flat vertex buffer.
 	// `streams` specifies one or more vertex data arrays, each stream must contain `num_indices` vertices.
 	// This function compacts the data within `streams` in-place, writing the deduplicated indices to `indices`.
-	generate_indices :: proc(streams: [^]Vertex_Stream, num_streams: c.size_t, indices: ^c.uint32_t, num_indices: c.size_t, allocator: ^Allocator_Opts, error: ^Error) -> c.size_t ---
+	generate_indices :: proc(streams: [^]Vertex_Stream, num_streams: c.size_t, indices: ^u32, num_indices: c.size_t, allocator: ^Allocator_Opts, error: ^Error) -> c.size_t ---
 
 	// Run a single thread pool task.
 	// See `ufbx_thread_pool_run_fn` for more information.
-	thread_pool_run_task :: proc(ctx: Thread_Pool_Context, index: c.uint32_t) ---
+	thread_pool_run_task :: proc(ctx: Thread_Pool_Context, index: u32) ---
 
 	// Get or set an arbitrary user pointer for the thread pool context.
 	// `ufbx_thread_pool_get_user_ptr()` returns `NULL` if unset.

--- a/examples/ufbx/ufbx/ufbx.odin
+++ b/examples/ufbx/ufbx/ufbx.odin
@@ -20,7 +20,7 @@ CPP11 :: 0
 
 // ufbx_abi_data :: Extern
 
-REAL_TYPE :: f32
+REAL_TYPE :: c.float
 
 // Limits for embedded arrays within structures.
 ERROR_STACK_MAX_DEPTH :: 8
@@ -39,25 +39,25 @@ HAS_FORCE_32BIT :: 1
 // `ufbx_source_version` contains the version of the corresponding source file.
 // HINT: The version can be compared numerically to the result of `ufbx_pack_version()`,
 // for example `#if UFBX_VERSION >= ufbx_pack_version(0, 12, 0)`.
-HEADER_VERSION :: (u32)(0)*1000000 + (u32)(18)*1000 + (u32)(0)
+HEADER_VERSION :: (c.uint32_t)(0)*1000000 + (c.uint32_t)(18)*1000 + (c.uint32_t)(0)
 // VERSION :: Ufbx_Header_Version
 
 // Main floating point type used everywhere in ufbx, defaults to `double`.
 // If you define `UFBX_REAL_IS_FLOAT` to any value, `ufbx_real` will be defined
 // as `float` instead.
 // You can also manually define `UFBX_REAL_TYPE` to any floating point type.
-Real :: f32
+Real :: c.float
 
 // Null-terminated UTF-8 encoded string within an FBX file
 String :: struct {
 	data:   cstring,
-	length: uint,
+	length: c.size_t,
 }
 
 // Opaque byte buffer blob
 Blob :: struct {
 	data: rawptr,
-	size: uint,
+	size: c.size_t,
 }
 
 // 2D vector
@@ -114,46 +114,46 @@ Matrix :: struct {
 
 Void_List :: struct {
 	data:  rawptr,
-	count: uint,
+	count: c.size_t,
 }
 
 Bool_List :: struct {
-	data:  ^bool,
-	count: uint,
+	data:  ^c.bool,
+	count: c.size_t,
 }
 
 Uint32_List :: struct {
-	data:  [^]u32,
-	count: uint,
+	data:  [^]c.uint32_t,
+	count: c.size_t,
 }
 
 Real_List :: struct {
 	data:  ^Real,
-	count: uint,
+	count: c.size_t,
 }
 
 Vec2_List :: struct {
 	data:  [^]Vec2,
-	count: uint,
+	count: c.size_t,
 }
 
 Vec3_List :: struct {
 	data:  [^]Vec3,
-	count: uint,
+	count: c.size_t,
 }
 
 Vec4_List :: struct {
 	data:  [^]Vec4,
-	count: uint,
+	count: c.size_t,
 }
 
 String_List :: struct {
 	data:  ^String,
-	count: uint,
+	count: c.size_t,
 }
 
 // Sentinel value used to represent a missing index.
-// NO_INDEX :: (u32)~0
+// NO_INDEX :: (c.uint32_t)~0
 
 // -- Document object model
 Dom_Value_Type :: enum c.int {
@@ -175,18 +175,18 @@ Dom_Value :: struct {
 	type:        Dom_Value_Type,
 	value_str:   String,
 	value_blob:  Blob,
-	value_int:   i64,
-	value_float: f64,
+	value_int:   c.int64_t,
+	value_float: c.double,
 }
 
 Dom_Node_List :: struct {
 	data:  ^^Dom_Node,
-	count: uint,
+	count: c.size_t,
 }
 
 Dom_Value_List :: struct {
 	data:  ^Dom_Value,
-	count: uint,
+	count: c.size_t,
 }
 
 Dom_Node :: struct {
@@ -324,12 +324,12 @@ PROP_FLAGS_FORCE_32BIT :: Prop_Flags { .ANIMATABLE, .USER_DEFINED, .HIDDEN, .LOC
 // Single property with name/type/value.
 Prop :: struct {
 	name:          String,
-	_internal_key: u32,
+	_internal_key: c.uint32_t,
 	type:          Prop_Type,
 	flags:         Prop_Flag,
 	value_str:     String,
 	value_blob:    Blob,
-	value_int:     i64,
+	value_int:     c.int64_t,
 	using _: struct #raw_union {
 		value_real_arr: [4]Real,
 		value_real:     Real,
@@ -341,7 +341,7 @@ Prop :: struct {
 
 Prop_List :: struct {
 	data:  ^Prop,
-	count: uint,
+	count: c.size_t,
 }
 
 // List of alphabetically sorted properties with potential defaults.
@@ -349,223 +349,223 @@ Prop_List :: struct {
 // only has the animated properties, the originals are stored under `defaults`.
 Props :: struct {
 	props:        Prop_List,
-	num_animated: uint,
+	num_animated: c.size_t,
 	defaults:     ^Props,
 }
 
 Element_List :: struct {
 	data:  ^^Element,
-	count: uint,
+	count: c.size_t,
 }
 
 Unknown_List :: struct {
 	data:  ^^Unknown,
-	count: uint,
+	count: c.size_t,
 }
 
 Node_List :: struct {
 	data:  [^]^Node,
-	count: uint,
+	count: c.size_t,
 }
 
 Mesh_List :: struct {
 	data:  ^^Mesh,
-	count: uint,
+	count: c.size_t,
 }
 
 Light_List :: struct {
 	data:  ^^Light,
-	count: uint,
+	count: c.size_t,
 }
 
 Camera_List :: struct {
 	data:  ^^Camera,
-	count: uint,
+	count: c.size_t,
 }
 
 Bone_List :: struct {
 	data:  ^^Bone,
-	count: uint,
+	count: c.size_t,
 }
 
 Empty_List :: struct {
 	data:  ^^Empty,
-	count: uint,
+	count: c.size_t,
 }
 
 Line_Curve_List :: struct {
 	data:  ^^Line_Curve,
-	count: uint,
+	count: c.size_t,
 }
 
 Nurbs_Curve_List :: struct {
 	data:  ^^Nurbs_Curve,
-	count: uint,
+	count: c.size_t,
 }
 
 Nurbs_Surface_List :: struct {
 	data:  ^^Nurbs_Surface,
-	count: uint,
+	count: c.size_t,
 }
 
 Nurbs_Trim_Surface_List :: struct {
 	data:  ^^Nurbs_Trim_Surface,
-	count: uint,
+	count: c.size_t,
 }
 
 Nurbs_Trim_Boundary_List :: struct {
 	data:  ^^Nurbs_Trim_Boundary,
-	count: uint,
+	count: c.size_t,
 }
 
 Procedural_Geometry_List :: struct {
 	data:  ^^Procedural_Geometry,
-	count: uint,
+	count: c.size_t,
 }
 
 Stereo_Camera_List :: struct {
 	data:  ^^Stereo_Camera,
-	count: uint,
+	count: c.size_t,
 }
 
 Camera_Switcher_List :: struct {
 	data:  ^^Camera_Switcher,
-	count: uint,
+	count: c.size_t,
 }
 
 Marker_List :: struct {
 	data:  ^^Marker,
-	count: uint,
+	count: c.size_t,
 }
 
 Lod_Group_List :: struct {
 	data:  ^^Lod_Group,
-	count: uint,
+	count: c.size_t,
 }
 
 Skin_Deformer_List :: struct {
 	data:  ^^Skin_Deformer,
-	count: uint,
+	count: c.size_t,
 }
 
 Skin_Cluster_List :: struct {
 	data:  ^^Skin_Cluster,
-	count: uint,
+	count: c.size_t,
 }
 
 Blend_Deformer_List :: struct {
 	data:  ^^Blend_Deformer,
-	count: uint,
+	count: c.size_t,
 }
 
 Blend_Channel_List :: struct {
 	data:  ^^Blend_Channel,
-	count: uint,
+	count: c.size_t,
 }
 
 Blend_Shape_List :: struct {
 	data:  ^^Blend_Shape,
-	count: uint,
+	count: c.size_t,
 }
 
 Cache_Deformer_List :: struct {
 	data:  ^^Cache_Deformer,
-	count: uint,
+	count: c.size_t,
 }
 
 Cache_File_List :: struct {
 	data:  ^^Cache_File,
-	count: uint,
+	count: c.size_t,
 }
 
 Material_List :: struct {
 	data:  ^^Material,
-	count: uint,
+	count: c.size_t,
 }
 
 Texture_List :: struct {
 	data:  ^^Texture,
-	count: uint,
+	count: c.size_t,
 }
 
 Video_List :: struct {
 	data:  ^^Video,
-	count: uint,
+	count: c.size_t,
 }
 
 Shader_List :: struct {
 	data:  ^^Shader,
-	count: uint,
+	count: c.size_t,
 }
 
 Shader_Binding_List :: struct {
 	data:  ^^Shader_Binding,
-	count: uint,
+	count: c.size_t,
 }
 
 Anim_Stack_List :: struct {
 	data:  ^^Anim_Stack,
-	count: uint,
+	count: c.size_t,
 }
 
 Anim_Layer_List :: struct {
 	data:  ^^Anim_Layer,
-	count: uint,
+	count: c.size_t,
 }
 
 Anim_Value_List :: struct {
 	data:  ^^Anim_Value,
-	count: uint,
+	count: c.size_t,
 }
 
 Anim_Curve_List :: struct {
 	data:  ^^Anim_Curve,
-	count: uint,
+	count: c.size_t,
 }
 
 Display_Layer_List :: struct {
 	data:  ^^Display_Layer,
-	count: uint,
+	count: c.size_t,
 }
 
 Selection_Set_List :: struct {
 	data:  ^^Selection_Set,
-	count: uint,
+	count: c.size_t,
 }
 
 Selection_Node_List :: struct {
 	data:  ^^Selection_Node,
-	count: uint,
+	count: c.size_t,
 }
 
 Character_List :: struct {
 	data:  ^^Character,
-	count: uint,
+	count: c.size_t,
 }
 
 Constraint_List :: struct {
 	data:  ^^Constraint,
-	count: uint,
+	count: c.size_t,
 }
 
 Audio_Layer_List :: struct {
 	data:  ^^Audio_Layer,
-	count: uint,
+	count: c.size_t,
 }
 
 Audio_Clip_List :: struct {
 	data:  ^^Audio_Clip,
-	count: uint,
+	count: c.size_t,
 }
 
 Pose_List :: struct {
 	data:  ^^Pose,
-	count: uint,
+	count: c.size_t,
 }
 
 Metadata_Object_List :: struct {
 	data:  ^^Metadata_Object,
-	count: uint,
+	count: c.size_t,
 }
 
 Element_Type :: enum c.int {
@@ -630,7 +630,7 @@ Connection :: struct {
 
 Connection_List :: struct {
 	data:  ^Connection,
-	count: uint,
+	count: c.size_t,
 }
 
 // Element "base-class" common to each element.
@@ -641,8 +641,8 @@ Connection_List :: struct {
 Element :: struct {
 	name:            String,
 	props:           Props,
-	element_id:      u32,
-	typed_id:        u32,
+	element_id:      c.uint32_t,
+	typed_id:        c.uint32_t,
 	instances:       Node_List,
 	type:            Element_Type,
 	connections_src: Connection_List,
@@ -659,8 +659,8 @@ Unknown :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 
@@ -725,8 +725,8 @@ Node :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 
@@ -834,36 +834,36 @@ Node :: struct {
 	bind_pose: ^Pose,
 
 	// Visibility state.
-	visible: bool,
+	visible: c.bool,
 
 	// True if this node is the implicit root node of the scene.
-	is_root: bool,
+	is_root: c.bool,
 
 	// True if the node has a non-identity `geometry_transform`.
-	has_geometry_transform: bool,
+	has_geometry_transform: c.bool,
 
 	// If `true` the transform is adjusted by ufbx, not enabled by default.
 	// See `adjust_pre_rotation`, `adjust_pre_scale`, `adjust_post_rotation`,
 	// and `adjust_post_scale`.
-	has_adjust_transform: bool,
+	has_adjust_transform: c.bool,
 
 	// Scale is adjusted by root scale.
-	has_root_adjust_transform: bool,
+	has_root_adjust_transform: c.bool,
 
 	// True if this node is a synthetic geometry transform helper.
 	// See `UFBX_GEOMETRY_TRANSFORM_HANDLING_HELPER_NODES`.
-	is_geometry_transform_helper: bool,
+	is_geometry_transform_helper: c.bool,
 
 	// True if the node is a synthetic scale compensation helper.
 	// See `UFBX_INHERIT_MODE_HANDLING_HELPER_NODES`.
-	is_scale_helper: bool,
+	is_scale_helper: c.bool,
 
 	// Parent node to children that can compensate for parent scale.
-	is_scale_compensate_parent: bool,
+	is_scale_compensate_parent: c.bool,
 
 	// How deep is this node in the parent hierarchy. Root node is at depth `0`
 	// and the immediate children of root at `1`.
-	node_depth: u32,
+	node_depth: c.uint32_t,
 }
 
 // Vertex attribute: All attributes are stored in a consistent indexed format
@@ -877,7 +877,7 @@ Node :: struct {
 //   attrib.values.data[attrib.indices.data[mesh->vertex_first_index[vertex_ix]]
 Vertex_Attrib :: struct {
 	// Is this attribute defined by the mesh.
-	exists: bool,
+	exists: c.bool,
 
 	// List of values the attribute uses.
 	values: Void_List,
@@ -886,10 +886,10 @@ Vertex_Attrib :: struct {
 	indices: Uint32_List,
 
 	// Number of `ufbx_real` entries per value.
-	value_reals: uint,
+	value_reals: c.size_t,
 
 	// `true` if this attribute is defined per vertex, instead of per index.
-	unique_per_vertex: bool,
+	unique_per_vertex: c.bool,
 
 	// Optional 4th 'W' component for the attribute.
 	// May be defined for the following:
@@ -902,48 +902,48 @@ Vertex_Attrib :: struct {
 
 // 1D vertex attribute, see `ufbx_vertex_attrib` for information
 Vertex_Real :: struct {
-	exists:            bool,
+	exists:            c.bool,
 	values:            Real_List,
 	indices:           Uint32_List,
-	value_reals:       uint,
-	unique_per_vertex: bool,
+	value_reals:       c.size_t,
+	unique_per_vertex: c.bool,
 	values_w:          Real_List,
 }
 
 // 2D vertex attribute, see `ufbx_vertex_attrib` for information
 Vertex_Vec2 :: struct {
-	exists:            bool,
+	exists:            c.bool,
 	values:            Vec2_List,
 	indices:           Uint32_List,
-	value_reals:       uint,
-	unique_per_vertex: bool,
+	value_reals:       c.size_t,
+	unique_per_vertex: c.bool,
 	values_w:          Real_List,
 }
 
 // 3D vertex attribute, see `ufbx_vertex_attrib` for information
 Vertex_Vec3 :: struct {
-	exists:            bool,
+	exists:            c.bool,
 	values:            Vec3_List,
 	indices:           Uint32_List,
-	value_reals:       uint,
-	unique_per_vertex: bool,
+	value_reals:       c.size_t,
+	unique_per_vertex: c.bool,
 	values_w:          Real_List,
 }
 
 // 4D vertex attribute, see `ufbx_vertex_attrib` for information
 Vertex_Vec4 :: struct {
-	exists:            bool,
+	exists:            c.bool,
 	values:            Vec4_List,
 	indices:           Uint32_List,
-	value_reals:       uint,
-	unique_per_vertex: bool,
+	value_reals:       c.size_t,
+	unique_per_vertex: c.bool,
 	values_w:          Real_List,
 }
 
 // Vertex UV set/layer
 Uv_Set :: struct {
 	name:             String,
-	index:            u32,
+	index:            c.uint32_t,
 	vertex_uv:        Vertex_Vec2, // < UV / texture coordinates
 	vertex_tangent:   Vertex_Vec3, // < (optional) Tangent vector in UV.x direction
 	vertex_bitangent: Vertex_Vec3, // < (optional) Tangent vector in UV.y direction
@@ -952,33 +952,33 @@ Uv_Set :: struct {
 // Vertex color set/layer
 Color_Set :: struct {
 	name:         String,
-	index:        u32,
+	index:        c.uint32_t,
 	vertex_color: Vertex_Vec4, // < Per-vertex RGBA color
 }
 
 Uv_Set_List :: struct {
 	data:  ^Uv_Set,
-	count: uint,
+	count: c.size_t,
 }
 
 Color_Set_List :: struct {
 	data:  ^Color_Set,
-	count: uint,
+	count: c.size_t,
 }
 
 // Edge between two _indices_ in a mesh
 Edge :: struct {
 	using _: struct #raw_union {
 		using _: struct {
-			a, b: u32,
+			a, b: c.uint32_t,
 		},
-		indices: [2]u32,
+		indices: [2]c.uint32_t,
 	},
 }
 
 Edge_List :: struct {
 	data:  ^Edge,
-	count: uint,
+	count: c.size_t,
 }
 
 // Polygonal face with arbitrary number vertices, a single face contains a
@@ -987,24 +987,24 @@ Edge_List :: struct {
 // NOTE: `num_indices` maybe less than 3 in which case the face is invalid!
 // [TODO #23: should probably remove the bad faces at load time]
 Face :: struct {
-	index_begin: u32,
-	num_indices: u32,
+	index_begin: c.uint32_t,
+	num_indices: c.uint32_t,
 }
 
 Face_List :: struct {
 	data:  [^]Face,
-	count: uint,
+	count: c.size_t,
 }
 
 // Subset of mesh faces used by a single material or group.
 Mesh_Part :: struct {
 	// Index of the mesh part.
-	index: u32,
-	num_faces:       uint, // < Number of faces (polygons)
-	num_triangles:   uint, // < Number of triangles if triangulated
-	num_empty_faces: uint, // < Number of faces with zero vertices
-	num_point_faces: uint, // < Number of faces with a single vertex
-	num_line_faces:  uint, // < Number of faces with two vertices
+	index: c.uint32_t,
+	num_faces:       c.size_t, // < Number of faces (polygons)
+	num_triangles:   c.size_t, // < Number of triangles if triangulated
+	num_empty_faces: c.size_t, // < Number of faces with zero vertices
+	num_point_faces: c.size_t, // < Number of faces with a single vertex
+	num_line_faces:  c.size_t, // < Number of faces with two vertices
 
 	// Indices to `ufbx_mesh.faces[]`.
 	// Always contains `num_faces` elements.
@@ -1013,44 +1013,44 @@ Mesh_Part :: struct {
 
 Mesh_Part_List :: struct {
 	data:  ^Mesh_Part,
-	count: uint,
+	count: c.size_t,
 }
 
 Face_Group :: struct {
-	id:   i32,    // < Numerical ID for this group.
-	name: String, // < Name for the face group.
+	id:   c.int32_t, // < Numerical ID for this group.
+	name: String,    // < Name for the face group.
 }
 
 Face_Group_List :: struct {
 	data:  ^Face_Group,
-	count: uint,
+	count: c.size_t,
 }
 
 Subdivision_Weight_Range :: struct {
-	weight_begin: u32,
-	num_weights:  u32,
+	weight_begin: c.uint32_t,
+	num_weights:  c.uint32_t,
 }
 
 Subdivision_Weight_Range_List :: struct {
 	data:  ^Subdivision_Weight_Range,
-	count: uint,
+	count: c.size_t,
 }
 
 Subdivision_Weight :: struct {
 	weight: Real,
-	index:  u32,
+	index:  c.uint32_t,
 }
 
 Subdivision_Weight_List :: struct {
 	data:  ^Subdivision_Weight,
-	count: uint,
+	count: c.size_t,
 }
 
 Subdivision_Result :: struct {
-	result_memory_used:    uint,
-	temp_memory_used:      uint,
-	result_allocs:         uint,
-	temp_allocs:           uint,
+	result_memory_used:    c.size_t,
+	temp_memory_used:      c.size_t,
+	result_allocs:         c.size_t,
+	temp_allocs:           c.size_t,
 
 	// Weights of vertices in the source model.
 	// Defined if `ufbx_subdivide_opts.evaluate_source_vertices` is set.
@@ -1146,23 +1146,23 @@ Mesh :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 			instances:  Node_List,
 		},
 	},
-	num_vertices:              uint,        // < Number of logical "vertex" points
-	num_indices:               uint,        // < Number of combiend vertex/attribute tuples
-	num_faces:                 uint,        // < Number of faces (polygons) in the mesh
-	num_triangles:             uint,        // < Number of triangles if triangulated
+	num_vertices:              c.size_t,    // < Number of logical "vertex" points
+	num_indices:               c.size_t,    // < Number of combiend vertex/attribute tuples
+	num_faces:                 c.size_t,    // < Number of faces (polygons) in the mesh
+	num_triangles:             c.size_t,    // < Number of triangles if triangulated
 
 	// Number of edges in the mesh.
 	// NOTE: May be zero in valid meshes if the file doesn't contain edge adjacency data!
-	num_edges: uint,
-	max_face_triangles:        uint,        // < Maximum number of triangles in a  face in this mesh
-	num_empty_faces:           uint,        // < Number of faces with zero vertices
-	num_point_faces:           uint,        // < Number of faces with a single vertex
-	num_line_faces:            uint,        // < Number of faces with two vertices
+	num_edges: c.size_t,
+	max_face_triangles:        c.size_t,    // < Maximum number of triangles in a  face in this mesh
+	num_empty_faces:           c.size_t,    // < Number of faces with zero vertices
+	num_point_faces:           c.size_t,    // < Number of faces with a single vertex
+	num_line_faces:            c.size_t,    // < Number of faces with two vertices
 	faces:                     Face_List,   // < Face index range
 	face_smoothing:            Bool_List,   // < Should the face have soft normals
 	face_material:             Uint32_List, // < Indices to `ufbx_mesh.materials[]` and `ufbx_node.materials[]`
@@ -1217,7 +1217,7 @@ Mesh :: struct {
 	// same as the static ones for non-skinned meshes and `skinned_is_local`
 	// is set to true meaning you need to transform them manually using
 	// `ufbx_transform_position(&node->geometry_to_world, skinned_pos)`!
-	skinned_is_local: bool,
+	skinned_is_local: c.bool,
 	skinned_position:          Vertex_Vec3,
 	skinned_normal:            Vertex_Vec3,
 
@@ -1228,26 +1228,26 @@ Mesh :: struct {
 	all_deformers:             Element_List,
 
 	// Subdivision
-	subdivision_preview_levels: u32,
-	subdivision_render_levels: u32,
+	subdivision_preview_levels: c.uint32_t,
+	subdivision_render_levels: c.uint32_t,
 	subdivision_display_mode:  Subdivision_Display_Mode,
 	subdivision_boundary:      Subdivision_Boundary,
 	subdivision_uv_boundary:   Subdivision_Boundary,
 
 	// The winding of the faces has been reversed.
-	reversed_winding: bool,
+	reversed_winding: c.bool,
 
 	// Normals have been generated instead of evaluated.
 	// Either from missing normals (via `ufbx_load_opts.generate_missing_normals`), skinning,
 	// tessellation, or subdivision.
-	generated_normals: bool,
+	generated_normals: c.bool,
 
 	// Subdivision (result)
-	subdivision_evaluated: bool,
+	subdivision_evaluated: c.bool,
 	subdivision_result:        ^Subdivision_Result,
 
 	// Tessellation (result)
-	from_tessellated_nurbs: bool,
+	from_tessellated_nurbs: c.bool,
 }
 
 // The kind of light source
@@ -1302,8 +1302,8 @@ Light :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 			instances:  Node_List,
 		},
 	},
@@ -1323,8 +1323,8 @@ Light :: struct {
 	area_shape:   Light_Area_Shape,
 	inner_angle:  Real,
 	outer_angle:  Real,
-	cast_light:   bool,
-	cast_shadows: bool,
+	cast_light:   c.bool,
+	cast_shadows: c.bool,
 }
 
 Projection_Mode :: enum c.int {
@@ -1454,8 +1454,8 @@ Camera :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 			instances:  Node_List,
 		},
 	},
@@ -1465,7 +1465,7 @@ Camera :: struct {
 
 	// If set to `true`, `resolution` represents actual pixel values, otherwise
 	// it's only useful for its aspect ratio.
-	resolution_is_pixels: bool,
+	resolution_is_pixels: c.bool,
 
 	// Render resolution, either in pixels or arbitrary units, depending on above
 	resolution: Vec2,
@@ -1524,8 +1524,8 @@ Bone :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 			instances:  Node_List,
 		},
 	},
@@ -1537,7 +1537,7 @@ Bone :: struct {
 	relative_length: Real,
 
 	// Is the bone a root bone
-	is_root: bool,
+	is_root: c.bool,
 }
 
 // Empty/NULL/locator connected to a node, actual details in `ufbx_node`
@@ -1547,8 +1547,8 @@ Empty :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 			instances:  Node_List,
 		},
 	},
@@ -1556,13 +1556,13 @@ Empty :: struct {
 
 // Segment of a `ufbx_line_curve`, indices refer to `ufbx_line_curve.point_indices[]`
 Line_Segment :: struct {
-	index_begin: u32,
-	num_indices: u32,
+	index_begin: c.uint32_t,
+	num_indices: c.uint32_t,
 }
 
 Line_Segment_List :: struct {
 	data:  ^Line_Segment,
-	count: uint,
+	count: c.size_t,
 }
 
 Line_Curve :: struct {
@@ -1571,8 +1571,8 @@ Line_Curve :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 			instances:  Node_List,
 		},
 	},
@@ -1582,7 +1582,7 @@ Line_Curve :: struct {
 	segments:       Line_Segment_List,
 
 	// Tessellation (result)
-	from_tessellated_nurbs: bool,
+	from_tessellated_nurbs: c.bool,
 }
 
 Nurbs_Topology :: enum c.int {
@@ -1603,7 +1603,7 @@ NURBS_TOPOLOGY_COUNT :: 3
 Nurbs_Basis :: struct {
 	// Number of control points influencing a point on the curve/surface.
 	// Equal to the degree plus one.
-	order: u32,
+	order: c.uint32_t,
 
 	// Topology (periodicity) of the dimension.
 	topology: Nurbs_Topology,
@@ -1619,7 +1619,7 @@ Nurbs_Basis :: struct {
 	spans: Real_List,
 
 	// `true` if this axis is two-dimensional.
-	is_2d: bool,
+	is_2d: c.bool,
 
 	// Number of control points that need to be copied to the end.
 	// This is just for convenience as it could be derived from `topology` and
@@ -1627,10 +1627,10 @@ Nurbs_Basis :: struct {
 	// the first 3 control points after the end.
 	// HINT: You don't need to worry about this if you use ufbx functions
 	// like `ufbx_evaluate_nurbs_curve()` as they handle this internally.
-	num_wrap_control_points: uint,
+	num_wrap_control_points: c.size_t,
 
 	// `true` if the parametrization is well defined.
-	valid: bool,
+	valid: c.bool,
 }
 
 Nurbs_Curve :: struct {
@@ -1639,8 +1639,8 @@ Nurbs_Curve :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 			instances:  Node_List,
 		},
 	},
@@ -1660,8 +1660,8 @@ Nurbs_Surface :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 			instances:  Node_List,
 		},
 	},
@@ -1671,8 +1671,8 @@ Nurbs_Surface :: struct {
 	basis_v:              Nurbs_Basis,
 
 	// Number of control points for the U/V axes
-	num_control_points_u: uint,
-	num_control_points_v: uint,
+	num_control_points_u: c.size_t,
+	num_control_points_v: c.size_t,
 
 	// 2D array of control points.
 	// Memory layout: `V * num_control_points_u + U`
@@ -1681,11 +1681,11 @@ Nurbs_Surface :: struct {
 	control_points: Vec4_List,
 
 	// How many segments tessellate each span in `ufbx_nurbs_basis.spans`.
-	span_subdivision_u: u32,
-	span_subdivision_v:   u32,
+	span_subdivision_u: c.uint32_t,
+	span_subdivision_v:   c.uint32_t,
 
 	// If `true` the resulting normals should be flipped when evaluated.
-	flip_normals: bool,
+	flip_normals: c.bool,
 
 	// Material for the whole surface.
 	// NOTE: May be `NULL`!
@@ -1698,8 +1698,8 @@ Nurbs_Trim_Surface :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 			instances:  Node_List,
 		},
 	},
@@ -1711,8 +1711,8 @@ Nurbs_Trim_Boundary :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 			instances:  Node_List,
 		},
 	},
@@ -1725,8 +1725,8 @@ Procedural_Geometry :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 			instances:  Node_List,
 		},
 	},
@@ -1738,8 +1738,8 @@ Stereo_Camera :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 			instances:  Node_List,
 		},
 	},
@@ -1753,8 +1753,8 @@ Camera_Switcher :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 			instances:  Node_List,
 		},
 	},
@@ -1776,8 +1776,8 @@ Marker :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 			instances:  Node_List,
 		},
 	},
@@ -1812,7 +1812,7 @@ Lod_Level :: struct {
 
 Lod_Level_List :: struct {
 	data:  ^Lod_Level,
-	count: uint,
+	count: c.size_t,
 }
 
 // Group of LOD (Level of Detail) levels for an object.
@@ -1823,24 +1823,24 @@ Lod_Group :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 			instances:  Node_List,
 		},
 	},
 
 	// If set to `true`, `ufbx_lod_level.distance` represents a screen size percentage.
-	relative_distances: bool,
+	relative_distances: c.bool,
 
 	// LOD levels matching in order to `ufbx_node.children`.
 	lod_levels: Lod_Level_List,
 
 	// If set to `true` don't account for parent transform when computing the distance.
-	ignore_parent_transform: bool,
+	ignore_parent_transform: c.bool,
 
 	// If `use_distance_limit` is enabled hide the group if the distance is not between
 	// `distance_limit_min` and `distance_limit_max`.
-	use_distance_limit: bool,
+	use_distance_limit: c.bool,
 	distance_limit_min: Real,
 	distance_limit_max: Real,
 }
@@ -1869,8 +1869,8 @@ SKINNING_METHOD_COUNT :: 4
 
 // Skin weight information for a single mesh vertex
 Skin_Vertex :: struct {
-	weight_begin: u32, // < Index to start from in the `weights[]` array
-	num_weights:  u32, // < Number of weights influencing the vertex
+	weight_begin: c.uint32_t, // < Index to start from in the `weights[]` array
+	num_weights:  c.uint32_t, // < Number of weights influencing the vertex
 
 	// Blend weight between Linear Blend Skinning (0.0) and Dual Quaternion (1.0).
 	// Should be used if `skinning_method == UFBX_SKINNING_METHOD_BLENDED_DQ_LINEAR`
@@ -1879,18 +1879,18 @@ Skin_Vertex :: struct {
 
 Skin_Vertex_List :: struct {
 	data:  ^Skin_Vertex,
-	count: uint,
+	count: c.size_t,
 }
 
 // Single per-vertex per-cluster weight, see `ufbx_skin_vertex`
 Skin_Weight :: struct {
-	cluster_index: u32,  // < Index into `ufbx_skin_deformer.clusters[]`
-	weight:        Real, // < Amount this bone influence the vertex
+	cluster_index: c.uint32_t, // < Index into `ufbx_skin_deformer.clusters[]`
+	weight:        Real,       // < Amount this bone influence the vertex
 }
 
 Skin_Weight_List :: struct {
 	data:  ^Skin_Weight,
-	count: uint,
+	count: c.size_t,
 }
 
 // Skin deformer specifies a binding between a logical set of bones (a skeleton)
@@ -1902,8 +1902,8 @@ Skin_Deformer :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 	skinning_method: Skinning_Method,
@@ -1916,12 +1916,12 @@ Skin_Deformer :: struct {
 	weights:         Skin_Weight_List,
 
 	// Largest amount of weights a single vertex can have
-	max_weights_per_vertex: uint,
+	max_weights_per_vertex: c.size_t,
 
 	// Blend weights between Linear Blend Skinning (0.0) and Dual Quaternion (1.0).
 	// HINT: You probably want to use `vertices` and `ufbx_skin_vertex.dq_weight` instead!
 	// NOTE: These may be out-of-bounds for a given mesh, `vertices` is always safe.
-	num_dq_weights: uint,
+	num_dq_weights: c.size_t,
 	dq_vertices:     Uint32_List,
 	dq_weights:      Real_List,
 }
@@ -1933,8 +1933,8 @@ Skin_Cluster :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 
@@ -1958,7 +1958,7 @@ Skin_Cluster :: struct {
 	// ie. `ufbx_matrix_mul(&cluster->bone->node_to_world, &cluster->geometry_to_bone)`
 	geometry_to_world: Matrix,
 	geometry_to_world_transform: Transform,
-	num_weights:                 uint,        // < Number of vertices in the cluster
+	num_weights:                 c.size_t,    // < Number of vertices in the cluster
 	vertices:                    Uint32_List, // < Vertex indices in `ufbx_mesh.vertices[]`
 	weights:                     Real_List,   // < Per-vertex weight values
 }
@@ -1971,8 +1971,8 @@ Blend_Deformer :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 
@@ -1994,7 +1994,7 @@ Blend_Keyframe :: struct {
 
 Blend_Keyframe_List :: struct {
 	data:  ^Blend_Keyframe,
-	count: uint,
+	count: c.size_t,
 }
 
 // Blend channel consists of multiple morph-key targets that are interpolated.
@@ -2005,8 +2005,8 @@ Blend_Channel :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 
@@ -2028,11 +2028,11 @@ Blend_Shape :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
-	num_offsets:      uint,        // < Number of vertex offsets in the following arrays
+	num_offsets:      c.size_t,    // < Number of vertex offsets in the following arrays
 	offset_vertices:  Uint32_List, // < Indices to `ufbx_mesh.vertices[]`
 	position_offsets: Vec3_List,   // < Always specified per-vertex offsets
 	normal_offsets:   Vec3_List,   // < Empty if not specified
@@ -2091,7 +2091,7 @@ Cache_Frame :: struct {
 	channel: String,
 
 	// Time of this frame in seconds.
-	time: f64,
+	time: c.double,
 
 	// Name of the file containing the data.
 	// The specified file may contain multiple frames, use `data_offset` etc. to
@@ -2108,15 +2108,15 @@ Cache_Frame :: struct {
 	scale_factor: Real,
 	data_format:        Cache_Data_Format,   // < Format of the data in the file
 	data_encoding:      Cache_Data_Encoding, // < Binary encoding of the data
-	data_offset:        u64,                 // < Byte offset into the file
-	data_count:         u32,                 // < Number of data elements
-	data_element_bytes: u32,                 // < Size of a single data element in bytes
-	data_total_bytes:   u64,                 // < Size of the whole data blob in bytes
+	data_offset:        c.uint64_t,          // < Byte offset into the file
+	data_count:         c.uint32_t,          // < Number of data elements
+	data_element_bytes: c.uint32_t,          // < Size of a single data element in bytes
+	data_total_bytes:   c.uint64_t,          // < Size of the whole data blob in bytes
 }
 
 Cache_Frame_List :: struct {
 	data:  ^Cache_Frame,
-	count: uint,
+	count: c.size_t,
 }
 
 Cache_Channel :: struct {
@@ -2143,7 +2143,7 @@ Cache_Channel :: struct {
 
 Cache_Channel_List :: struct {
 	data:  ^Cache_Channel,
-	count: uint,
+	count: c.size_t,
 }
 
 Geometry_Cache :: struct {
@@ -2159,8 +2159,8 @@ Cache_Deformer :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 	channel:          String,
@@ -2177,8 +2177,8 @@ Cache_File :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 
@@ -2222,7 +2222,7 @@ Material_Map :: struct {
 		value_vec3: Vec3,
 		value_vec4: Vec4,
 	},
-	value_int: i64,
+	value_int: c.int64_t,
 
 	// Texture if connected, otherwise `NULL`.
 	// May be valid but "disabled" (application specific) if `texture_enabled == false`.
@@ -2231,27 +2231,27 @@ Material_Map :: struct {
 	// `true` if the file has specified any of the values above.
 	// NOTE: The value may be set to a non-zero default even if `has_value == false`,
 	// for example missing factors are set to `1.0` if a color is defined.
-	has_value: bool,
+	has_value: c.bool,
 
 	// Controls whether shading should use `texture`.
 	// NOTE: Some shading models allow this to be `true` even if `texture == NULL`.
-	texture_enabled: bool,
+	texture_enabled: c.bool,
 
 	// Set to `true` if this feature should be disabled (specific to shader type).
-	feature_disabled: bool,
+	feature_disabled: c.bool,
 
 	// Number of components in the value from 1 to 4 if defined, 0 if not.
-	value_components: u8,
+	value_components: c.uint8_t,
 }
 
 // Material feature
 Material_Feature_Info :: struct {
 	// Whether the material model uses this feature or not.
 	// NOTE: The feature can be enabled but still not used if eg. the corresponding factor is at zero!
-	enabled: bool,
+	enabled: c.bool,
 
 	// Explicitly enabled/disabled by the material.
-	is_explicit: bool,
+	is_explicit: c.bool,
 }
 
 // Texture attached to an FBX property
@@ -2265,7 +2265,7 @@ Material_Texture :: struct {
 
 Material_Texture_List :: struct {
 	data:  ^Material_Texture,
-	count: uint,
+	count: c.size_t,
 }
 
 // Shading model type
@@ -2574,8 +2574,8 @@ Material :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 
@@ -2682,7 +2682,7 @@ Texture_Layer :: struct {
 
 Texture_Layer_List :: struct {
 	data:  ^Texture_Layer,
-	count: uint,
+	count: c.size_t,
 }
 
 Shader_Texture_Type :: enum c.int {
@@ -2714,7 +2714,7 @@ Shader_Texture_Input :: struct {
 		value_vec3: Vec3,
 		value_vec4: Vec4,
 	},
-	value_int:  i64,
+	value_int:  c.int64_t,
 	value_str:  String,
 	value_blob: Blob,
 
@@ -2722,11 +2722,11 @@ Shader_Texture_Input :: struct {
 	texture: ^Texture,
 
 	// Index of the output to use if `texture` is a multi-output shader node.
-	texture_output_index: i64,
+	texture_output_index: c.int64_t,
 
 	// Controls whether shading should use `texture`.
 	// NOTE: Some shading models allow this to be `true` even if `texture == NULL`.
-	texture_enabled: bool,
+	texture_enabled: c.bool,
 
 	// Property representing this input.
 	prop: ^Prop,
@@ -2740,7 +2740,7 @@ Shader_Texture_Input :: struct {
 
 Shader_Texture_Input_List :: struct {
 	data:  ^Shader_Texture_Input,
-	count: uint,
+	count: c.size_t,
 }
 
 // Texture that emulates a shader graph node.
@@ -2758,7 +2758,7 @@ Shader_Texture :: struct {
 	shader_name: String,
 
 	// 64-bit opaque identifier for the shader type.
-	shader_type_id: u64,
+	shader_type_id: c.uint64_t,
 
 	// Input values/textures (possibly further shader textures) to the shader.
 	// Sorted by `ufbx_shader_texture_input.name`.
@@ -2774,7 +2774,7 @@ Shader_Texture :: struct {
 	main_texture: ^Texture,
 
 	// Output index of `main_texture` if it is a multi-output shader.
-	main_texture_output_index: i64,
+	main_texture_output_index: c.int64_t,
 
 	// Prefix for properties related to this shader in `ufbx_texture`.
 	// NOTE: Contains the trailing '|' if not empty.
@@ -2784,7 +2784,7 @@ Shader_Texture :: struct {
 // Unique texture within the file.
 Texture_File :: struct {
 	// Index in `ufbx_scene.texture_files[]`.
-	index: u32,
+	index: c.uint32_t,
 
 	// Filename relative to the currently loaded file.
 	// HINT: If using functions other than `ufbx_load_file()`, you can provide
@@ -2816,7 +2816,7 @@ Texture_File :: struct {
 
 Texture_File_List :: struct {
 	data:  ^Texture_File,
-	count: uint,
+	count: c.size_t,
 }
 
 // Texture that controls material appearance
@@ -2826,8 +2826,8 @@ Texture :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 
@@ -2865,10 +2865,10 @@ Texture :: struct {
 	video: ^Video,
 
 	// FILE: Index into `ufbx_scene.texture_files[]` or `UFBX_NO_INDEX`.
-	file_index: u32,
+	file_index: c.uint32_t,
 
 	// FILE: True if `file_index` has a valid value.
-	has_file: bool,
+	has_file: c.bool,
 
 	// LAYERED: Inner texture layers, ordered from _bottom_ to _top_
 	layers: Texture_Layer_List,
@@ -2888,7 +2888,7 @@ Texture :: struct {
 	// Wrapping mode
 	wrap_u: Wrap_Mode,
 	wrap_v:           Wrap_Mode,
-	has_uv_transform: bool,      // < Has a non-identity `transform` and derived matrices.
+	has_uv_transform: c.bool,    // < Has a non-identity `transform` and derived matrices.
 	uv_transform:     Transform, // < Texture transformation in UV space
 	texture_to_uv:    Matrix,    // < Matrix representation of `transform`
 	uv_to_texture:    Matrix,    // < UV coordinate to normalized texture coordinate matrix
@@ -2901,8 +2901,8 @@ Video :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 
@@ -2942,8 +2942,8 @@ Shader :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 
@@ -2963,7 +2963,7 @@ Shader_Prop_Binding :: struct {
 
 Shader_Prop_Binding_List :: struct {
 	data:  ^Shader_Prop_Binding,
-	count: uint,
+	count: c.size_t,
 }
 
 // Shader binding table
@@ -2973,8 +2973,8 @@ Shader_Binding :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 	prop_bindings: Shader_Prop_Binding_List, // < Sorted by `shader_prop`
@@ -2982,27 +2982,27 @@ Shader_Binding :: struct {
 
 // -- Animation
 Prop_Override :: struct {
-	element_id:    u32,
-	_internal_key: u32,
+	element_id:    c.uint32_t,
+	_internal_key: c.uint32_t,
 	prop_name:     String,
 	value:         Vec4,
 	value_str:     String,
-	value_int:     i64,
+	value_int:     c.int64_t,
 }
 
 Prop_Override_List :: struct {
 	data:  ^Prop_Override,
-	count: uint,
+	count: c.size_t,
 }
 
 Transform_Override :: struct {
-	node_id:   u32,
+	node_id:   c.uint32_t,
 	transform: Transform,
 }
 
 Transform_Override_List :: struct {
 	data:  ^Transform_Override,
-	count: uint,
+	count: c.size_t,
 }
 
 // Animation descriptor used for evaluating animation.
@@ -3013,8 +3013,8 @@ Transform_Override_List :: struct {
 // with custom layers, property overrides, special flags, etc.
 Anim :: struct {
 	// Time begin/end for the animation, both may be zero if absent.
-	time_begin: f64,
-	time_end: f64,
+	time_begin: c.double,
+	time_end: c.double,
 
 	// List of layers in the animation.
 	layers: Anim_Layer_List,
@@ -3029,10 +3029,10 @@ Anim :: struct {
 	transform_overrides: Transform_Override_List,
 
 	// Evaluate connected properties as if they would not be connected.
-	ignore_connections: bool,
+	ignore_connections: c.bool,
 
 	// Custom `ufbx_anim` created by `ufbx_create_anim()`.
-	custom: bool,
+	custom: c.bool,
 }
 
 Anim_Stack :: struct {
@@ -3041,26 +3041,26 @@ Anim_Stack :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
-	time_begin: f64,
-	time_end:   f64,
+	time_begin: c.double,
+	time_end:   c.double,
 	layers:     Anim_Layer_List,
 	anim:       ^Anim,
 }
 
 Anim_Prop :: struct {
 	element:       ^Element,
-	_internal_key: u32,
+	_internal_key: c.uint32_t,
 	prop_name:     String,
 	anim_value:    ^Anim_Value,
 }
 
 Anim_Prop_List :: struct {
 	data:  ^Anim_Prop,
-	count: uint,
+	count: c.size_t,
 }
 
 Anim_Layer :: struct {
@@ -3069,22 +3069,22 @@ Anim_Layer :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 	weight:              Real,
-	weight_is_animated:  bool,
-	blended:             bool,
-	additive:            bool,
-	compose_rotation:    bool,
-	compose_scale:       bool,
+	weight_is_animated:  c.bool,
+	blended:             c.bool,
+	additive:            c.bool,
+	compose_rotation:    c.bool,
+	compose_scale:       c.bool,
 	anim_values:         Anim_Value_List,
 	anim_props:          Anim_Prop_List, // < Sorted by `element,prop_name`
 	anim:                ^Anim,
-	_min_element_id:     u32,
-	_max_element_id:     u32,
-	_element_id_bitmask: [4]u32,
+	_min_element_id:     c.uint32_t,
+	_max_element_id:     c.uint32_t,
+	_element_id_bitmask: [4]c.uint32_t,
 }
 
 Anim_Value :: struct {
@@ -3093,8 +3093,8 @@ Anim_Value :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 	default_value: Vec3,
@@ -3128,13 +3128,13 @@ Extrapolation :: struct {
 
 	// Count used for repeating modes.
 	// Negative values mean infinite repetition.
-	repeat_count: i32,
+	repeat_count: c.int32_t,
 }
 
 // Tangent vector at a keyframe, may be split into left/right
 Tangent :: struct {
-	dx: f32, // < Derivative in the time axis
-	dy: f32, // < Derivative in the (curve specific) value axis
+	dx: c.float, // < Derivative in the time axis
+	dy: c.float, // < Derivative in the (curve specific) value axis
 }
 
 // Single real `value` at a specified `time`, interpolation between two keyframes
@@ -3150,7 +3150,7 @@ Tangent :: struct {
 // HINT: You can use `ufbx_evaluate_curve(ufbx_anim_curve *curve, double time)`
 // rather than trying to manually handle all the interpolation modes.
 Keyframe :: struct {
-	time:          f64,
+	time:          c.double,
 	value:         Real,
 	interpolation: Interpolation,
 	left:          Tangent,
@@ -3159,7 +3159,7 @@ Keyframe :: struct {
 
 Keyframe_List :: struct {
 	data:  ^Keyframe,
-	count: uint,
+	count: c.size_t,
 }
 
 Anim_Curve :: struct {
@@ -3168,8 +3168,8 @@ Anim_Curve :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 
@@ -3187,8 +3187,8 @@ Anim_Curve :: struct {
 	max_value: Real,
 
 	// Time range for all the keyframes.
-	min_time: f64,
-	max_time:  f64,
+	min_time: c.double,
+	max_time:  c.double,
 }
 
 // Collection of nodes to hide/freeze
@@ -3198,16 +3198,16 @@ Display_Layer :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 
 	// Nodes included in the layer (exclusively at most one layer per node)
 	nodes: Node_List,
-	visible:  bool, // < Contained nodes are visible
-	frozen:   bool, // < Contained nodes cannot be edited
-	ui_color: Vec3, // < Visual color for UI
+	visible:  c.bool, // < Contained nodes are visible
+	frozen:   c.bool, // < Contained nodes cannot be edited
+	ui_color: Vec3,   // < Visual color for UI
 }
 
 // Named set of nodes/geometry features to select.
@@ -3217,8 +3217,8 @@ Selection_Set :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 
@@ -3233,15 +3233,15 @@ Selection_Node :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 
 	// Selection targets, possibly `NULL`
 	target_node: ^Node,
 	target_mesh:  ^Mesh,
-	include_node: bool,        // < Is `target_node` included in the selection
+	include_node: c.bool,      // < Is `target_node` included in the selection
 	vertices:     Uint32_List, // < Indices to `ufbx_mesh.vertices`
 	edges:        Uint32_List, // < Indices to `ufbx_mesh.edges`
 	faces:        Uint32_List, // < Indices to `ufbx_mesh.faces`
@@ -3254,8 +3254,8 @@ Character :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 }
@@ -3287,7 +3287,7 @@ Constraint_Target :: struct {
 
 Constraint_Target_List :: struct {
 	data:  ^Constraint_Target,
-	count: uint,
+	count: c.size_t,
 }
 
 // Method to determine the up vector in aim constraints
@@ -3317,8 +3317,8 @@ Constraint :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 
@@ -3334,12 +3334,12 @@ Constraint :: struct {
 
 	// State of the constraint
 	weight: Real,
-	active:             bool,
+	active:             c.bool,
 
 	// Translation/rotation/scale axes the constraint is applied to
-	constrain_translation: [3]bool,
-	constrain_rotation: [3]bool,
-	constrain_scale:    [3]bool,
+	constrain_translation: [3]c.bool,
+	constrain_rotation: [3]c.bool,
+	constrain_scale:    [3]c.bool,
 
 	// Offset from the constrained position
 	transform_offset: Transform,
@@ -3363,8 +3363,8 @@ Audio_Layer :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 
@@ -3378,8 +3378,8 @@ Audio_Clip :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 
@@ -3427,7 +3427,7 @@ Bone_Pose :: struct {
 
 Bone_Pose_List :: struct {
 	data:  ^Bone_Pose,
-	count: uint,
+	count: c.size_t,
 }
 
 Pose :: struct {
@@ -3436,13 +3436,13 @@ Pose :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 
 	// Set if this pose is marked as a bind pose.
-	is_bind_pose: bool,
+	is_bind_pose: c.bool,
 
 	// List of bone poses.
 	// Sorted by `ufbx_node.typed_id`.
@@ -3455,8 +3455,8 @@ Metadata_Object :: struct {
 		using _: struct {
 			name:       String,
 			props:      Props,
-			element_id: u32,
-			typed_id:   u32,
+			element_id: c.uint32_t,
+			typed_id:   c.uint32_t,
 		},
 	},
 }
@@ -3465,13 +3465,13 @@ Metadata_Object :: struct {
 Name_Element :: struct {
 	name:          String,
 	type:          Element_Type,
-	_internal_key: u32,
+	_internal_key: c.uint32_t,
 	element:       ^Element,
 }
 
 Name_Element_List :: struct {
 	data:  ^Name_Element,
-	count: uint,
+	count: c.size_t,
 }
 
 // Scene is the root object loaded by ufbx that everything is accessed from.
@@ -3574,15 +3574,15 @@ Warning :: struct {
 	description: String,
 
 	// The element related to this warning or `UFBX_NO_INDEX` if not related to a specific element.
-	element_id: u32,
+	element_id: c.uint32_t,
 
 	// Number of times this warning was encountered.
-	count: uint,
+	count: c.size_t,
 }
 
 Warning_List :: struct {
 	data:  ^Warning,
-	count: uint,
+	count: c.size_t,
 }
 
 Thumbnail_Format :: enum c.int {
@@ -3624,8 +3624,8 @@ Thumbnail :: struct {
 	props:  Props,
 
 	// Extents of the thumbnail
-	width: u32,
-	height: u32,
+	width: c.uint32_t,
+	height: c.uint32_t,
 
 	// Format of `ufbx_thumbnail.data`.
 	format: Thumbnail_Format,
@@ -3643,59 +3643,59 @@ Metadata :: struct {
 	warnings: Warning_List,
 
 	// FBX ASCII file format.
-	ascii: bool,
+	ascii: c.bool,
 
 	// FBX version in integer format, eg. 7400 for 7.4.
-	version: u32,
+	version: c.uint32_t,
 
 	// File format of the source file.
 	file_format: File_Format,
 
 	// Index arrays may contain `UFBX_NO_INDEX` instead of a valid index
 	// to indicate gaps.
-	may_contain_no_index: bool,
+	may_contain_no_index: c.bool,
 
 	// May contain meshes with no defined vertex position.
 	// NOTE: `ufbx_mesh.vertex_position.exists` may be `false`!
-	may_contain_missing_vertex_position: bool,
+	may_contain_missing_vertex_position: c.bool,
 
 	// Arrays may contain items with `NULL` element references.
 	// See `ufbx_load_opts.connect_broken_elements`.
-	may_contain_broken_elements: bool,
+	may_contain_broken_elements: c.bool,
 
 	// Some API guarantees do not apply (depending on unsafe options used).
 	// Loaded with `ufbx_load_opts.allow_unsafe` enabled.
-	is_unsafe: bool,
+	is_unsafe: c.bool,
 
 	// Flag for each possible warning type.
 	// See `ufbx_metadata.warnings[]` for detailed warning information.
-	has_warning: [15]bool,
+	has_warning: [15]c.bool,
 	creator:                        String,
-	big_endian:                     bool,
+	big_endian:                     c.bool,
 	filename:                       String,
 	relative_root:                  String,
 	raw_filename:                   Blob,
 	raw_relative_root:              Blob,
 	exporter:                       Exporter,
-	exporter_version:               u32,
+	exporter_version:               c.uint32_t,
 	scene_props:                    Props,
 	original_application:           Application,
 	latest_application:             Application,
 	thumbnail:                      Thumbnail,
-	geometry_ignored:               bool,
-	animation_ignored:              bool,
-	embedded_ignored:               bool,
-	max_face_triangles:             uint,
-	result_memory_used:             uint,
-	temp_memory_used:               uint,
-	result_allocs:                  uint,
-	temp_allocs:                    uint,
-	element_buffer_size:            uint,
-	num_shader_textures:            uint,
+	geometry_ignored:               c.bool,
+	animation_ignored:              c.bool,
+	embedded_ignored:               c.bool,
+	max_face_triangles:             c.size_t,
+	result_memory_used:             c.size_t,
+	temp_memory_used:               c.size_t,
+	result_allocs:                  c.size_t,
+	temp_allocs:                    c.size_t,
+	element_buffer_size:            c.size_t,
+	num_shader_textures:            c.size_t,
 	bone_prop_size_unit:            Real,
-	bone_prop_limb_length_relative: bool,
+	bone_prop_limb_length_relative: c.bool,
 	ortho_size_unit:                Real,
-	ktime_second:                   i64, // < One second in internal KTime units
+	ktime_second:                   c.int64_t, // < One second in internal KTime units
 	original_file_path:             String,
 	raw_original_file_path:         Blob,
 
@@ -3773,7 +3773,7 @@ Scene_Settings :: struct {
 	unit_meters: Real,
 
 	// Frames per second the animation is defined at.
-	frames_per_second: f64,
+	frames_per_second: c.double,
 	ambient_color:        Vec3,
 	default_camera:       String,
 
@@ -3884,13 +3884,13 @@ Scene :: struct {
 
 // -- Curves
 Curve_Point :: struct {
-	valid:      bool,
+	valid:      c.bool,
 	position:   Vec3,
 	derivative: Vec3,
 }
 
 Surface_Point :: struct {
-	valid:        bool,
+	valid:        c.bool,
 	position:     Vec3,
 	derivative_u: Vec3,
 	derivative_v: Vec3,
@@ -3903,12 +3903,12 @@ Topo_Flags :: enum c.int {
 }
 
 Topo_Edge :: struct {
-	index: u32, // < Starting index of the edge, always defined
-	next:  u32, // < Ending index of the edge / next per-face `ufbx_topo_edge`, always defined
-	prev:  u32, // < Previous per-face `ufbx_topo_edge`, always defined
-	twin:  u32, // < `ufbx_topo_edge` on the opposite side, `UFBX_NO_INDEX` if not found
-	face:  u32, // < Index into `mesh->faces[]`, always defined
-	edge:  u32, // < Index into `mesh->edges[]`, `UFBX_NO_INDEX` if not found
+	index: c.uint32_t, // < Starting index of the edge, always defined
+	next:  c.uint32_t, // < Ending index of the edge / next per-face `ufbx_topo_edge`, always defined
+	prev:  c.uint32_t, // < Previous per-face `ufbx_topo_edge`, always defined
+	twin:  c.uint32_t, // < `ufbx_topo_edge` on the opposite side, `UFBX_NO_INDEX` if not found
+	face:  c.uint32_t, // < Index into `mesh->faces[]`, always defined
+	edge:  c.uint32_t, // < Index into `mesh->edges[]`, `UFBX_NO_INDEX` if not found
 	flags: Topo_Flags,
 }
 
@@ -3916,22 +3916,22 @@ Topo_Edge :: struct {
 // NOTE: `ufbx_generate_indices()` compares the vertices using `memcmp()`, so
 // any padding should be cleared to zero.
 Vertex_Stream :: struct {
-	data:         rawptr, // < Data pointer of shape `char[vertex_count][vertex_size]`.
-	vertex_count: uint,   // < Number of vertices in this stream, for sanity checking.
-	vertex_size:  uint,   // < Size of a vertex in bytes.
+	data:         rawptr,   // < Data pointer of shape `char[vertex_count][vertex_size]`.
+	vertex_count: c.size_t, // < Number of vertices in this stream, for sanity checking.
+	vertex_size:  c.size_t, // < Size of a vertex in bytes.
 }
 
 // Allocate `size` bytes, must be at least 8 byte aligned
-Alloc_Fn :: proc "c" (rawptr, uint) -> rawptr
+Alloc_Fn :: proc "c" (rawptr, c.size_t) -> rawptr
 
 // Reallocate `old_ptr` from `old_size` to `new_size`
 // NOTE: If omit `alloc_fn` and `free_fn` they will be translated to:
 //   `alloc(size)` -> `realloc_fn(user, NULL, 0, size)`
 //   `free_fn(ptr, size)` ->  `realloc_fn(user, ptr, size, 0)`
-Realloc_Fn :: proc "c" (rawptr, rawptr, uint, uint) -> rawptr
+Realloc_Fn :: proc "c" (rawptr, rawptr, c.size_t, c.size_t) -> rawptr
 
 // Free pointer `ptr` (of `size` bytes) returned by `alloc_fn` or `realloc_fn`
-Free_Fn :: proc "c" (rawptr, rawptr, uint)
+Free_Fn :: proc "c" (rawptr, rawptr, c.size_t)
 
 // Free the allocator itself
 Free_Allocator_Fn :: proc "c" (rawptr)
@@ -3954,16 +3954,16 @@ Allocator_Opts :: struct {
 	allocator: Allocator,
 
 	// Maximum number of bytes to allocate before failing
-	memory_limit: uint,
+	memory_limit: c.size_t,
 
 	// Maximum number of allocations to attempt before failing
-	allocation_limit: uint,
+	allocation_limit: c.size_t,
 
 	// Threshold to swap from batched allocations to individual ones
 	// Defaults to 1MB if set to zero
 	// NOTE: If set to `1` ufbx will allocate everything in the smallest
 	// possible chunks which may be useful for debugging (eg. ASAN)
-	huge_threshold: uint,
+	huge_threshold: c.size_t,
 
 	// Maximum size of a single allocation containing sub-allocations.
 	// Defaults to 16MB if set to zero
@@ -3975,19 +3975,19 @@ Allocator_Opts :: struct {
 	// slightly as the chunks start out at 4kB and double in size each time,
 	// meaning that the maximum fixed overhead (up to 32MB with defaults) is
 	// at most ~30% of the total allocation size.
-	max_chunk_size: uint,
+	max_chunk_size: c.size_t,
 }
 
 // Try to read up to `size` bytes to `data`, return the amount of read bytes.
 // Return `SIZE_MAX` to indicate an IO error.
-Read_Fn :: proc "c" (rawptr, rawptr, uint) -> uint
+Read_Fn :: proc "c" (rawptr, rawptr, c.size_t) -> c.size_t
 
 // Skip `size` bytes in the file.
-Skip_Fn :: proc "c" (rawptr, uint) -> bool
+Skip_Fn :: proc "c" (rawptr, c.size_t) -> c.bool
 
 // Get the size of the file.
 // Return `0` if unknown, `UINT64_MAX` if error.
-Size_Fn :: proc "c" (rawptr) -> u64
+Size_Fn :: proc "c" (rawptr) -> c.uint64_t
 
 // Close the file
 Close_Fn :: proc "c" (rawptr)
@@ -4011,7 +4011,7 @@ Open_File_Type :: enum c.int {
 
 OPEN_FILE_TYPE_COUNT :: 3
 
-Open_File_Context :: uintptr
+Open_File_Context :: c.uintptr_t
 
 Open_File_Info :: struct {
 	// Context that can be passed to the following functions to use a shared allocator:
@@ -4028,7 +4028,7 @@ Open_File_Info :: struct {
 }
 
 // Callback for opening an external file from the filesystem
-Open_File_Fn :: proc "c" (rawptr, ^Stream, cstring, uint, ^Open_File_Info) -> bool
+Open_File_Fn :: proc "c" (rawptr, ^Stream, cstring, c.size_t, ^Open_File_Info) -> c.bool
 
 Open_File_Cb :: struct {
 	fn:   Open_File_Fn,
@@ -4037,18 +4037,18 @@ Open_File_Cb :: struct {
 
 // Options for `ufbx_open_file()`.
 Open_File_Opts :: struct {
-	_begin_zero: u32,
+	_begin_zero: c.uint32_t,
 
 	// Allocator to allocate the memory with.
 	allocator: Allocator_Opts,
 
 	// The filename is guaranteed to be NULL-terminated.
-	filename_null_terminated: bool,
-	_end_zero:   u32,
+	filename_null_terminated: c.bool,
+	_end_zero:   c.uint32_t,
 }
 
 // Memory stream options
-Close_Memory_Fn :: proc "c" (rawptr, rawptr, uint)
+Close_Memory_Fn :: proc "c" (rawptr, rawptr, c.size_t)
 
 Close_Memory_Cb :: struct {
 	fn:   Close_Memory_Fn,
@@ -4057,7 +4057,7 @@ Close_Memory_Cb :: struct {
 
 // Options for `ufbx_open_memory()`.
 Open_Memory_Opts :: struct {
-	_begin_zero: u32,
+	_begin_zero: c.uint32_t,
 
 	// Allocator to allocate the memory with.
 	// NOTE: Used even if no copy is made to allocate a small metadata block.
@@ -4067,17 +4067,17 @@ Open_Memory_Opts :: struct {
 	// You can use `close_cb` to free the memory when the stream is closed.
 	// NOTE: This means the provided data pointer is referenced after creating
 	// the memory stream, make sure the data stays valid until the stream is closed!
-	no_copy: bool,
+	no_copy: c.bool,
 
 	// Callback to free the memory blob.
 	close_cb: Close_Memory_Cb,
-	_end_zero:   u32,
+	_end_zero:   c.uint32_t,
 }
 
 // Detailed error stack frame.
 // NOTE: You must compile `ufbx.c` with `UFBX_ENABLE_ERROR_STACK` to enable the error stack.
 Error_Frame :: struct {
-	source_line: u32,
+	source_line: c.uint32_t,
 	function:    String,
 	description: String,
 }
@@ -4184,19 +4184,19 @@ Error :: struct {
 
 	// Internal error stack.
 	// NOTE: You must compile `ufbx.c` with `UFBX_ENABLE_ERROR_STACK` to enable the error stack.
-	stack_size: u32,
+	stack_size: c.uint32_t,
 	stack: [8]Error_Frame,
 
 	// Additional error information, such as missing file filename.
 	// `info` is a NULL-terminated UTF-8 string containing `info_length` bytes, excluding the trailing `'\0'`.
-	info_length: uint,
-	info:  [256]u8,
+	info_length: c.size_t,
+	info:  [256]c.char,
 }
 
 // Loading progress information.
 Progress :: struct {
-	bytes_read:  u64,
-	bytes_total: u64,
+	bytes_read:  c.uint64_t,
+	bytes_total: c.uint64_t,
 }
 
 // Progress result returned from `ufbx_progress_fn()` callback.
@@ -4222,15 +4222,15 @@ Progress_Cb :: struct {
 // Source data/stream to decompress with `ufbx_inflate()`
 Inflate_Input :: struct {
 	// Total size of the data in bytes
-	total_size: uint,
+	total_size: c.size_t,
 
 	// (optional) Initial or complete data chunk
 	data: rawptr,
-	data_size:              uint,
+	data_size:              c.size_t,
 
 	// (optional) Temporary buffer, defaults to 256b stack buffer
 	buffer: rawptr,
-	buffer_size:            uint,
+	buffer_size:            c.size_t,
 
 	// (optional) Streaming read function, concatenated after `data`
 	read_fn: Read_Fn,
@@ -4238,27 +4238,27 @@ Inflate_Input :: struct {
 
 	// (optional) Progress reporting
 	progress_cb: Progress_Cb,
-	progress_interval_hint: u64, // < Bytes between progress report calls
+	progress_interval_hint: c.uint64_t, // < Bytes between progress report calls
 
 	// (optional) Change the progress scope
-	progress_size_before: u64,
-	progress_size_after:    u64,
+	progress_size_before: c.uint64_t,
+	progress_size_after:    c.uint64_t,
 
 	// (optional) No the DEFLATE header
-	no_header: bool,
+	no_header: c.bool,
 
 	// (optional) No the Adler32 checksum
-	no_checksum: bool,
+	no_checksum: c.bool,
 
 	// (optional) Force internal fast lookup bit amount
-	internal_fast_bits: uint,
+	internal_fast_bits: c.size_t,
 }
 
 // Persistent data between `ufbx_inflate()` calls
 // NOTE: You must set `initialized` to `false`, but `data` may be uninitialized
 Inflate_Retain :: struct {
-	initialized: bool,
-	data:        [1024]u64,
+	initialized: c.bool,
+	data:        [1024]c.uint64_t,
 }
 
 Index_Error_Handling :: enum c.int {
@@ -4424,43 +4424,43 @@ Baked_Key_Flags :: distinct bit_set[Baked_Key_Flag; c.int]
 BAKED_KEY_FORCE_32BIT :: Baked_Key_Flags { .STEP_LEFT, .STEP_RIGHT, .STEP_KEY, .KEYFRAME, .REDUCED }
 
 Baked_Vec3 :: struct {
-	time:  f64,            // < Time of the keyframe, in seconds
+	time:  c.double,       // < Time of the keyframe, in seconds
 	value: Vec3,           // < Value at `time`, can be linearly interpolated
 	flags: Baked_Key_Flag, // < Additional information about the keyframe
 }
 
 Baked_Vec3_List :: struct {
 	data:  ^Baked_Vec3,
-	count: uint,
+	count: c.size_t,
 }
 
 Baked_Quat :: struct {
-	time:  f64,            // < Time of the keyframe, in seconds
+	time:  c.double,       // < Time of the keyframe, in seconds
 	value: Quat,           // < Value at `time`, can be (spherically) linearly interpolated
 	flags: Baked_Key_Flag, // < Additional information about the keyframe
 }
 
 Baked_Quat_List :: struct {
 	data:  ^Baked_Quat,
-	count: uint,
+	count: c.size_t,
 }
 
 // Baked transform animation for a single node.
 Baked_Node :: struct {
 	// Typed ID of the node, maps to `ufbx_scene.nodes[]`.
-	typed_id: u32,
+	typed_id: c.uint32_t,
 
 	// Element ID of the element, maps to `ufbx_scene.elements[]`.
-	element_id: u32,
+	element_id: c.uint32_t,
 
 	// The translation channel has constant values for the whole animation.
-	constant_translation: bool,
+	constant_translation: c.bool,
 
 	// The rotation channel has constant values for the whole animation.
-	constant_rotation: bool,
+	constant_rotation: c.bool,
 
 	// The scale channel has constant values for the whole animation.
-	constant_scale: bool,
+	constant_scale: c.bool,
 
 	// Translation keys for the animation, maps to `ufbx_node.local_transform.translation`.
 	translation_keys: Baked_Vec3_List,
@@ -4474,7 +4474,7 @@ Baked_Node :: struct {
 
 Baked_Node_List :: struct {
 	data:  ^Baked_Node,
-	count: uint,
+	count: c.size_t,
 }
 
 // Baked property animation.
@@ -4483,7 +4483,7 @@ Baked_Prop :: struct {
 	name: String,
 
 	// The value of the property is constant for the whole animation.
-	constant_value: bool,
+	constant_value: c.bool,
 
 	// Property value keys.
 	keys: Baked_Vec3_List,
@@ -4491,13 +4491,13 @@ Baked_Prop :: struct {
 
 Baked_Prop_List :: struct {
 	data:  ^Baked_Prop,
-	count: uint,
+	count: c.size_t,
 }
 
 // Baked property animation for a single element.
 Baked_Element :: struct {
 	// Element ID of the element, maps to `ufbx_scene.elements[]`.
-	element_id: u32,
+	element_id: c.uint32_t,
 
 	// List of properties the animation modifies.
 	props: Baked_Prop_List,
@@ -4505,15 +4505,15 @@ Baked_Element :: struct {
 
 Baked_Element_List :: struct {
 	data:  ^Baked_Element,
-	count: uint,
+	count: c.size_t,
 }
 
 Baked_Anim_Metadata :: struct {
 	// Memory statistics
-	result_memory_used: uint,
-	temp_memory_used: uint,
-	result_allocs:    uint,
-	temp_allocs:      uint,
+	result_memory_used: c.size_t,
+	temp_memory_used: c.size_t,
+	result_allocs:    c.size_t,
+	temp_allocs:      c.size_t,
 }
 
 // Animation baked into linearly interpolated keyframes.
@@ -4529,13 +4529,13 @@ Baked_Anim :: struct {
 	elements: Baked_Element_List,
 
 	// Playback time range for the animation.
-	playback_time_begin: f64,
-	playback_time_end: f64,
-	playback_duration: f64,
+	playback_time_begin: c.double,
+	playback_time_end: c.double,
+	playback_duration: c.double,
 
 	// Keyframe time range.
-	key_time_min: f64,
-	key_time_max:      f64,
+	key_time_min: c.double,
+	key_time_max:      c.double,
 
 	// Additional bake information.
 	metadata: Baked_Anim_Metadata,
@@ -4544,26 +4544,26 @@ Baked_Anim :: struct {
 // Internal thread pool handle.
 // Passed to `ufbx_thread_pool_run_task()` from an user thread to run ufbx tasks.
 // HINT: This context can store a user pointer via `ufbx_thread_pool_set_user_ptr()`.
-Thread_Pool_Context :: uintptr
+Thread_Pool_Context :: c.uintptr_t
 
 // Thread pool creation information from ufbx.
 Thread_Pool_Info :: struct {
-	max_concurrent_tasks: u32,
+	max_concurrent_tasks: c.uint32_t,
 }
 
 // Initialize the thread pool.
 // Return `true` on success.
-Thread_Pool_Init_Fn :: proc "c" (rawptr, Thread_Pool_Context, ^Thread_Pool_Info) -> bool
+Thread_Pool_Init_Fn :: proc "c" (rawptr, Thread_Pool_Context, ^Thread_Pool_Info) -> c.bool
 
 // Run tasks `count` tasks in threads.
 // You must call `ufbx_thread_pool_run_task()` with indices `[start_index, start_index + count)`.
 // The threads are launched in batches indicated by `group`, see `UFBX_THREAD_GROUP_COUNT` for more information.
 // Ideally, you should run all the task indices in parallel within each `ufbx_thread_pool_run_fn()` call.
-Thread_Pool_Run_Fn :: proc "c" (rawptr, Thread_Pool_Context, u32, u32, u32)
+Thread_Pool_Run_Fn :: proc "c" (rawptr, Thread_Pool_Context, c.uint32_t, c.uint32_t, c.uint32_t)
 
 // Wait for previous tasks spawned in `ufbx_thread_pool_run_fn()` to finish.
 // `group` specifies the batch to wait for, `max_index` contains `start_index + count` from that group instance.
-Thread_Pool_Wait_Fn :: proc "c" (rawptr, Thread_Pool_Context, u32, u32)
+Thread_Pool_Wait_Fn :: proc "c" (rawptr, Thread_Pool_Context, c.uint32_t, c.uint32_t)
 
 // Free the thread pool.
 Thread_Pool_Free_Fn :: proc "c" (rawptr, Thread_Pool_Context)
@@ -4595,13 +4595,13 @@ Thread_Opts :: struct {
 
 	// Maximum of tasks to have in-flight.
 	// Default: 2048
-	num_tasks: uint,
+	num_tasks: c.size_t,
 
 	// Maximum amount of memory to use for batched threaded processing.
 	// Default: 32MB
 	// NOTE: The actual used memory usage might be higher, if there are individual tasks
 	// that rqeuire a high amount of memory.
-	memory_limit: uint,
+	memory_limit: c.size_t,
 }
 
 // Flags to control nanimation evaluation functions.
@@ -4614,16 +4614,16 @@ Evaluate_Flags :: enum c.int {
 // Options for `ufbx_load_file/memory/stream/stdio()`
 // NOTE: Initialize to zero with `{ 0 }` (C) or `{ }` (C++)
 Load_Opts :: struct {
-	_begin_zero:            u32,
+	_begin_zero:            c.uint32_t,
 	temp_allocator:         Allocator_Opts, // < Allocator used during loading
 	result_allocator:       Allocator_Opts, // < Allocator used for the final scene
 	thread_opts:            Thread_Opts,    // < Threading options
-	ignore_geometry:        bool,           // < Do not load geometry datsa (vertices, indices, etc)
-	ignore_animation:       bool,           // < Do not load animation curves
-	ignore_embedded:        bool,           // < Do not load embedded content
-	ignore_all_content:     bool,           // < Do not load any content (geometry, animation, embedded)
-	evaluate_skinning:      bool,           // < Evaluate skinning (see ufbx_mesh.skinned_vertices)
-	evaluate_caches:        bool,           // < Evaluate vertex caches (see ufbx_mesh.skinned_vertices)
+	ignore_geometry:        c.bool,         // < Do not load geometry datsa (vertices, indices, etc)
+	ignore_animation:       c.bool,         // < Do not load animation curves
+	ignore_embedded:        c.bool,         // < Do not load embedded content
+	ignore_all_content:     c.bool,         // < Do not load any content (geometry, animation, embedded)
+	evaluate_skinning:      c.bool,         // < Evaluate skinning (see ufbx_mesh.skinned_vertices)
+	evaluate_caches:        c.bool,         // < Evaluate vertex caches (see ufbx_mesh.skinned_vertices)
 
 	// Try to open external files referenced by the main file automatically.
 	// Applies to geometry caches and .mtl files for OBJ.
@@ -4635,41 +4635,41 @@ Load_Opts :: struct {
 	// NOTE: Will fail loading if any external files are not found by default, use
 	// `ufbx_load_opts.ignore_missing_external_files` to suppress this, in this case
 	// you can find the errors at `ufbx_metadata.warnings[]` as `UFBX_WARNING_MISSING_EXTERNAL_FILE`.
-	load_external_files: bool,
+	load_external_files: c.bool,
 
 	// Don't fail loading if external files are not found.
-	ignore_missing_external_files: bool,
+	ignore_missing_external_files: c.bool,
 
 	// Don't compute `ufbx_skin_deformer` `vertices` and `weights` arrays saving
 	// a bit of memory and time if not needed
-	skip_skin_vertices: bool,
+	skip_skin_vertices: c.bool,
 
 	// Skip computing `ufbx_mesh.material_parts[]` and `ufbx_mesh.face_group_parts[]`.
-	skip_mesh_parts: bool,
+	skip_mesh_parts: c.bool,
 
 	// Clean-up skin weights by removing negative, zero and NAN weights.
-	clean_skin_weights: bool,
+	clean_skin_weights: c.bool,
 
 	// Read Blender materials as PBR values.
 	// Blender converts PBR materials to legacy FBX Phong materials in a deterministic way.
 	// If this setting is enabled, such materials will be read as `UFBX_SHADER_BLENDER_PHONG`,
 	// which means ufbx will be able to parse roughness and metallic textures.
-	use_blender_pbr_material: bool,
+	use_blender_pbr_material: c.bool,
 
 	// Don't adjust reading the FBX file depending on the detected exporter
-	disable_quirks: bool,
+	disable_quirks: c.bool,
 
 	// Don't allow partially broken FBX files to load
-	strict: bool,
+	strict: c.bool,
 
 	// Force ASCII parsing to use a single thread.
 	// The multi-threaded ASCII parsing is slightly more lenient as it ignores
 	// the self-reported size of ASCII arrays, that threaded parsing depends on.
-	force_single_thread_ascii_parsing: bool,
+	force_single_thread_ascii_parsing: c.bool,
 
 	// UNSAFE: If enabled allows using unsafe options that may fundamentally
 	// break the API guarantees.
-	allow_unsafe: bool,
+	allow_unsafe: c.bool,
 
 	// Specify how to handle broken indices.
 	index_error_handling: Index_Error_Handling,
@@ -4677,40 +4677,40 @@ Load_Opts :: struct {
 	// Connect related elements even if they are broken. If `false` (default)
 	// `ufbx_skin_cluster` with a missing `bone` field are _not_ included in
 	// the `ufbx_skin_deformer.clusters[]` array for example.
-	connect_broken_elements: bool,
+	connect_broken_elements: c.bool,
 
 	// Allow nodes that are not connected in any way to the root. Conversely if
 	// disabled, all lone nodes will be parented under `ufbx_scene.root_node`.
-	allow_nodes_out_of_root: bool,
+	allow_nodes_out_of_root: c.bool,
 
 	// Allow meshes with no vertex position attribute.
 	// NOTE: If this is set `ufbx_mesh.vertex_position.exists` may be `false`.
-	allow_missing_vertex_position: bool,
+	allow_missing_vertex_position: c.bool,
 
 	// Allow faces with zero indices.
-	allow_empty_faces: bool,
+	allow_empty_faces: c.bool,
 
 	// Generate vertex normals for a meshes that are missing normals.
 	// You can see if the normals have been generated from `ufbx_mesh.generated_normals`.
-	generate_missing_normals: bool,
+	generate_missing_normals: c.bool,
 
 	// Ignore `open_file_cb` when loading the main file.
-	open_main_file_with_default: bool,
+	open_main_file_with_default: c.bool,
 
 	// Path separator character, defaults to '\' on Windows and '/' otherwise.
-	path_separator: u8,
+	path_separator: c.char,
 
 	// Maximum depth of the node hirerachy.
 	// Will fail with `UFBX_ERROR_NODE_DEPTH_LIMIT` if a node is deeper than this limit.
 	// NOTE: The default of 0 allows arbitrarily deep hierarchies. Be careful if using
 	// recursive algorithms without setting this limit.
-	node_depth_limit: u32,
+	node_depth_limit: c.uint32_t,
 
 	// Estimated file size for progress reporting
-	file_size_estimate: u64,
+	file_size_estimate: c.uint64_t,
 
 	// Buffer size in bytes to use for reading from files or IO callbacks
-	read_buffer_size: uint,
+	read_buffer_size: c.size_t,
 
 	// Filename to use as a base for relative file paths if not specified using
 	// `ufbx_load_file()`. Use `length = SIZE_MAX` for NULL-terminated strings.
@@ -4723,7 +4723,7 @@ Load_Opts :: struct {
 
 	// Progress reporting
 	progress_cb: Progress_Cb,
-	progress_interval_hint: u64,            // < Bytes between progress report calls
+	progress_interval_hint: c.uint64_t,     // < Bytes between progress report calls
 
 	// External file callbacks (defaults to stdio.h)
 	open_file_cb: Open_File_Cb,
@@ -4748,12 +4748,12 @@ Load_Opts :: struct {
 	handedness_conversion_axis: Mirror_Axis,
 
 	// Do not change winding of faces when converting handedness.
-	handedness_conversion_retain_winding: bool,
+	handedness_conversion_retain_winding: c.bool,
 
 	// Reverse winding of all faces.
 	// If `handedness_conversion_retain_winding` is not specified, mirrored meshes
 	// will retain their original winding.
-	reverse_winding: bool,
+	reverse_winding: c.bool,
 
 	// Apply an implicit root transformation to match axes.
 	// Used if `ufbx_coordinate_axes_valid(target_axes)`.
@@ -4782,57 +4782,57 @@ Load_Opts :: struct {
 	scale_helper_name: String,
 
 	// Normalize vertex normals.
-	normalize_normals: bool,
+	normalize_normals: c.bool,
 
 	// Normalize tangents and bitangents.
-	normalize_tangents: bool,
+	normalize_tangents: c.bool,
 
 	// Override for the root transform
-	use_root_transform: bool,
+	use_root_transform: c.bool,
 	root_transform:         Transform,
 
 	// Animation keyframe clamp threshold, only applies to specific interpolation modes.
-	key_clamp_threshold: f64,
+	key_clamp_threshold: c.double,
 
 	// Specify how to handle Unicode errors in strings.
 	unicode_error_handling: Unicode_Error_Handling,
 
 	// Retain the 'W' component of mesh normal/tangent/bitangent.
 	// See `ufbx_vertex_attrib.values_w`.
-	retain_vertex_attrib_w: bool,
+	retain_vertex_attrib_w: c.bool,
 
 	// Retain the raw document structure using `ufbx_dom_node`.
-	retain_dom: bool,
+	retain_dom: c.bool,
 
 	// Force a specific file format instead of detecting it.
 	file_format: File_Format,
 
 	// How far to read into the file to determine the file format.
 	// Default: 16kB
-	file_format_lookahead: uint,
+	file_format_lookahead: c.size_t,
 
 	// Do not attempt to detect file format from file content.
-	no_format_from_content: bool,
+	no_format_from_content: c.bool,
 
 	// Do not attempt to detect file format from filename extension.
 	// ufbx primarily detects file format from the file header,
 	// this is just used as a fallback.
-	no_format_from_extension: bool,
+	no_format_from_extension: c.bool,
 
 	// (.obj) Try to find .mtl file with matching filename as the .obj file.
 	// Used if the file specified `mtllib` line is not found, eg. for a file called
 	// `model.obj` that contains the line `usemtl materials.mtl`, ufbx would first
 	// try to open `materials.mtl` and if that fails it tries to open `model.mtl`.
-	obj_search_mtl_by_filename: bool,
+	obj_search_mtl_by_filename: c.bool,
 
 	// (.obj) Don't split geometry into meshes by object.
-	obj_merge_objects: bool,
+	obj_merge_objects: c.bool,
 
 	// (.obj) Don't split geometry into meshes by groups.
-	obj_merge_groups: bool,
+	obj_merge_groups: c.bool,
 
 	// (.obj) Force splitting groups even on object boundaries.
-	obj_split_groups: bool,
+	obj_split_groups: c.bool,
 
 	// (.obj) Path to the .mtl file.
 	// Use `length = SIZE_MAX` for NULL-terminated strings.
@@ -4852,43 +4852,43 @@ Load_Opts :: struct {
 	// .obj files do not define the coordinate space they use. By default no
 	// coordinate space is assumed and no conversion is performed.
 	obj_axes: Coordinate_Axes,
-	_end_zero:              u32,
+	_end_zero:              c.uint32_t,
 }
 
 // Options for `ufbx_evaluate_scene()`
 // NOTE: Initialize to zero with `{ 0 }` (C) or `{ }` (C++)
 Evaluate_Opts :: struct {
-	_begin_zero:       u32,
+	_begin_zero:       c.uint32_t,
 	temp_allocator:    Allocator_Opts, // < Allocator used during evaluation
 	result_allocator:  Allocator_Opts, // < Allocator used for the final scene
-	evaluate_skinning: bool,           // < Evaluate skinning (see ufbx_mesh.skinned_vertices)
-	evaluate_caches:   bool,           // < Evaluate vertex caches (see ufbx_mesh.skinned_vertices)
+	evaluate_skinning: c.bool,         // < Evaluate skinning (see ufbx_mesh.skinned_vertices)
+	evaluate_caches:   c.bool,         // < Evaluate vertex caches (see ufbx_mesh.skinned_vertices)
 
 	// Evaluation flags.
 	// See `ufbx_evaluate_flags` for information.
-	evaluate_flags: u32,
+	evaluate_flags: c.uint32_t,
 
 	// WARNING: Potentially unsafe! Try to open external files such as geometry caches
-	load_external_files: bool,
+	load_external_files: c.bool,
 
 	// External file callbacks (defaults to stdio.h)
 	open_file_cb: Open_File_Cb,
-	_end_zero:         u32,
+	_end_zero:         c.uint32_t,
 }
 
 Const_Uint32_List :: struct {
-	data:  ^u32,
-	count: uint,
+	data:  ^c.uint32_t,
+	count: c.size_t,
 }
 
 Const_Real_List :: struct {
 	data:  ^Real,
-	count: uint,
+	count: c.size_t,
 }
 
 Prop_Override_Desc :: struct {
 	// Element (`ufbx_element.element_id`) to override the property from
-	element_id: u32,
+	element_id: c.uint32_t,
 
 	// Property name to override.
 	prop_name: String,
@@ -4897,21 +4897,21 @@ Prop_Override_Desc :: struct {
 	// from `value.x` if zero so keep `value` zeroed even if you don't need it!
 	value: Vec4,
 	value_str: String,
-	value_int: i64,
+	value_int: c.int64_t,
 }
 
 Const_Prop_Override_Desc_List :: struct {
 	data:  ^Prop_Override_Desc,
-	count: uint,
+	count: c.size_t,
 }
 
 Const_Transform_Override_List :: struct {
 	data:  ^Transform_Override,
-	count: uint,
+	count: c.size_t,
 }
 
 Anim_Opts :: struct {
-	_begin_zero:      u32,
+	_begin_zero:      c.uint32_t,
 
 	// Animation layers indices.
 	// Corresponding to `ufbx_scene.anim_layers[]`, aka `ufbx_anim_layer.typed_id`.
@@ -4929,9 +4929,9 @@ Anim_Opts :: struct {
 	transform_overrides: Const_Transform_Override_List,
 
 	// Ignore connected properties
-	ignore_connections: bool,
+	ignore_connections: c.bool,
 	result_allocator: Allocator_Opts, // < Allocator used to create the `ufbx_anim`
-	_end_zero:        u32,
+	_end_zero:        c.uint32_t,
 }
 
 // Specifies how to handle stepped tangents.
@@ -4963,7 +4963,7 @@ Bake_Step_Handling :: enum c.int {
 BAKE_STEP_HANDLING_COUNT :: 5
 
 Bake_Opts :: struct {
-	_begin_zero:      u32,
+	_begin_zero:      c.uint32_t,
 	temp_allocator:   Allocator_Opts, // < Allocator used during loading
 	result_allocator: Allocator_Opts, // < Allocator used for the final baked animation
 
@@ -4972,88 +4972,88 @@ Bake_Opts :: struct {
 	// [0, 30] in the baked animation.
 	// NOTE: This is in general not equivalent to subtracting `ufbx_anim.time_begin`
 	// from each keyframe, as this trimming is done exactly using internal FBX ticks.
-	trim_start_time: bool,
+	trim_start_time: c.bool,
 
 	// Samples per second to use for resampling non-linear animation.
 	// Default: 30
-	resample_rate: f64,
+	resample_rate: c.double,
 
 	// Minimum sample rate to not resample.
 	// Many exporters resample animation by default. To avoid double-resampling
 	// keyframe rates higher or equal to this will not be resampled.
 	// Default: 19.5
-	minimum_sample_rate: f64,
+	minimum_sample_rate: c.double,
 
 	// Maximum sample rate to use, this will remove keys if they are too close together.
 	// Default: unlimited
-	maximum_sample_rate: f64,
+	maximum_sample_rate: c.double,
 
 	// Bake the raw versions of properties related to transforms.
-	bake_transform_props: bool,
+	bake_transform_props: c.bool,
 
 	// Do not bake node transforms.
-	skip_node_transforms: bool,
+	skip_node_transforms: c.bool,
 
 	// Do not resample linear rotation keyframes.
 	// FBX interpolates rotation in Euler angles, so this might cause incorrect interpolation.
-	no_resample_rotation: bool,
+	no_resample_rotation: c.bool,
 
 	// Ignore layer weight animation.
-	ignore_layer_weight_animation: bool,
+	ignore_layer_weight_animation: c.bool,
 
 	// Maximum number of segments to generate from one keyframe.
 	// Default: 32
-	max_keyframe_segments: uint,
+	max_keyframe_segments: c.size_t,
 
 	// How to handle stepped tangents.
 	step_handling: Bake_Step_Handling,
 
 	// Interpolation duration used by `UFBX_BAKE_STEP_HANDLING_CUSTOM_DURATION`.
-	step_custom_duration: f64,
+	step_custom_duration: c.double,
 
 	// Interpolation epsilon used by `UFBX_BAKE_STEP_HANDLING_CUSTOM_DURATION`.
 	// Defined as the minimum fractional decrease/increase in key time, ie.
 	// `time / (1.0 + step_custom_epsilon)` and `time * (1.0 + step_custom_epsilon)`.
-	step_custom_epsilon: f64,
+	step_custom_epsilon: c.double,
 
 	// Flags passed to animation evaluation functions.
 	// See `ufbx_evaluate_flags`.
-	evaluate_flags: u32,
+	evaluate_flags: c.uint32_t,
 
 	// Enable key reduction.
-	key_reduction_enabled: bool,
+	key_reduction_enabled: c.bool,
 
 	// Enable key reduction for non-constant rotations.
 	// Assumes rotations will be interpolated using a spherical linear interpolation at runtime.
-	key_reduction_rotation: bool,
+	key_reduction_rotation: c.bool,
 
 	// Threshold for reducing keys for linear segments.
 	// Default `0.000001`, use negative to disable.
-	key_reduction_threshold: f64,
+	key_reduction_threshold: c.double,
 
 	// Maximum passes over the keys to reduce.
 	// Every pass can potentially halve the the amount of keys.
 	// Default: `4`
-	key_reduction_passes: uint,
-	_end_zero:        u32,
+	key_reduction_passes: c.size_t,
+	_end_zero:        c.uint32_t,
 }
 
 // Options for `ufbx_tessellate_nurbs_curve()`
 // NOTE: Initialize to zero with `{ 0 }` (C) or `{ }` (C++)
 Tessellate_Curve_Opts :: struct {
-	_begin_zero:      u32,
+	_begin_zero:      c.uint32_t,
 	temp_allocator:   Allocator_Opts, // < Allocator used during tessellation
 	result_allocator: Allocator_Opts, // < Allocator used for the final line curve
 
 	// How many segments tessellate each span in `ufbx_nurbs_basis.spans`.
-	span_subdivision: uint,
-	_end_zero:        u32,
+	span_subdivision: c.size_t,
+	_end_zero:        c.uint32_t,
 }
 
 // Options for `ufbx_tessellate_nurbs_surface()`
 // NOTE: Initialize to zero with `{ 0 }` (C) or `{ }` (C++)
 Tessellate_Surface_Opts :: struct {
-	_begin_zero:        u32,
+	_begin_zero:        c.uint32_t,
 	temp_allocator:     Allocator_Opts, // < Allocator used during tessellation
 	result_allocator:   Allocator_Opts, // < Allocator used for the final mesh
 
@@ -5062,56 +5062,56 @@ Tessellate_Surface_Opts :: struct {
 	// would make it easy to create an FBX file with an absurdly high subdivision
 	// rate (similar to mesh subdivision). Please enforce copy the value yourself
 	// enforcing whatever limits you deem reasonable.
-	span_subdivision_u: uint,
-	span_subdivision_v: uint,
+	span_subdivision_u: c.size_t,
+	span_subdivision_v: c.size_t,
 
 	// Skip computing `ufbx_mesh.material_parts[]`
-	skip_mesh_parts: bool,
-	_end_zero:          u32,
+	skip_mesh_parts: c.bool,
+	_end_zero:          c.uint32_t,
 }
 
 // Options for `ufbx_subdivide_mesh()`
 // NOTE: Initialize to zero with `{ 0 }` (C) or `{ }` (C++)
 Subdivide_Opts :: struct {
-	_begin_zero:      u32,
+	_begin_zero:      c.uint32_t,
 	temp_allocator:   Allocator_Opts, // < Allocator used during subdivision
 	result_allocator: Allocator_Opts, // < Allocator used for the final mesh
 	boundary:         Subdivision_Boundary,
 	uv_boundary:      Subdivision_Boundary,
 
 	// Do not generate normals
-	ignore_normals: bool,
+	ignore_normals: c.bool,
 
 	// Interpolate existing normals using the subdivision rules
 	// instead of generating new normals
-	interpolate_normals: bool,
+	interpolate_normals: c.bool,
 
 	// Subdivide also tangent attributes
-	interpolate_tangents: bool,
+	interpolate_tangents: c.bool,
 
 	// Map subdivided vertices into weighted original vertices.
 	// NOTE: May be O(n^2) if `max_source_vertices` is not specified!
-	evaluate_source_vertices: bool,
+	evaluate_source_vertices: c.bool,
 
 	// Limit source vertices per subdivided vertex.
-	max_source_vertices: uint,
+	max_source_vertices: c.size_t,
 
 	// Calculate bone influences over subdivided vertices (if applicable).
 	// NOTE: May be O(n^2) if `max_skin_weights` is not specified!
-	evaluate_skin_weights: bool,
+	evaluate_skin_weights: c.bool,
 
 	// Limit bone influences per subdivided vertex.
-	max_skin_weights: uint,
+	max_skin_weights: c.size_t,
 
 	// Index of the skin deformer to use for `evaluate_skin_weights`.
-	skin_deformer_index: uint,
-	_end_zero:        u32,
+	skin_deformer_index: c.size_t,
+	_end_zero:        c.uint32_t,
 }
 
 // Options for `ufbx_load_geometry_cache()`
 // NOTE: Initialize to zero with `{ 0 }` (C) or `{ }` (C++)
 Geometry_Cache_Opts :: struct {
-	_begin_zero:      u32,
+	_begin_zero:      c.uint32_t,
 	temp_allocator:   Allocator_Opts, // < Allocator used during loading
 	result_allocator: Allocator_Opts, // < Allocator used for the final scene
 
@@ -5119,39 +5119,39 @@ Geometry_Cache_Opts :: struct {
 	open_file_cb: Open_File_Cb,
 
 	// FPS value for converting frame times to seconds
-	frames_per_second: f64,
+	frames_per_second: c.double,
 
 	// Axis to mirror the geometry by.
 	mirror_axis: Mirror_Axis,
 
 	// Enable scaling `scale_factor` all geometry by.
-	use_scale_factor: bool,
+	use_scale_factor: c.bool,
 
 	// Factor to scale the geometry by.
 	scale_factor: Real,
-	_end_zero:        u32,
+	_end_zero:        c.uint32_t,
 }
 
 // Options for `ufbx_read_geometry_cache_TYPE()`
 // NOTE: Initialize to zero with `{ 0 }` (C) or `{ }` (C++)
 Geometry_Cache_Data_Opts :: struct {
-	_begin_zero: u32,
+	_begin_zero: c.uint32_t,
 
 	// External file callbacks (defaults to stdio.h)
 	open_file_cb: Open_File_Cb,
-	additive:    bool,
-	use_weight:  bool,
+	additive:    c.bool,
+	use_weight:  c.bool,
 	weight:      Real,
 
 	// Ignore scene transform.
-	ignore_transform: bool,
-	_end_zero:   u32,
+	ignore_transform: c.bool,
+	_end_zero:   c.uint32_t,
 }
 
 Panic :: struct {
-	did_panic:      bool,
-	message_length: uint,
-	message:        [128]u8,
+	did_panic:      c.bool,
+	message_length: c.size_t,
+	message:        [128]c.char,
 }
 
 // Flags to control `ufbx_evaluate_transform_flags()`.
@@ -5261,14 +5261,14 @@ foreign lib {
 	//   ufbx_subdivide_mesh()
 	//   ufbx_tessellate_nurbs_surface()
 	//   ufbx_free_mesh()
-	is_thread_safe :: proc() -> bool ---
+	is_thread_safe :: proc() -> c.bool ---
 
 	// Load a scene from a `size` byte memory buffer at `data`
-	load_memory :: proc(data: rawptr, data_size: uint, opts: ^Load_Opts, error: ^Error) -> ^Scene ---
+	load_memory :: proc(data: rawptr, data_size: c.size_t, opts: ^Load_Opts, error: ^Error) -> ^Scene ---
 
 	// Load a scene by opening a file named `filename`
 	load_file     :: proc(filename: cstring, opts: ^Load_Opts, error: ^Error) -> ^Scene ---
-	load_file_len :: proc(filename: cstring, filename_len: uint, opts: ^Load_Opts, error: ^Error) -> ^Scene ---
+	load_file_len :: proc(filename: cstring, filename_len: c.size_t, opts: ^Load_Opts, error: ^Error) -> ^Scene ---
 
 	// Load a scene by reading from an `FILE *file` stream
 	// NOTE: `file` is passed as a `void` pointer to avoid including <stdio.h>
@@ -5276,13 +5276,13 @@ foreign lib {
 
 	// Load a scene by reading from an `FILE *file` stream with a prefix
 	// NOTE: `file` is passed as a `void` pointer to avoid including <stdio.h>
-	load_stdio_prefix :: proc(file: rawptr, prefix: rawptr, prefix_size: uint, opts: ^Load_Opts, error: ^Error) -> ^Scene ---
+	load_stdio_prefix :: proc(file: rawptr, prefix: rawptr, prefix_size: c.size_t, opts: ^Load_Opts, error: ^Error) -> ^Scene ---
 
 	// Load a scene from a user-specified stream
 	load_stream :: proc(stream: ^Stream, opts: ^Load_Opts, error: ^Error) -> ^Scene ---
 
 	// Load a scene from a user-specified stream with a prefix
-	load_stream_prefix :: proc(stream: ^Stream, prefix: rawptr, prefix_size: uint, opts: ^Load_Opts, error: ^Error) -> ^Scene ---
+	load_stream_prefix :: proc(stream: ^Stream, prefix: rawptr, prefix_size: c.size_t, opts: ^Load_Opts, error: ^Error) -> ^Scene ---
 
 	// Free a previously loaded or evaluated scene
 	free_scene :: proc(scene: ^Scene) ---
@@ -5293,60 +5293,60 @@ foreign lib {
 	// Format a textual description of `error`.
 	// Always produces a NULL-terminated string to `char dst[dst_size]`, truncating if
 	// necessary. Returns the number of characters written not including the NULL terminator.
-	format_error :: proc(dst: cstring, dst_size: uint, error: ^Error) -> uint ---
+	format_error :: proc(dst: cstring, dst_size: c.size_t, error: ^Error) -> c.size_t ---
 
 	// Find a property `name` from `props`, returns `NULL` if not found.
 	// Searches through `ufbx_props.defaults` as well.
-	find_prop_len :: proc(props: ^Props, name: cstring, name_len: uint) -> ^Prop ---
+	find_prop_len :: proc(props: ^Props, name: cstring, name_len: c.size_t) -> ^Prop ---
 	find_prop     :: proc(props: ^Props, name: cstring) -> ^Prop ---
 
 	// Utility functions for finding the value of a property, returns `def` if not found.
 	// NOTE: For `ufbx_string` you need to ensure the lifetime of the default is
 	// sufficient as no copy is made.
-	find_real_len   :: proc(props: ^Props, name: cstring, name_len: uint, def: Real) -> Real ---
+	find_real_len   :: proc(props: ^Props, name: cstring, name_len: c.size_t, def: Real) -> Real ---
 	find_real       :: proc(props: ^Props, name: cstring, def: Real) -> Real ---
-	find_vec3_len   :: proc(props: ^Props, name: cstring, name_len: uint, def: Vec3) -> Vec3 ---
+	find_vec3_len   :: proc(props: ^Props, name: cstring, name_len: c.size_t, def: Vec3) -> Vec3 ---
 	find_vec3       :: proc(props: ^Props, name: cstring, def: Vec3) -> Vec3 ---
-	find_int_len    :: proc(props: ^Props, name: cstring, name_len: uint, def: i64) -> i64 ---
-	find_int        :: proc(props: ^Props, name: cstring, def: i64) -> i64 ---
-	find_bool_len   :: proc(props: ^Props, name: cstring, name_len: uint, def: bool) -> bool ---
-	find_bool       :: proc(props: ^Props, name: cstring, def: bool) -> bool ---
-	find_string_len :: proc(props: ^Props, name: cstring, name_len: uint, def: String) -> String ---
+	find_int_len    :: proc(props: ^Props, name: cstring, name_len: c.size_t, def: c.int64_t) -> c.int64_t ---
+	find_int        :: proc(props: ^Props, name: cstring, def: c.int64_t) -> c.int64_t ---
+	find_bool_len   :: proc(props: ^Props, name: cstring, name_len: c.size_t, def: c.bool) -> c.bool ---
+	find_bool       :: proc(props: ^Props, name: cstring, def: c.bool) -> c.bool ---
+	find_string_len :: proc(props: ^Props, name: cstring, name_len: c.size_t, def: String) -> String ---
 	find_string     :: proc(props: ^Props, name: cstring, def: String) -> String ---
-	find_blob_len   :: proc(props: ^Props, name: cstring, name_len: uint, def: Blob) -> Blob ---
+	find_blob_len   :: proc(props: ^Props, name: cstring, name_len: c.size_t, def: Blob) -> Blob ---
 	find_blob       :: proc(props: ^Props, name: cstring, def: Blob) -> Blob ---
 
 	// Find property in `props` with concatenated `parts[num_parts]`.
-	find_prop_concat :: proc(props: ^Props, parts: ^String, num_parts: uint) -> ^Prop ---
+	find_prop_concat :: proc(props: ^Props, parts: ^String, num_parts: c.size_t) -> ^Prop ---
 
 	// Get an element connected to a property.
 	get_prop_element :: proc(element: ^Element, prop: ^Prop, type: Element_Type) -> ^Element ---
 
 	// Find an element connected to a property by name.
-	find_prop_element_len :: proc(element: ^Element, name: cstring, name_len: uint, type: Element_Type) -> ^Element ---
+	find_prop_element_len :: proc(element: ^Element, name: cstring, name_len: c.size_t, type: Element_Type) -> ^Element ---
 	find_prop_element     :: proc(element: ^Element, name: cstring, type: Element_Type) -> ^Element ---
 
 	// Find any element of type `type` in `scene` by `name`.
 	// For example if you want to find `ufbx_material` named `Mat`:
 	//   (ufbx_material*)ufbx_find_element(scene, UFBX_ELEMENT_MATERIAL, "Mat");
-	find_element_len :: proc(scene: ^Scene, type: Element_Type, name: cstring, name_len: uint) -> ^Element ---
+	find_element_len :: proc(scene: ^Scene, type: Element_Type, name: cstring, name_len: c.size_t) -> ^Element ---
 	find_element     :: proc(scene: ^Scene, type: Element_Type, name: cstring) -> ^Element ---
 
 	// Find node in `scene` by `name` (shorthand for `ufbx_find_element(UFBX_ELEMENT_NODE)`).
-	find_node_len :: proc(scene: ^Scene, name: cstring, name_len: uint) -> ^Node ---
+	find_node_len :: proc(scene: ^Scene, name: cstring, name_len: c.size_t) -> ^Node ---
 	find_node     :: proc(scene: ^Scene, name: cstring) -> ^Node ---
 
 	// Find an animation stack in `scene` by `name` (shorthand for `ufbx_find_element(UFBX_ELEMENT_ANIM_STACK)`)
-	find_anim_stack_len :: proc(scene: ^Scene, name: cstring, name_len: uint) -> ^Anim_Stack ---
+	find_anim_stack_len :: proc(scene: ^Scene, name: cstring, name_len: c.size_t) -> ^Anim_Stack ---
 	find_anim_stack     :: proc(scene: ^Scene, name: cstring) -> ^Anim_Stack ---
 
 	// Find a material in `scene` by `name` (shorthand for `ufbx_find_element(UFBX_ELEMENT_MATERIAL)`).
-	find_material_len :: proc(scene: ^Scene, name: cstring, name_len: uint) -> ^Material ---
+	find_material_len :: proc(scene: ^Scene, name: cstring, name_len: c.size_t) -> ^Material ---
 	find_material     :: proc(scene: ^Scene, name: cstring) -> ^Material ---
 
 	// Find a single animated property `prop` of `element` in `layer`.
 	// Returns `NULL` if not found.
-	find_anim_prop_len :: proc(layer: ^Anim_Layer, element: ^Element, prop: cstring, prop_len: uint) -> ^Anim_Prop ---
+	find_anim_prop_len :: proc(layer: ^Anim_Layer, element: ^Element, prop: cstring, prop_len: c.size_t) -> ^Anim_Prop ---
 	find_anim_prop     :: proc(layer: ^Anim_Layer, element: ^Element, prop: cstring) -> ^Anim_Prop ---
 
 	// Find all animated properties of `element` in `layer`.
@@ -5362,55 +5362,55 @@ foreign lib {
 	// Returns the decompressed size or a negative error code (see source for details).
 	// NOTE: You must supply a valid `retain` with `ufbx_inflate_retain.initialized == false`
 	// but the rest can be uninitialized.
-	inflate :: proc(dst: rawptr, dst_size: uint, input: ^Inflate_Input, retain: ^Inflate_Retain) -> int ---
+	inflate :: proc(dst: rawptr, dst_size: c.size_t, input: ^Inflate_Input, retain: ^Inflate_Retain) -> c.ptrdiff_t ---
 
 	// Same as `ufbx_open_file()` but compatible with the callback in `ufbx_open_file_fn`.
 	// The `user` parameter is actually not used here.
-	default_open_file :: proc(user: rawptr, stream: ^Stream, path: cstring, path_len: uint, info: ^Open_File_Info) -> bool ---
+	default_open_file :: proc(user: rawptr, stream: ^Stream, path: cstring, path_len: c.size_t, info: ^Open_File_Info) -> c.bool ---
 
 	// Open a `ufbx_stream` from a file.
 	// Use `path_len == SIZE_MAX` for NULL terminated string.
-	open_file     :: proc(stream: ^Stream, path: cstring, path_len: uint, opts: ^Open_File_Opts, error: ^Error) -> bool ---
-	open_file_ctx :: proc(stream: ^Stream, ctx: Open_File_Context, path: cstring, path_len: uint, opts: ^Open_File_Opts, error: ^Error) -> bool ---
+	open_file     :: proc(stream: ^Stream, path: cstring, path_len: c.size_t, opts: ^Open_File_Opts, error: ^Error) -> c.bool ---
+	open_file_ctx :: proc(stream: ^Stream, ctx: Open_File_Context, path: cstring, path_len: c.size_t, opts: ^Open_File_Opts, error: ^Error) -> c.bool ---
 
 	// NOTE: Uses the default ufbx allocator!
-	open_memory     :: proc(stream: ^Stream, data: rawptr, data_size: uint, opts: ^Open_Memory_Opts, error: ^Error) -> bool ---
-	open_memory_ctx :: proc(stream: ^Stream, ctx: Open_File_Context, data: rawptr, data_size: uint, opts: ^Open_Memory_Opts, error: ^Error) -> bool ---
+	open_memory     :: proc(stream: ^Stream, data: rawptr, data_size: c.size_t, opts: ^Open_Memory_Opts, error: ^Error) -> c.bool ---
+	open_memory_ctx :: proc(stream: ^Stream, ctx: Open_File_Context, data: rawptr, data_size: c.size_t, opts: ^Open_Memory_Opts, error: ^Error) -> c.bool ---
 
 	// Evaluate a single animation `curve` at a `time`.
 	// Returns `default_value` only if `curve == NULL` or it has no keyframes.
-	evaluate_curve       :: proc(curve: ^Anim_Curve, time: f64, default_value: Real) -> Real ---
-	evaluate_curve_flags :: proc(curve: ^Anim_Curve, time: f64, default_value: Real, flags: u32) -> Real ---
+	evaluate_curve       :: proc(curve: ^Anim_Curve, time: c.double, default_value: Real) -> Real ---
+	evaluate_curve_flags :: proc(curve: ^Anim_Curve, time: c.double, default_value: Real, flags: c.uint32_t) -> Real ---
 
 	// Evaluate a value from bundled animation curves.
-	evaluate_anim_value_real       :: proc(anim_value: ^Anim_Value, time: f64) -> Real ---
-	evaluate_anim_value_vec3       :: proc(anim_value: ^Anim_Value, time: f64) -> Vec3 ---
-	evaluate_anim_value_real_flags :: proc(anim_value: ^Anim_Value, time: f64, flags: u32) -> Real ---
-	evaluate_anim_value_vec3_flags :: proc(anim_value: ^Anim_Value, time: f64, flags: u32) -> Vec3 ---
+	evaluate_anim_value_real       :: proc(anim_value: ^Anim_Value, time: c.double) -> Real ---
+	evaluate_anim_value_vec3       :: proc(anim_value: ^Anim_Value, time: c.double) -> Vec3 ---
+	evaluate_anim_value_real_flags :: proc(anim_value: ^Anim_Value, time: c.double, flags: c.uint32_t) -> Real ---
+	evaluate_anim_value_vec3_flags :: proc(anim_value: ^Anim_Value, time: c.double, flags: c.uint32_t) -> Vec3 ---
 
 	// Evaluate an animated property `name` from `element` at `time`.
 	// NOTE: If the property is not found it will have the flag `UFBX_PROP_FLAG_NOT_FOUND`.
-	evaluate_prop_len       :: proc(anim: ^Anim, element: ^Element, name: cstring, name_len: uint, time: f64) -> Prop ---
-	evaluate_prop           :: proc(anim: ^Anim, element: ^Element, name: cstring, time: f64) -> Prop ---
-	evaluate_prop_len_flags :: proc(anim: ^Anim, element: ^Element, name: cstring, name_len: uint, time: f64, flags: u32) -> Prop ---
-	evaluate_prop_flags     :: proc(anim: ^Anim, element: ^Element, name: cstring, time: f64, flags: u32) -> Prop ---
+	evaluate_prop_len       :: proc(anim: ^Anim, element: ^Element, name: cstring, name_len: c.size_t, time: c.double) -> Prop ---
+	evaluate_prop           :: proc(anim: ^Anim, element: ^Element, name: cstring, time: c.double) -> Prop ---
+	evaluate_prop_len_flags :: proc(anim: ^Anim, element: ^Element, name: cstring, name_len: c.size_t, time: c.double, flags: c.uint32_t) -> Prop ---
+	evaluate_prop_flags     :: proc(anim: ^Anim, element: ^Element, name: cstring, time: c.double, flags: c.uint32_t) -> Prop ---
 
 	// Evaluate all _animated_ properties of `element`.
 	// HINT: This function returns an `ufbx_props` structure with the original properties as
 	// `ufbx_props.defaults`. This lets you use `ufbx_find_prop/value()` for the results.
-	evaluate_props       :: proc(anim: ^Anim, element: ^Element, time: f64, buffer: ^Prop, buffer_size: uint) -> Props ---
-	evaluate_props_flags :: proc(anim: ^Anim, element: ^Element, time: f64, buffer: ^Prop, buffer_size: uint, flags: u32) -> Props ---
+	evaluate_props       :: proc(anim: ^Anim, element: ^Element, time: c.double, buffer: ^Prop, buffer_size: c.size_t) -> Props ---
+	evaluate_props_flags :: proc(anim: ^Anim, element: ^Element, time: c.double, buffer: ^Prop, buffer_size: c.size_t, flags: c.uint32_t) -> Props ---
 
 	// Evaluate the animated transform of a node given a time.
 	// The returned transform is the local transform of the node (ie. relative to the parent),
 	// comparable to `ufbx_node.local_transform`.
-	evaluate_transform       :: proc(anim: ^Anim, node: ^Node, time: f64) -> Transform ---
-	evaluate_transform_flags :: proc(anim: ^Anim, node: ^Node, time: f64, flags: u32) -> Transform ---
+	evaluate_transform       :: proc(anim: ^Anim, node: ^Node, time: c.double) -> Transform ---
+	evaluate_transform_flags :: proc(anim: ^Anim, node: ^Node, time: c.double, flags: c.uint32_t) -> Transform ---
 
 	// Evaluate the blend shape weight of a blend channel.
 	// NOTE: Return value uses `1.0` for full weight, instead of `100.0` that the internal property `UFBX_Weight` uses.
-	evaluate_blend_weight       :: proc(anim: ^Anim, channel: ^Blend_Channel, time: f64) -> Real ---
-	evaluate_blend_weight_flags :: proc(anim: ^Anim, channel: ^Blend_Channel, time: f64, flags: u32) -> Real ---
+	evaluate_blend_weight       :: proc(anim: ^Anim, channel: ^Blend_Channel, time: c.double) -> Real ---
+	evaluate_blend_weight_flags :: proc(anim: ^Anim, channel: ^Blend_Channel, time: c.double, flags: c.uint32_t) -> Real ---
 
 	// Evaluate the whole `scene` at a specific `time` in the animation `anim`.
 	// The returned scene behaves as if it had been exported at a specific time
@@ -5419,7 +5419,7 @@ foreign lib {
 	//
 	// NOTE: The returned scene refers to the original `scene` so the original
 	// scene cannot be freed until all evaluated scenes are freed.
-	evaluate_scene :: proc(scene: ^Scene, anim: ^Anim, time: f64, opts: ^Evaluate_Opts, error: ^Error) -> ^Scene ---
+	evaluate_scene :: proc(scene: ^Scene, anim: ^Anim, time: c.double, opts: ^Evaluate_Opts, error: ^Error) -> ^Scene ---
 
 	// Create a custom animation descriptor.
 	// `ufbx_anim_opts` is used to specify animation layers and weights.
@@ -5438,43 +5438,43 @@ foreign lib {
 	bake_anim                        :: proc(scene: ^Scene, anim: ^Anim, opts: ^Bake_Opts, error: ^Error) -> ^Baked_Anim ---
 	retain_baked_anim                :: proc(bake: ^Baked_Anim) ---
 	free_baked_anim                  :: proc(bake: ^Baked_Anim) ---
-	find_baked_node_by_typed_id      :: proc(bake: ^Baked_Anim, typed_id: u32) -> ^Baked_Node ---
+	find_baked_node_by_typed_id      :: proc(bake: ^Baked_Anim, typed_id: c.uint32_t) -> ^Baked_Node ---
 	find_baked_node                  :: proc(bake: ^Baked_Anim, node: ^Node) -> ^Baked_Node ---
-	find_baked_element_by_element_id :: proc(bake: ^Baked_Anim, element_id: u32) -> ^Baked_Element ---
+	find_baked_element_by_element_id :: proc(bake: ^Baked_Anim, element_id: c.uint32_t) -> ^Baked_Element ---
 	find_baked_element               :: proc(bake: ^Baked_Anim, element: ^Element) -> ^Baked_Element ---
 
 	// Evaluate baked animation `keyframes` at `time`.
 	// Internally linearly interpolates between two adjacent keyframes.
 	// Handles stepped tangents cleanly, which is not strictly necessary for custom interpolation.
-	evaluate_baked_vec3 :: proc(keyframes: Baked_Vec3_List, time: f64) -> Vec3 ---
+	evaluate_baked_vec3 :: proc(keyframes: Baked_Vec3_List, time: c.double) -> Vec3 ---
 
 	// Evaluate baked animation `keyframes` at `time`.
 	// Internally spherically interpolates (`ufbx_quat_slerp()`) between two adjacent keyframes.
 	// Handles stepped tangents cleanly, which is not strictly necessary for custom interpolation.
-	evaluate_baked_quat :: proc(keyframes: Baked_Quat_List, time: f64) -> Quat ---
+	evaluate_baked_quat :: proc(keyframes: Baked_Quat_List, time: c.double) -> Quat ---
 
 	// Retrieve the bone pose for `node`.
 	// Returns `NULL` if the pose does not contain `node`.
 	get_bone_pose :: proc(pose: ^Pose, node: ^Node) -> ^Bone_Pose ---
 
 	// Find a texture for a given material FBX property.
-	find_prop_texture_len :: proc(material: ^Material, name: cstring, name_len: uint) -> ^Texture ---
+	find_prop_texture_len :: proc(material: ^Material, name: cstring, name_len: c.size_t) -> ^Texture ---
 	find_prop_texture     :: proc(material: ^Material, name: cstring) -> ^Texture ---
 
 	// Find a texture for a given shader property.
-	find_shader_prop_len :: proc(shader: ^Shader, name: cstring, name_len: uint) -> String ---
+	find_shader_prop_len :: proc(shader: ^Shader, name: cstring, name_len: c.size_t) -> String ---
 	find_shader_prop     :: proc(shader: ^Shader, name: cstring) -> String ---
 
 	// Map from a shader property to material property.
-	find_shader_prop_bindings_len :: proc(shader: ^Shader, name: cstring, name_len: uint) -> Shader_Prop_Binding_List ---
+	find_shader_prop_bindings_len :: proc(shader: ^Shader, name: cstring, name_len: c.size_t) -> Shader_Prop_Binding_List ---
 	find_shader_prop_bindings     :: proc(shader: ^Shader, name: cstring) -> Shader_Prop_Binding_List ---
 
 	// Find an input in a shader texture.
-	find_shader_texture_input_len :: proc(shader: ^Shader_Texture, name: cstring, name_len: uint) -> ^Shader_Texture_Input ---
+	find_shader_texture_input_len :: proc(shader: ^Shader_Texture, name: cstring, name_len: c.size_t) -> ^Shader_Texture_Input ---
 	find_shader_texture_input     :: proc(shader: ^Shader_Texture, name: cstring) -> ^Shader_Texture_Input ---
 
 	// Returns `true` if `axes` forms a valid coordinate space.
-	coordinate_axes_valid :: proc(axes: Coordinate_Axes) -> bool ---
+	coordinate_axes_valid :: proc(axes: Coordinate_Axes) -> c.bool ---
 
 	// Vector math utility functions.
 	vec3_normalize :: proc(v: Vec3) -> Vec3 ---
@@ -5510,30 +5510,30 @@ foreign lib {
 
 	// Get a matrix representing the deformation for a single vertex.
 	// Returns `fallback` if the vertex is not skinned.
-	catch_get_skin_vertex_matrix :: proc(panic: ^Panic, skin: ^Skin_Deformer, vertex: uint, fallback: ^Matrix) -> Matrix ---
-	get_skin_vertex_matrix       :: proc(skin: ^Skin_Deformer, vertex: uint, fallback: ^Matrix) -> Matrix ---
+	catch_get_skin_vertex_matrix :: proc(panic: ^Panic, skin: ^Skin_Deformer, vertex: c.size_t, fallback: ^Matrix) -> Matrix ---
+	get_skin_vertex_matrix       :: proc(skin: ^Skin_Deformer, vertex: c.size_t, fallback: ^Matrix) -> Matrix ---
 
 	// Resolve the index into `ufbx_blend_shape.position_offsets[]` given a vertex.
 	// Returns `UFBX_NO_INDEX` if the vertex is not included in the blend shape.
-	get_blend_shape_offset_index :: proc(shape: ^Blend_Shape, vertex: uint) -> u32 ---
+	get_blend_shape_offset_index :: proc(shape: ^Blend_Shape, vertex: c.size_t) -> c.uint32_t ---
 
 	// Get the offset for a given vertex in the blend shape.
 	// Returns `ufbx_zero_vec3` if the vertex is not a included in the blend shape.
-	get_blend_shape_vertex_offset :: proc(shape: ^Blend_Shape, vertex: uint) -> Vec3 ---
+	get_blend_shape_vertex_offset :: proc(shape: ^Blend_Shape, vertex: c.size_t) -> Vec3 ---
 
 	// Get the _current_ blend offset given a blend deformer.
 	// NOTE: This depends on the current animated blend weight of the deformer.
-	get_blend_vertex_offset :: proc(blend: ^Blend_Deformer, vertex: uint) -> Vec3 ---
+	get_blend_vertex_offset :: proc(blend: ^Blend_Deformer, vertex: c.size_t) -> Vec3 ---
 
 	// Apply the blend shape with `weight` to given vertices.
-	add_blend_shape_vertex_offsets :: proc(shape: ^Blend_Shape, vertices: ^Vec3, num_vertices: uint, weight: Real) ---
+	add_blend_shape_vertex_offsets :: proc(shape: ^Blend_Shape, vertices: ^Vec3, num_vertices: c.size_t, weight: Real) ---
 
 	// Apply the blend deformer with `weight` to given vertices.
 	// NOTE: This depends on the current animated blend weight of the deformer.
-	add_blend_vertex_offsets :: proc(blend: ^Blend_Deformer, vertices: ^Vec3, num_vertices: uint, weight: Real) ---
+	add_blend_vertex_offsets :: proc(blend: ^Blend_Deformer, vertices: ^Vec3, num_vertices: c.size_t, weight: Real) ---
 
 	// Low-level utility to evaluate NURBS the basis functions.
-	evaluate_nurbs_basis :: proc(basis: ^Nurbs_Basis, u: Real, weights: ^Real, num_weights: uint, derivatives: ^Real, num_derivatives: uint) -> uint ---
+	evaluate_nurbs_basis :: proc(basis: ^Nurbs_Basis, u: Real, weights: ^Real, num_weights: c.size_t, derivatives: ^Real, num_derivatives: c.size_t) -> c.size_t ---
 
 	// Evaluate a point on a NURBS curve given the parameter `u`.
 	evaluate_nurbs_curve :: proc(curve: ^Nurbs_Curve, u: Real) -> Curve_Point ---
@@ -5555,25 +5555,25 @@ foreign lib {
 
 	// Find the face that contains a given `index`.
 	// Returns `UFBX_NO_INDEX` if out of bounds.
-	find_face_index :: proc(mesh: ^Mesh, index: uint) -> u32 ---
+	find_face_index :: proc(mesh: ^Mesh, index: c.size_t) -> c.uint32_t ---
 
 	// Triangulate a mesh face, returning the number of triangles.
 	// NOTE: You need to space for `(face.num_indices - 2) * 3 - 1` indices!
 	// HINT: Using `ufbx_mesh.max_face_triangles * 3` is always safe.
-	catch_triangulate_face :: proc(panic: ^Panic, indices: ^u32, num_indices: uint, mesh: ^Mesh, face: Face) -> u32 ---
-	triangulate_face       :: proc(indices: ^u32, num_indices: uint, mesh: ^Mesh, face: Face) -> u32 ---
+	catch_triangulate_face :: proc(panic: ^Panic, indices: ^c.uint32_t, num_indices: c.size_t, mesh: ^Mesh, face: Face) -> c.uint32_t ---
+	triangulate_face       :: proc(indices: ^c.uint32_t, num_indices: c.size_t, mesh: ^Mesh, face: Face) -> c.uint32_t ---
 
 	// Generate the half-edge representation of `mesh` to `topo[mesh->num_indices]`
-	catch_compute_topology :: proc(panic: ^Panic, mesh: ^Mesh, topo: ^Topo_Edge, num_topo: uint) ---
-	compute_topology       :: proc(mesh: ^Mesh, topo: ^Topo_Edge, num_topo: uint) ---
+	catch_compute_topology :: proc(panic: ^Panic, mesh: ^Mesh, topo: ^Topo_Edge, num_topo: c.size_t) ---
+	compute_topology       :: proc(mesh: ^Mesh, topo: ^Topo_Edge, num_topo: c.size_t) ---
 
 	// Get the next half-edge in `topo`.
-	catch_topo_next_vertex_edge :: proc(panic: ^Panic, topo: ^Topo_Edge, num_topo: uint, index: u32) -> u32 ---
-	topo_next_vertex_edge       :: proc(topo: ^Topo_Edge, num_topo: uint, index: u32) -> u32 ---
+	catch_topo_next_vertex_edge :: proc(panic: ^Panic, topo: ^Topo_Edge, num_topo: c.size_t, index: c.uint32_t) -> c.uint32_t ---
+	topo_next_vertex_edge       :: proc(topo: ^Topo_Edge, num_topo: c.size_t, index: c.uint32_t) -> c.uint32_t ---
 
 	// Get the previous half-edge in `topo`.
-	catch_topo_prev_vertex_edge :: proc(panic: ^Panic, topo: ^Topo_Edge, num_topo: uint, index: u32) -> u32 ---
-	topo_prev_vertex_edge       :: proc(topo: ^Topo_Edge, num_topo: uint, index: u32) -> u32 ---
+	catch_topo_prev_vertex_edge :: proc(panic: ^Panic, topo: ^Topo_Edge, num_topo: c.size_t, index: c.uint32_t) -> c.uint32_t ---
+	topo_prev_vertex_edge       :: proc(topo: ^Topo_Edge, num_topo: c.size_t, index: c.uint32_t) -> c.uint32_t ---
 
 	// Calculate a normal for a given face.
 	// The returned normal is weighted by face area.
@@ -5582,16 +5582,16 @@ foreign lib {
 
 	// Generate indices for normals from the topology.
 	// Respects smoothing groups.
-	catch_generate_normal_mapping :: proc(panic: ^Panic, mesh: ^Mesh, topo: ^Topo_Edge, num_topo: uint, normal_indices: ^u32, num_normal_indices: uint, assume_smooth: bool) -> uint ---
-	generate_normal_mapping       :: proc(mesh: ^Mesh, topo: ^Topo_Edge, num_topo: uint, normal_indices: ^u32, num_normal_indices: uint, assume_smooth: bool) -> uint ---
+	catch_generate_normal_mapping :: proc(panic: ^Panic, mesh: ^Mesh, topo: ^Topo_Edge, num_topo: c.size_t, normal_indices: ^c.uint32_t, num_normal_indices: c.size_t, assume_smooth: c.bool) -> c.size_t ---
+	generate_normal_mapping       :: proc(mesh: ^Mesh, topo: ^Topo_Edge, num_topo: c.size_t, normal_indices: ^c.uint32_t, num_normal_indices: c.size_t, assume_smooth: c.bool) -> c.size_t ---
 
 	// Compute normals given normal indices.
 	// You can use `ufbx_generate_normal_mapping()` to generate the normal indices.
-	catch_compute_normals :: proc(panic: ^Panic, mesh: ^Mesh, positions: ^Vertex_Vec3, normal_indices: ^u32, num_normal_indices: uint, normals: ^Vec3, num_normals: uint) ---
-	compute_normals       :: proc(mesh: ^Mesh, positions: ^Vertex_Vec3, normal_indices: ^u32, num_normal_indices: uint, normals: ^Vec3, num_normals: uint) ---
+	catch_compute_normals :: proc(panic: ^Panic, mesh: ^Mesh, positions: ^Vertex_Vec3, normal_indices: ^c.uint32_t, num_normal_indices: c.size_t, normals: ^Vec3, num_normals: c.size_t) ---
+	compute_normals       :: proc(mesh: ^Mesh, positions: ^Vertex_Vec3, normal_indices: ^c.uint32_t, num_normal_indices: c.size_t, normals: ^Vec3, num_normals: c.size_t) ---
 
 	// Subdivide a mesh using the Catmull-Clark subdivision `level` times.
-	subdivide_mesh :: proc(mesh: ^Mesh, level: uint, opts: ^Subdivide_Opts, error: ^Error) -> ^Mesh ---
+	subdivide_mesh :: proc(mesh: ^Mesh, level: c.size_t, opts: ^Subdivide_Opts, error: ^Error) -> ^Mesh ---
 
 	// Free a mesh returned from `ufbx_subdivide_mesh()` or `ufbx_tessellate_nurbs_surface()`.
 	free_mesh :: proc(mesh: ^Mesh) ---
@@ -5603,7 +5603,7 @@ foreign lib {
 	// As geometry caches can be massive, this does not actually read the data, but
 	// only seeks through the files to form the metadata.
 	load_geometry_cache     :: proc(filename: cstring, opts: ^Geometry_Cache_Opts, error: ^Error) -> ^Geometry_Cache ---
-	load_geometry_cache_len :: proc(filename: cstring, filename_len: uint, opts: ^Geometry_Cache_Opts, error: ^Error) -> ^Geometry_Cache ---
+	load_geometry_cache_len :: proc(filename: cstring, filename_len: c.size_t, opts: ^Geometry_Cache_Opts, error: ^Error) -> ^Geometry_Cache ---
 
 	// Free a geometry cache returned from `ufbx_load_geometry_cache()`.
 	free_geometry_cache :: proc(cache: ^Geometry_Cache) ---
@@ -5612,25 +5612,25 @@ foreign lib {
 	retain_geometry_cache :: proc(cache: ^Geometry_Cache) ---
 
 	// Read a frame from a geometry cache.
-	read_geometry_cache_real :: proc(frame: ^Cache_Frame, data: ^Real, num_data: uint, opts: ^Geometry_Cache_Data_Opts) -> uint ---
-	read_geometry_cache_vec3 :: proc(frame: ^Cache_Frame, data: ^Vec3, num_data: uint, opts: ^Geometry_Cache_Data_Opts) -> uint ---
+	read_geometry_cache_real :: proc(frame: ^Cache_Frame, data: ^Real, num_data: c.size_t, opts: ^Geometry_Cache_Data_Opts) -> c.size_t ---
+	read_geometry_cache_vec3 :: proc(frame: ^Cache_Frame, data: ^Vec3, num_data: c.size_t, opts: ^Geometry_Cache_Data_Opts) -> c.size_t ---
 
 	// Sample the a geometry cache channel, linearly blending between adjacent frames.
-	sample_geometry_cache_real :: proc(channel: ^Cache_Channel, time: f64, data: ^Real, num_data: uint, opts: ^Geometry_Cache_Data_Opts) -> uint ---
-	sample_geometry_cache_vec3 :: proc(channel: ^Cache_Channel, time: f64, data: ^Vec3, num_data: uint, opts: ^Geometry_Cache_Data_Opts) -> uint ---
+	sample_geometry_cache_real :: proc(channel: ^Cache_Channel, time: c.double, data: ^Real, num_data: c.size_t, opts: ^Geometry_Cache_Data_Opts) -> c.size_t ---
+	sample_geometry_cache_vec3 :: proc(channel: ^Cache_Channel, time: c.double, data: ^Vec3, num_data: c.size_t, opts: ^Geometry_Cache_Data_Opts) -> c.size_t ---
 
 	// Find a DOM node given a name.
-	dom_find_len :: proc(parent: ^Dom_Node, name: cstring, name_len: uint) -> ^Dom_Node ---
+	dom_find_len :: proc(parent: ^Dom_Node, name: cstring, name_len: c.size_t) -> ^Dom_Node ---
 	dom_find     :: proc(parent: ^Dom_Node, name: cstring) -> ^Dom_Node ---
 
 	// Generate an index buffer for a flat vertex buffer.
 	// `streams` specifies one or more vertex data arrays, each stream must contain `num_indices` vertices.
 	// This function compacts the data within `streams` in-place, writing the deduplicated indices to `indices`.
-	generate_indices :: proc(streams: [^]Vertex_Stream, num_streams: uint, indices: ^u32, num_indices: uint, allocator: ^Allocator_Opts, error: ^Error) -> uint ---
+	generate_indices :: proc(streams: [^]Vertex_Stream, num_streams: c.size_t, indices: ^c.uint32_t, num_indices: c.size_t, allocator: ^Allocator_Opts, error: ^Error) -> c.size_t ---
 
 	// Run a single thread pool task.
 	// See `ufbx_thread_pool_run_fn` for more information.
-	thread_pool_run_task :: proc(ctx: Thread_Pool_Context, index: u32) ---
+	thread_pool_run_task :: proc(ctx: Thread_Pool_Context, index: c.uint32_t) ---
 
 	// Get or set an arbitrary user pointer for the thread pool context.
 	// `ufbx_thread_pool_get_user_ptr()` returns `NULL` if unset.
@@ -5638,18 +5638,18 @@ foreign lib {
 	thread_pool_get_user_ptr :: proc(ctx: Thread_Pool_Context) -> rawptr ---
 
 	// Utility functions for reading geometry data for a single index.
-	catch_get_vertex_real :: proc(panic: ^Panic, v: ^Vertex_Real, index: uint) -> Real ---
-	catch_get_vertex_vec2 :: proc(panic: ^Panic, v: ^Vertex_Vec2, index: uint) -> Vec2 ---
-	catch_get_vertex_vec3 :: proc(panic: ^Panic, v: ^Vertex_Vec3, index: uint) -> Vec3 ---
-	catch_get_vertex_vec4 :: proc(panic: ^Panic, v: ^Vertex_Vec4, index: uint) -> Vec4 ---
+	catch_get_vertex_real :: proc(panic: ^Panic, v: ^Vertex_Real, index: c.size_t) -> Real ---
+	catch_get_vertex_vec2 :: proc(panic: ^Panic, v: ^Vertex_Vec2, index: c.size_t) -> Vec2 ---
+	catch_get_vertex_vec3 :: proc(panic: ^Panic, v: ^Vertex_Vec3, index: c.size_t) -> Vec3 ---
+	catch_get_vertex_vec4 :: proc(panic: ^Panic, v: ^Vertex_Vec4, index: c.size_t) -> Vec4 ---
 
 	// Utility functions for reading geometry data for a single index.
-	get_vertex_real         :: proc(v: ^Vertex_Real, index: uint) -> Real ---
-	get_vertex_vec2         :: proc(v: ^Vertex_Vec2, index: uint) -> Vec2 ---
-	get_vertex_vec3         :: proc(v: ^Vertex_Vec3, index: uint) -> Vec3 ---
-	get_vertex_vec4         :: proc(v: ^Vertex_Vec4, index: uint) -> Vec4 ---
-	catch_get_vertex_w_vec3 :: proc(panic: ^Panic, v: ^Vertex_Vec3, index: uint) -> Real ---
-	get_vertex_w_vec3       :: proc(v: ^Vertex_Vec3, index: uint) -> Real ---
+	get_vertex_real         :: proc(v: ^Vertex_Real, index: c.size_t) -> Real ---
+	get_vertex_vec2         :: proc(v: ^Vertex_Vec2, index: c.size_t) -> Vec2 ---
+	get_vertex_vec3         :: proc(v: ^Vertex_Vec3, index: c.size_t) -> Vec3 ---
+	get_vertex_vec4         :: proc(v: ^Vertex_Vec4, index: c.size_t) -> Vec4 ---
+	catch_get_vertex_w_vec3 :: proc(panic: ^Panic, v: ^Vertex_Vec3, index: c.size_t) -> Real ---
+	get_vertex_w_vec3       :: proc(v: ^Vertex_Vec3, index: c.size_t) -> Real ---
 
 	// Functions for converting an untyped `ufbx_element` to a concrete type.
 	// Returns `NULL` if the element is not that type.

--- a/src/bindgen.odin
+++ b/src/bindgen.odin
@@ -1248,39 +1248,40 @@ c_type_mapping := map[string]string {
 	"unsigned long"      = "c.ulong",
 	"unsigned long long" = "c.ulonglong",
 
-	"bool" = "c.bool",
-	"Bool" = "c.bool", // I don't know why this needs to have a capital B, but it does.
-	"BOOL" = "c.bool", // bool is sometimes a macro for BOOL
+	"bool" = "bool",
+	"Bool" = "bool", // I don't know why this needs to have a capital B, but it does.
+	"BOOL" = "bool", // bool is sometimes a macro for BOOL
 
 	"size_t"  = "c.size_t",
 	"ssize_t" = "c.ssize_t",
 	"wchar_t" = "c.wchar_t",
 
-	"float"          = "c.float",
-	"double"         = "c.double",
+	"float"          = "f32",
+	"double"         = "f64",
 	// I think clang changes this to something else so this might not work.
 	// I tried testing it but I couldn't get the complex type working in C.
-	"float complex"  = "c.complex_float",
-	"double complex" = "c.complex_double",
+	"float complex"  = "complex64",
+	"double complex" = "complex128",
 
-	"int8_t"   = "c.int8_t",
-	"uint8_t"  = "c.uint8_t",
-	"int16_t"  = "c.int16_t",
-	"uint16_t" = "c.uint16_t",
-	"int32_t"  = "c.int32_t",
-	"uint32_t" = "c.uint32_t",
-	"int64_t"  = "c.int64_t",
-	"uint64_t" = "c.uint64_t",
+	"int8_t"   = "i8",
+	"uint8_t"  = "u8",
+	"int16_t"  = "i16",
+	"uint16_t" = "u16",
+	"int32_t"  = "i32",
+	"uint32_t" = "u32",
+	"int64_t"  = "i64",
+	"uint64_t" = "u64",
 
-	"int_least8_t"   = "c.int_least8_t",
-	"uint_least8_t"  = "c.uint_least8_t",
-	"int_least16_t"  = "c.int_least16_t",
-	"uint_least16_t" = "c.uint_least16_t",
-	"int_least32_t"  = "c.int_least32_t",
-	"uint_least32_t" = "c.uint_least32_t",
-	"int_least64_t"  = "c.int_least64_t",
-	"uint_least64_t" = "c.uint_least64_t",
+	"int_least8_t"   = "i8",
+	"uint_least8_t"  = "u8",
+	"int_least16_t"  = "i16",
+	"uint_least16_t" = "u16",
+	"int_least32_t"  = "i32",
+	"uint_least32_t" = "u32",
+	"int_least64_t"  = "i64",
+	"uint_least64_t" = "u64",
 	
+	// These type could change base on the platform.
 	"int_fast8_t"   = "c.int_fast8_t",
 	"uint_fast8_t"  = "c.uint_fast8_t",
 	"int_fast16_t"  = "c.int_fast16_t",

--- a/src/bindgen.odin
+++ b/src/bindgen.odin
@@ -1251,6 +1251,7 @@ c_type_mapping := map[string]string {
 	"unsigned long long" = "c.ulonglong",
 
 	"bool" = "c.bool",
+	"Bool" = "c.bool", // I don't know why this needs to have a capital B, but it does.
 	"BOOL" = "c.bool", // bool is sometimes a macro for BOOL
 
 	"size_t"  = "c.size_t",


### PR DESCRIPTION
Struct fields and function return types weren't being checked for if their type was a C/libc/posix type so I added a check for those to make sure the imports are added. Also updated the c type map to include all types included in core:c. 