### PR TITLE
`name_without_overlap` can be empty

### DIFF
--- a/src/bindgen.odin
+++ b/src/bindgen.odin
@@ -2207,7 +2207,15 @@ gen :: proc(input: string, c: Config) {
 				name_without_overlap := m.name[overlap_length:]
 
 				// Remove any leading underscores.
-				for ; name_without_overlap[0] == '_'; name_without_overlap = name_without_overlap[1:] {} 
+                // Here, name_without_overlap can be empty. 
+                // (ex: libcurl lib curl.h line 991)
+                if len(name_without_overlap) == 0 {
+                    // TODO: this approach is somewhat duck-tape problem solving.
+                    // If one has a nice replacement, please change it
+                    name_without_overlap = name
+                } else {
+                    for ; name_without_overlap[0] == '_'; name_without_overlap = name_without_overlap[1:] {}
+                }
 
 				// First letter is number... Can't have that!
 				if len(name_without_overlap) > 0 && unicode.is_number(utf8.rune_at(name_without_overlap, 0)) {


### PR DESCRIPTION
In the curl.h of libcurl library, there is the case that `name_without_overlap` is empty so that bindgen fails to generate odin file.
Below code comes from curl.h where the error happens
```c
/* parameter for the CURLOPT_FTP_CREATE_MISSING_DIRS option */
typedef enum {
  CURLFTP_CREATE_DIR_NONE,  /* do NOT create missing dirs! */
  CURLFTP_CREATE_DIR,       /* (FTP/SFTP) if CWD fails, try MKD and then CWD
                               again if MKD succeeded, for SFTP this does
                               similar magic */
  CURLFTP_CREATE_DIR_RETRY, /* (FTP only) if CWD fails, try MKD and then CWD
                               again even if MKD failed! */
  CURLFTP_CREATE_DIR_LAST   /* not an option, never use */
} curl_ftpcreatedir;
```
One of the solution is that bind `name_without_overlap` by the name of the enum. However I think is not the best idea to solve this issue.