### PR TITLE
Array fixes

### DIFF
--- a/examples/pdfio/bindgen.sjson
+++ b/examples/pdfio/bindgen.sjson
@@ -19,8 +19,8 @@ bit_setify = {
 procedure_type_overrides = {
 	"ArrayAppendBinary.value"    = "[^]"
 	"ArrayGetBinary"             = "[^]"
-	"FileCreateTemporary.buffer" = "[^]"
-	"StreamGetToken.buffer"      = "[^]"
+	"FileCreateTemporary.buffer" = "[^]c.char"
+	"StreamGetToken.buffer"      = "[^]c.char"
 
 	// This is not a complete override list, it's just an example.
 }

--- a/examples/pdfio/pdfio/pdfio.odin
+++ b/examples/pdfio/pdfio/pdfio.odin
@@ -166,7 +166,7 @@ foreign lib {
 	// TODO: Add number, array, string, etc. versions of pdfioFileCreateObject?
 	FileCreatePage      :: proc(pdf: ^file_t, dict: ^dict_t) -> ^stream_t ---
 	FileCreateStringObj :: proc(pdf: ^file_t, s: cstring) -> ^obj_t ---
-	FileCreateTemporary :: proc(buffer: [^]cstring, bufsize: c.size_t, version: cstring, media_box: ^rect_t, crop_box: ^rect_t, error_cb: error_cb_t, error_data: rawptr) -> ^file_t ---
+	FileCreateTemporary :: proc(buffer: [^]c.char, bufsize: c.size_t, version: cstring, media_box: ^rect_t, crop_box: ^rect_t, error_cb: error_cb_t, error_data: rawptr) -> ^file_t ---
 	FileFindObj         :: proc(pdf: ^file_t, number: c.size_t) -> ^obj_t ---
 	FileGetAuthor       :: proc(pdf: ^file_t) -> cstring ---
 	FileGetCatalog      :: proc(pdf: ^file_t) -> ^dict_t ---
@@ -209,7 +209,7 @@ foreign lib {
 	PageOpenStream      :: proc(page: ^obj_t, n: c.size_t, decode: bool) -> ^stream_t ---
 	StreamClose         :: proc(st: ^stream_t) -> bool ---
 	StreamConsume       :: proc(st: ^stream_t, bytes: c.size_t) -> bool ---
-	StreamGetToken      :: proc(st: ^stream_t, buffer: [^]cstring, bufsize: c.size_t) -> bool ---
+	StreamGetToken      :: proc(st: ^stream_t, buffer: [^]c.char, bufsize: c.size_t) -> bool ---
 	StreamPeek          :: proc(st: ^stream_t, buffer: rawptr, bytes: c.size_t) -> c.ssize_t ---
 	StreamPrintf        :: proc(st: ^stream_t, format: cstring, #c_vararg _: ..any) -> bool ---
 	StreamPutChar       :: proc(st: ^stream_t, ch: c.int) -> bool ---

--- a/examples/raylib/raylib/raylib.odin
+++ b/examples/raylib/raylib/raylib.odin
@@ -401,9 +401,9 @@ VrStereoConfig :: struct {
 
 // File path list
 FilePathList :: struct {
-	capacity: c.uint,   // Filepaths max entries
-	count:    c.uint,   // Filepaths entries count
-	paths:    ^^c.char, // Filepaths entries
+	capacity: c.uint,     // Filepaths max entries
+	count:    c.uint,     // Filepaths entries count
+	paths:    [^]cstring, // Filepaths entries
 }
 
 // Automation event
@@ -1341,7 +1341,7 @@ foreign lib {
 	LoadFontFromMemory :: proc(fileType: cstring, fileData: ^c.uchar, dataSize: c.int, fontSize: c.int, codepoints: ^c.int, codepointCount: c.int) -> Font --- // Load font from memory buffer, fileType refers to extension: i.e. '.ttf'
 	IsFontValid        :: proc(font: Font) -> bool ---                                 // Check if a font is valid (font data loaded, WARNING: GPU texture not checked)
 	LoadFontData       :: proc(fileData: ^c.uchar, dataSize: c.int, fontSize: c.int, codepoints: ^c.int, codepointCount: c.int, type: c.int) -> ^GlyphInfo --- // Load font data for further use
-	GenImageFontAtlas  :: proc(glyphs: ^GlyphInfo, glyphRecs: ^^Rectangle, glyphCount: c.int, fontSize: c.int, padding: c.int, packMethod: c.int) -> Image --- // Generate image font atlas using chars info
+	GenImageFontAtlas  :: proc(glyphs: ^GlyphInfo, glyphRecs: [^]^Rectangle, glyphCount: c.int, fontSize: c.int, padding: c.int, packMethod: c.int) -> Image --- // Generate image font atlas using chars info
 	UnloadFontData     :: proc(glyphs: ^GlyphInfo, glyphCount: c.int) ---              // Unload font chars info data (RAM)
 	UnloadFont         :: proc(font: Font) ---                                         // Unload font from GPU memory (VRAM)
 	ExportFontAsCode   :: proc(font: Font, fileName: cstring) -> bool ---              // Export font as code file, returns true on success
@@ -1376,24 +1376,24 @@ foreign lib {
 	// Text strings management functions (no UTF-8 strings, only byte chars)
 	// WARNING 1: Most of these functions use internal static buffers, it's recommended to store returned data on user-side for re-use
 	// WARNING 2: Some strings allocate memory internally for the returned strings, those strings must be free by user using MemFree()
-	TextCopy      :: proc(dst: cstring, src: cstring) -> c.int ---                         // Copy one string to another, returns bytes copied
-	TextIsEqual   :: proc(text1: cstring, text2: cstring) -> bool ---                      // Check if two text string are equal
-	TextLength    :: proc(text: cstring) -> c.uint ---                                     // Get text length, checks for '\0' ending
-	TextFormat    :: proc(text: cstring, #c_vararg _: ..any) -> cstring ---                // Text formatting with variables (sprintf() style)
-	TextSubtext   :: proc(text: cstring, position: c.int, length: c.int) -> cstring ---    // Get a piece of a text string
-	TextReplace   :: proc(text: cstring, replace: cstring, by: cstring) -> cstring ---     // Replace text string (WARNING: memory must be freed!)
-	TextInsert    :: proc(text: cstring, insert: cstring, position: c.int) -> cstring ---  // Insert text in a position (WARNING: memory must be freed!)
-	TextJoin      :: proc(textList: ^^c.char, count: c.int, delimiter: cstring) -> cstring --- // Join text strings with delimiter
-	TextSplit     :: proc(text: cstring, delimiter: c.char, count: ^c.int) -> ^^c.char --- // Split text into multiple strings
-	TextAppend    :: proc(text: cstring, append: cstring, position: ^c.int) ---            // Append text at specific position and move cursor!
-	TextFindIndex :: proc(text: cstring, find: cstring) -> c.int ---                       // Find first text occurrence within a string
-	TextToUpper   :: proc(text: cstring) -> cstring ---                                    // Get upper case version of provided string
-	TextToLower   :: proc(text: cstring) -> cstring ---                                    // Get lower case version of provided string
-	TextToPascal  :: proc(text: cstring) -> cstring ---                                    // Get Pascal case notation version of provided string
-	TextToSnake   :: proc(text: cstring) -> cstring ---                                    // Get Snake case notation version of provided string
-	TextToCamel   :: proc(text: cstring) -> cstring ---                                    // Get Camel case notation version of provided string
-	TextToInteger :: proc(text: cstring) -> c.int ---                                      // Get integer value from text
-	TextToFloat   :: proc(text: cstring) -> f32 ---                                        // Get float value from text
+	TextCopy      :: proc(dst: cstring, src: cstring) -> c.int ---                           // Copy one string to another, returns bytes copied
+	TextIsEqual   :: proc(text1: cstring, text2: cstring) -> bool ---                        // Check if two text string are equal
+	TextLength    :: proc(text: cstring) -> c.uint ---                                       // Get text length, checks for '\0' ending
+	TextFormat    :: proc(text: cstring, #c_vararg _: ..any) -> cstring ---                  // Text formatting with variables (sprintf() style)
+	TextSubtext   :: proc(text: cstring, position: c.int, length: c.int) -> cstring ---      // Get a piece of a text string
+	TextReplace   :: proc(text: cstring, replace: cstring, by: cstring) -> cstring ---       // Replace text string (WARNING: memory must be freed!)
+	TextInsert    :: proc(text: cstring, insert: cstring, position: c.int) -> cstring ---    // Insert text in a position (WARNING: memory must be freed!)
+	TextJoin      :: proc(textList: [^]cstring, count: c.int, delimiter: cstring) -> cstring --- // Join text strings with delimiter
+	TextSplit     :: proc(text: cstring, delimiter: c.char, count: ^c.int) -> [^]cstring --- // Split text into multiple strings
+	TextAppend    :: proc(text: cstring, append: cstring, position: ^c.int) ---              // Append text at specific position and move cursor!
+	TextFindIndex :: proc(text: cstring, find: cstring) -> c.int ---                         // Find first text occurrence within a string
+	TextToUpper   :: proc(text: cstring) -> cstring ---                                      // Get upper case version of provided string
+	TextToLower   :: proc(text: cstring) -> cstring ---                                      // Get lower case version of provided string
+	TextToPascal  :: proc(text: cstring) -> cstring ---                                      // Get Pascal case notation version of provided string
+	TextToSnake   :: proc(text: cstring) -> cstring ---                                      // Get Snake case notation version of provided string
+	TextToCamel   :: proc(text: cstring) -> cstring ---                                      // Get Camel case notation version of provided string
+	TextToInteger :: proc(text: cstring) -> c.int ---                                        // Get integer value from text
+	TextToFloat   :: proc(text: cstring) -> f32 ---                                          // Get float value from text
 
 	// Basic geometric 3D shapes drawing functions
 	DrawLine3D          :: proc(startPos: Vector3, endPos: Vector3, color: Color) ---    // Draw a line in 3D world space

--- a/examples/ufbx/bindgen.sjson
+++ b/examples/ufbx/bindgen.sjson
@@ -26,12 +26,16 @@ clang_defines = {
 }
 
 struct_field_overrides = {
-    "Node_List.data" = "[^]"
     "Face_List.data" = "[^]"
     "Uint32_List.data" = "[^]"
     "Vec2_List.data" = "[^]"
     "Vec3_List.data" = "[^]"
     "Vec4_List.data" = "[^]"
+    "Void_List.data" = "[^]rawptr"
+    "Bool_List.data" = "[^]"
+    "Real_List.data" = "[^]"
+    "String_List.data" = "[^]"
+    "Dom_Value_List.data" = "[^]"
 }
 
 procedure_type_overrides = {

--- a/examples/ufbx/ufbx/ufbx.odin
+++ b/examples/ufbx/ufbx/ufbx.odin
@@ -113,12 +113,12 @@ Matrix :: struct {
 }
 
 Void_List :: struct {
-	data:  rawptr,
+	data:  [^]rawptr,
 	count: c.size_t,
 }
 
 Bool_List :: struct {
-	data:  ^bool,
+	data:  [^]bool,
 	count: c.size_t,
 }
 
@@ -128,7 +128,7 @@ Uint32_List :: struct {
 }
 
 Real_List :: struct {
-	data:  ^Real,
+	data:  [^]Real,
 	count: c.size_t,
 }
 
@@ -148,7 +148,7 @@ Vec4_List :: struct {
 }
 
 String_List :: struct {
-	data:  ^String,
+	data:  [^]String,
 	count: c.size_t,
 }
 
@@ -180,12 +180,12 @@ Dom_Value :: struct {
 }
 
 Dom_Node_List :: struct {
-	data:  ^^Dom_Node,
+	data:  [^]^Dom_Node,
 	count: c.size_t,
 }
 
 Dom_Value_List :: struct {
-	data:  ^Dom_Value,
+	data:  [^]Dom_Value,
 	count: c.size_t,
 }
 
@@ -354,12 +354,12 @@ Props :: struct {
 }
 
 Element_List :: struct {
-	data:  ^^Element,
+	data:  [^]^Element,
 	count: c.size_t,
 }
 
 Unknown_List :: struct {
-	data:  ^^Unknown,
+	data:  [^]^Unknown,
 	count: c.size_t,
 }
 
@@ -369,202 +369,202 @@ Node_List :: struct {
 }
 
 Mesh_List :: struct {
-	data:  ^^Mesh,
+	data:  [^]^Mesh,
 	count: c.size_t,
 }
 
 Light_List :: struct {
-	data:  ^^Light,
+	data:  [^]^Light,
 	count: c.size_t,
 }
 
 Camera_List :: struct {
-	data:  ^^Camera,
+	data:  [^]^Camera,
 	count: c.size_t,
 }
 
 Bone_List :: struct {
-	data:  ^^Bone,
+	data:  [^]^Bone,
 	count: c.size_t,
 }
 
 Empty_List :: struct {
-	data:  ^^Empty,
+	data:  [^]^Empty,
 	count: c.size_t,
 }
 
 Line_Curve_List :: struct {
-	data:  ^^Line_Curve,
+	data:  [^]^Line_Curve,
 	count: c.size_t,
 }
 
 Nurbs_Curve_List :: struct {
-	data:  ^^Nurbs_Curve,
+	data:  [^]^Nurbs_Curve,
 	count: c.size_t,
 }
 
 Nurbs_Surface_List :: struct {
-	data:  ^^Nurbs_Surface,
+	data:  [^]^Nurbs_Surface,
 	count: c.size_t,
 }
 
 Nurbs_Trim_Surface_List :: struct {
-	data:  ^^Nurbs_Trim_Surface,
+	data:  [^]^Nurbs_Trim_Surface,
 	count: c.size_t,
 }
 
 Nurbs_Trim_Boundary_List :: struct {
-	data:  ^^Nurbs_Trim_Boundary,
+	data:  [^]^Nurbs_Trim_Boundary,
 	count: c.size_t,
 }
 
 Procedural_Geometry_List :: struct {
-	data:  ^^Procedural_Geometry,
+	data:  [^]^Procedural_Geometry,
 	count: c.size_t,
 }
 
 Stereo_Camera_List :: struct {
-	data:  ^^Stereo_Camera,
+	data:  [^]^Stereo_Camera,
 	count: c.size_t,
 }
 
 Camera_Switcher_List :: struct {
-	data:  ^^Camera_Switcher,
+	data:  [^]^Camera_Switcher,
 	count: c.size_t,
 }
 
 Marker_List :: struct {
-	data:  ^^Marker,
+	data:  [^]^Marker,
 	count: c.size_t,
 }
 
 Lod_Group_List :: struct {
-	data:  ^^Lod_Group,
+	data:  [^]^Lod_Group,
 	count: c.size_t,
 }
 
 Skin_Deformer_List :: struct {
-	data:  ^^Skin_Deformer,
+	data:  [^]^Skin_Deformer,
 	count: c.size_t,
 }
 
 Skin_Cluster_List :: struct {
-	data:  ^^Skin_Cluster,
+	data:  [^]^Skin_Cluster,
 	count: c.size_t,
 }
 
 Blend_Deformer_List :: struct {
-	data:  ^^Blend_Deformer,
+	data:  [^]^Blend_Deformer,
 	count: c.size_t,
 }
 
 Blend_Channel_List :: struct {
-	data:  ^^Blend_Channel,
+	data:  [^]^Blend_Channel,
 	count: c.size_t,
 }
 
 Blend_Shape_List :: struct {
-	data:  ^^Blend_Shape,
+	data:  [^]^Blend_Shape,
 	count: c.size_t,
 }
 
 Cache_Deformer_List :: struct {
-	data:  ^^Cache_Deformer,
+	data:  [^]^Cache_Deformer,
 	count: c.size_t,
 }
 
 Cache_File_List :: struct {
-	data:  ^^Cache_File,
+	data:  [^]^Cache_File,
 	count: c.size_t,
 }
 
 Material_List :: struct {
-	data:  ^^Material,
+	data:  [^]^Material,
 	count: c.size_t,
 }
 
 Texture_List :: struct {
-	data:  ^^Texture,
+	data:  [^]^Texture,
 	count: c.size_t,
 }
 
 Video_List :: struct {
-	data:  ^^Video,
+	data:  [^]^Video,
 	count: c.size_t,
 }
 
 Shader_List :: struct {
-	data:  ^^Shader,
+	data:  [^]^Shader,
 	count: c.size_t,
 }
 
 Shader_Binding_List :: struct {
-	data:  ^^Shader_Binding,
+	data:  [^]^Shader_Binding,
 	count: c.size_t,
 }
 
 Anim_Stack_List :: struct {
-	data:  ^^Anim_Stack,
+	data:  [^]^Anim_Stack,
 	count: c.size_t,
 }
 
 Anim_Layer_List :: struct {
-	data:  ^^Anim_Layer,
+	data:  [^]^Anim_Layer,
 	count: c.size_t,
 }
 
 Anim_Value_List :: struct {
-	data:  ^^Anim_Value,
+	data:  [^]^Anim_Value,
 	count: c.size_t,
 }
 
 Anim_Curve_List :: struct {
-	data:  ^^Anim_Curve,
+	data:  [^]^Anim_Curve,
 	count: c.size_t,
 }
 
 Display_Layer_List :: struct {
-	data:  ^^Display_Layer,
+	data:  [^]^Display_Layer,
 	count: c.size_t,
 }
 
 Selection_Set_List :: struct {
-	data:  ^^Selection_Set,
+	data:  [^]^Selection_Set,
 	count: c.size_t,
 }
 
 Selection_Node_List :: struct {
-	data:  ^^Selection_Node,
+	data:  [^]^Selection_Node,
 	count: c.size_t,
 }
 
 Character_List :: struct {
-	data:  ^^Character,
+	data:  [^]^Character,
 	count: c.size_t,
 }
 
 Constraint_List :: struct {
-	data:  ^^Constraint,
+	data:  [^]^Constraint,
 	count: c.size_t,
 }
 
 Audio_Layer_List :: struct {
-	data:  ^^Audio_Layer,
+	data:  [^]^Audio_Layer,
 	count: c.size_t,
 }
 
 Audio_Clip_List :: struct {
-	data:  ^^Audio_Clip,
+	data:  [^]^Audio_Clip,
 	count: c.size_t,
 }
 
 Pose_List :: struct {
-	data:  ^^Pose,
+	data:  [^]^Pose,
 	count: c.size_t,
 }
 
 Metadata_Object_List :: struct {
-	data:  ^^Metadata_Object,
+	data:  [^]^Metadata_Object,
 	count: c.size_t,
 }
 
@@ -3098,7 +3098,7 @@ Anim_Value :: struct {
 		},
 	},
 	default_value: Vec3,
-	curves:        ^[3]Anim_Curve,
+	curves:        [3]^Anim_Curve,
 }
 
 // Animation curve segment interpolation mode between two keyframes

--- a/src/bindgen.odin
+++ b/src/bindgen.odin
@@ -1326,7 +1326,7 @@ c_type_mapping := map[string]string {
 }
 
 // For translating type names in procedure parameters and struct fields.
-translate_type :: proc(s: Gen_State, t: string) -> string {
+translate_type :: proc(s: Gen_State, t: string, override: bool) -> string {
 	t := t
 	t = strings.trim_space(t)
 
@@ -1340,7 +1340,7 @@ translate_type :: proc(s: Gen_State, t: string) -> string {
 			remainder_start = delimiter + 1
 		}
 
-		return_type := translate_type(s, t[:delimiter])
+		return_type := translate_type(s, t[:delimiter], false)
 
 		func_builder := strings.builder_make()
 
@@ -1356,7 +1356,7 @@ translate_type :: proc(s: Gen_State, t: string) -> string {
 			} else {
 				strings.write_string(&func_builder, ", ")
 			}
-			strings.write_string(&func_builder, translate_type(s, strings.trim_space(param_type)))
+			strings.write_string(&func_builder, translate_type(s, strings.trim_space(param_type), false))
 		}
 
 		if return_type == "void" {
@@ -1369,7 +1369,7 @@ translate_type :: proc(s: Gen_State, t: string) -> string {
 	}
 
 	// This type usually means "an array of strings"
-	if t == "const char *const *" {
+	if t == "const char *const *" || t == "char *const *" || t == "const char **" || t == "char **" {
 		return "[^]cstring"
 	}
 
@@ -1454,11 +1454,14 @@ translate_type :: proc(s: Gen_State, t: string) -> string {
 		t = final_name(vet_name(t), s)
 	}
 
-	if array_start != -1 {
-		t = fmt.tprintf("%s%s%s", multi_array != -1 ? "[^]" : "", t_original[array_start:array_end + 1], t)
-	}
-
 	b := strings.builder_make()
+
+	if array_start != -1 {
+		if multi_array != -1 {
+			strings.write_string(&b, "[^]")
+		}
+		strings.write_string(&b, t_original[array_start:array_end + 1])
+	}
 
 	if num_ptrs > 0 {
 		if t == "void" {
@@ -1475,8 +1478,17 @@ translate_type :: proc(s: Gen_State, t: string) -> string {
 		}
 	}
 
-	for _ in 0..<num_ptrs{
-		strings.write_string(&b, "^")
+	// Can we assume that if we have multiple pointers it's a pointer to an array of pointers as aposed to a pointer to a pointer?
+	// I'm going to say yes but this could be wrong sometimes.
+	// If wrong I think you can still use the data by `variable[0]` which will function the same as a pointer to a pointer
+	// or you can override the type to the corrected type (e.g. ^^int).
+	for num_ptrs > 0 {
+		if num_ptrs > 1 || override {
+			strings.write_string(&b, "[^]")
+		} else {
+			strings.write_string(&b, "^")
+		}
+		num_ptrs -= 1
 	}
 
 	strings.write_string(&b, t)
@@ -1967,18 +1979,18 @@ gen :: proc(input: string, c: Config) {
 							}
 						}
 					}
-					
-					field_type := translate_type(s, field.type)
 
-					if override_key != "" {
-						if field_type_override, has_field_type_override := s.struct_field_overrides[override_key]; has_field_type_override {
-							if field_type_override == "[^]" {
-								// Change first `^` for `[^]`
-								field_type = fmt.tprintf("[^]%v", strings.trim_prefix(field_type, "^"))
-							} else {
-								field_type = field_type_override
-							}
+					field_type: string
+					
+					if field_type_override, has_field_type_override := s.struct_field_overrides[override_key]; override_key != "" && has_field_type_override {
+						if field_type_override == "[^]" {
+							// Change first `^` for `[^]`
+							field_type = translate_type(s, field.type, true)
+						} else {
+							field_type = field_type_override
 						}
+					} else {
+						field_type = translate_type(s, field.type, false)
 					}
 
 					comment := field.comment
@@ -2274,7 +2286,7 @@ gen :: proc(input: string, c: Config) {
 				continue
 			}
 
-			if translate_type(s, d.type) == d.name {
+			if translate_type(s, d.type, false) == d.name {
 				continue
 			}
 
@@ -2306,10 +2318,10 @@ gen :: proc(input: string, c: Config) {
 				fp(f, "struct {}")
 			} else if strings.contains(type, "(") && strings.contains(type, ")") {
 				// function pointer typedef
-				fp(f, translate_type(s, type))
+				fp(f, translate_type(s, type, false))
 				add_to_set(&s.type_is_proc, n)
 			} else {
-				fpf(f, "%v", translate_type(s, type))
+				fpf(f, "%v", translate_type(s, type, false))
 			}
 
 			if d.side_comment != "" {
@@ -2535,19 +2547,21 @@ gen :: proc(input: string, c: Config) {
 				for &p, i in d.parameters {
 					n := vet_name(p.name)
 
-					type := translate_type(s, p.type)
+					type: string
 					type_override_key := fmt.tprintf("%v.%v", d.name, n)
 
 					if type_override, type_override_ok := s.procedure_type_overrides[type_override_key]; type_override_ok {
 						switch type_override {
 						case "#by_ptr":
-							type = strings.trim_prefix(type, "^")
+							type = strings.trim_prefix(translate_type(s, p.type, false), "^")
 							w(&b, "#by_ptr ")
 						case "[^]":
-							type = fmt.tprintf("[^]%v", strings.trim_prefix(type, "^"))
+							type = translate_type(s, p.type, true)
 						case:
 							type = type_override
 						}
+					} else {
+						type = translate_type(s, p.type, false)
 					}
 
 					// Empty name means unnamed parameter. Drop the colon.
@@ -2574,15 +2588,17 @@ gen :: proc(input: string, c: Config) {
 				if d.return_type != "" {
 					w(&b, " -> ")
 
-					return_type := translate_type(s, d.return_type)
+					return_type: string
 
 					if override, override_ok := s.procedure_type_overrides[d.name]; override_ok {
 						switch override {
 						case "[^]":
-							return_type = fmt.tprintf("[^]%v", strings.trim_prefix(return_type, "^"))
+							return_type = translate_type(s, d.return_type, true)
 						case:
 							return_type = override
 						}
+					} else {
+						return_type = translate_type(s, d.return_type, false)
 					}
 
 					w(&b, return_type)


### PR DESCRIPTION
Closes #32.

I also made a few changes to bindgens logic with multi pointers. Now any type with `**` will be interpreted as an array of pointer `[^]^` by default. I also updated the type override settings to change the last pointer into `[^]`. 

I also considered implementing the ability to pass `^` as a type override to undo this behaviour but i haven't implemented this yet.