### PR TITLE
Add link name for functions in rename_types

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ imports_file = ""
 package_name = "my_lib"
 
 // "Old_Name" = "New_Name",
-rename_types = {
+rename = {
 }
 
 // Turns an enum into a bit_set. Converts the values of the enum into
@@ -102,7 +102,7 @@ procedure_type_overrides = {
 	// "GetKeyPressed"        = "KeyboardKey"
 }
 
-// Inject a new type before another type. Use `rename_types` to just rename
+// Inject a new type before another type. Use `rename` to just rename
 // a pre-existing type.
 inject_before = {
 	// "Some_Type" = "New_Type :: distinct int"

--- a/examples/raylib/bindgen.sjson
+++ b/examples/raylib/bindgen.sjson
@@ -10,7 +10,7 @@ package_name = "raylib"
 
 // "Old_Name" = "New_Name"
 // We rename ConfigFlags to ConfigFlag so we can introduce a bit_set with the naem ConfigFlags.
-rename_types = {
+rename = {
 	"ConfigFlags" = "ConfigFlag"
 }
 

--- a/examples/ufbx/bindgen.sjson
+++ b/examples/ufbx/bindgen.sjson
@@ -38,7 +38,7 @@ procedure_type_overrides = {
     "generate_indices.streams" = "[^]"
 }
 
-rename_types = {
+rename = {
     "Prop_Flags" = "Prop_Flag"
     "Transform_Flags" = "Transform_Flag"
     "Baked_Key_Flags" = "Baked_Key_Flag"

--- a/src/bindgen.odin
+++ b/src/bindgen.odin
@@ -1813,19 +1813,19 @@ gen :: proc(input: string, c: Config) {
 				name = strings.to_ada_case(name)
 			}
 
-      d.name = final_name(vet_name(name), s)
-      add_to_set(&s.created_types, d.name)
-    case Function:
-      name := trim_prefix(d.name, s.remove_function_prefix)
+		d.name = final_name(vet_name(name), s)
+		add_to_set(&s.created_types, d.name)
+	case Function:
+		name := trim_prefix(d.name, s.remove_function_prefix)
 
-      if replacement, has_replacement := s.rename[name]; has_replacement {
-        d.link_name = d.name
-        name = replacement
-      }
+		if replacement, has_replacement := s.rename[name]; has_replacement {
+		d.link_name = d.name
+		name = replacement
+		}
 
-      d.name = name
-    case Enum:
-      name := d.name
+		d.name = name
+	case Enum:
+		name := d.name
 
 
 			if typedef, has_typedef := s.typedefs[d.id]; has_typedef {

--- a/src/bindgen.odin
+++ b/src/bindgen.odin
@@ -2554,7 +2554,7 @@ gen :: proc(input: string, c: Config) {
 				append(&formatted_functions, Formatted_Function {
 					function = strings.to_string(b),
 					post_comment = d.post_comment,
-					attributes = attributes
+					attributes = attributes,
 				})
 			}
 


### PR DESCRIPTION
Example:
```c
// test.h
void import();

void test_foreign();
```
```sjson
// bindgen.sjson
inputs = [
  "test.h"
]

remove_function_prefix = "test_"

rename_types = {
  "import" = "my_import"
  "foreign" = "my_foreign"
}
```
```odin
// test.odin
@(default_calling_convention = "c", link_prefix = "test_")
foreign lib {
	@(link_name = "import")
	my_import :: proc() ---
	@(link_name = "test_foreign")
	my_foreign :: proc() ---
}
```