### PR TITLE
Remove parsing for nested comments

### DIFF
--- a/src/bindgen.odin
+++ b/src/bindgen.odin
@@ -1189,22 +1189,6 @@ get_comment :: proc(v: json.Value, s: ^Gen_State) -> (comment: string, ok: bool)
 		}
 	}
 
-	cmt := s.source[begin:end+1]
-
-	num_block_openings := strings.count(cmt, "/*")
-	num_block_closing := strings.count(cmt, "*/")
-
-	if num_block_openings != num_block_closing {
-		for idx in end..<len(s.source) - 2 {
-			cur := s.source[idx:idx+2]
-
-			if cur == "*/" {
-				end = idx+1
-				break
-			}
-		}
-	}
-
 	return s.source[begin:end+1], true
 }
 


### PR DESCRIPTION
I ran into an issue involving single-line comments containing either an opening or ending of a multi-line comment which caused the comment text to dump C code into the resulting Odin file.

The issue was caused by code attempting to parse nested comments. Unlike Odin, standard C doesn't support nested comments, so it makes the most sense to remove it entirely. Its removal appears to have fixed the issue.

Ran the changes with the test folder and saw no issues.