### PR TITLE
Added vet_type to parse_typedef_decl for proper imports

### DIFF
--- a/src/bindgen.odin
+++ b/src/bindgen.odin
@@ -1012,6 +1012,7 @@ gen :: proc(input: string, c: Config) {
 
 	parse_typedef_decl :: proc(state: ^Gen_State, cursor: clang.Cursor) -> Typedef {
 		type := clang.getTypedefDeclUnderlyingType(cursor)
+		vet_type(state, type)
 
 		source_range := clang.getCursorExtent(cursor)
 		start := clang.getRangeStart(source_range)

--- a/test/binding/test.odin
+++ b/test/binding/test.odin
@@ -1,10 +1,16 @@
 package test
 
+import "core:c"
 
+_ :: c
 
 foreign import lib "test.lib"
 
 TEST :: u8
+
+Int64 :: c.long
+
+UInt64 :: c.ulong
 
 testType :: [4]i32
 

--- a/test/binding/test.yml
+++ b/test/binding/test.yml
@@ -10,6 +10,16 @@ Cursors:
   Kind: MacroDefinition
   TypeKind: Invalid
   Children:
+- Visiting: Int64
+  Parent: ./src/test.h
+  Kind: TypedefDecl
+  TypeKind: Typedef
+  Children:
+- Visiting: UInt64
+  Parent: ./src/test.h
+  Kind: TypedefDecl
+  TypeKind: Typedef
+  Children:
 - Visiting: testType
   Parent: ./src/test.h
   Kind: TypedefDecl

--- a/test/src/test.h
+++ b/test/src/test.h
@@ -5,6 +5,9 @@
 
 #define TEST unsigned char
 
+typedef signed long   Int64;
+typedef unsigned long UInt64;
+
 typedef int testType[4];
 
 typedef void (*myLogImpl)(const char* fmt, ...);


### PR DESCRIPTION
Ass title suggests just aone line patch to make sure typedef types casue the appropriate package to be imported for their types.