### PR TITLE
Add unnamed procedure parameter type override

### DIFF
--- a/src/translate_process.odin
+++ b/src/translate_process.odin
@@ -261,8 +261,9 @@ translate_process :: proc(tcr: Translate_Collect_Result, config: Config, types: 
 				}
 			}
 		case Type_Procedure:
-			for &p in v.parameters {
-				param_key := fmt.tprintf("%s.%s", d.name, p.name)
+			for &p, p_i in v.parameters {
+				param_name := len(p.name) != 0 ? p.name : fmt.tprintf("#%d", p_i)
+				param_key := fmt.tprintf("%s.%s", d.name, param_name)
 				if override, has_override := config.procedure_type_overrides[param_key]; has_override {
 					if override == "[^]" {
 						if ptr_type, is_ptr_type := resolve_type_definition(types, p.type, Type_Pointer); is_ptr_type {


### PR DESCRIPTION
Hello, I am changing my nuklear bindings to use your bindgen, but when the C function have a procedure parameter with no name, there is no way to override it using 'procedure_type_overrides' in 'bindgen.sjson'.

This is simple, but adds a way to override a parameter by its index on the procedure signature.

How it works:

nuklear.h
<img width="731" height="34" alt="image" src="https://github.com/user-attachments/assets/92f71283-d65d-4875-9dc9-e018d7f3e6d7" />

bindgen.sjson
<img width="417" height="174" alt="image" src="https://github.com/user-attachments/assets/0de3e7e6-1eda-4bd0-81d8-7ee7bfa27e14" />

generated odin bindings
<img width="771" height="42" alt="image" src="https://github.com/user-attachments/assets/8307a1a7-a525-445f-83f5-8a21182fb1c6" />



