### PR TITLE
Add bit_setify_macro (Closes #85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ rename = {
 //
 // Note that the enum will be turned into a bit_set type. There will be a new type created that
 // contains the actual enum, which the bit_set then references.
-bit_setify = {
+bit_setify_enum = {
 	// "Enum_To_Turn_Into_Bitset" = "New_Enum_Type_Name"
 }
 
@@ -184,7 +184,7 @@ Use `imports_file` in `bindgen.sjson`. See `examples/raylib`
 In `bindgen.sjson`:
 
 ```
-bit_setify = {
+bit_setify_enum = {
 	"Enum_To_Turn_Into_Bitset" = "New_Enum_Type_Name"
 }
 ```

--- a/examples/raylib/bindgen.sjson
+++ b/examples/raylib/bindgen.sjson
@@ -15,7 +15,7 @@ rename = {
 }
 
 // "Enum_To_Turn_Into_Bitset" = "New_Enum_Type_Name"
-bit_setify = {
+bit_setify_enum = {
 	"Gesture" = "Gesture_Enum"
 	"ConfigFlags" = "ConfigFlag"
 }

--- a/examples/ufbx/bindgen.sjson
+++ b/examples/ufbx/bindgen.sjson
@@ -43,7 +43,7 @@ procedure_type_overrides = {
     "ufbx_generate_indices.streams" = "[^]"
 }
 
-bit_setify = {
+bit_setify_enum = {
     "ufbx_prop_flags" = "Prop_Flag"
     "ufbx_transform_flags" = "Transform_Flag"
     "ufbx_baked_key_flags" = "Baked_Key_Flag"

--- a/src/config.odin
+++ b/src/config.odin
@@ -45,7 +45,13 @@ Config :: struct {
 	//
 	// Note that the enum will be turned into a bit_set type. There will be a new type created that
 	// contains the actual enum, which the bit_set then references.
-	bit_setify: map[string]string,
+	bit_setify_enum: map[string]string,
+	
+	// The key is the old type name that is defined using a typedef, e.g. MyLib_Flags
+	bit_setify_macro: map[string]struct {
+		new_enum_name, // e.g. Flag
+		member_prefix: string, // e.g. MYLIB_FLAG_
+	},
 
 	// Completely override the definition of a type.
 	type_overrides: map[string]string,

--- a/src/output.odin
+++ b/src/output.odin
@@ -395,7 +395,11 @@ output_enum_definition :: proc(types: ^[dynamic]Type, idx: Type_Index, b: ^strin
 	t := types[idx]
 	t_enum := &t.(Type_Enum)
 
-	pfln(b, "enum %v {{", t_enum.storage_type)
+	if t_enum.storage_type != nil {
+		pfln(b, "enum %v {{", t_enum.storage_type)
+	} else {
+		pln(b, "enum {")
+	}
 
 	longest_name: int
 	for &m in t_enum.members {

--- a/src/translate_process.odin
+++ b/src/translate_process.odin
@@ -186,9 +186,9 @@ translate_process :: proc(tcr: Translate_Collect_Result, config: Config, types: 
 				}
 			}
 
-			bit_set_enum_name, bit_setify := config.bit_setify[d.name]
+			bit_set_enum_name, bit_setify_enum := config.bit_setify_enum[d.name]
 
-			if bit_setify {
+			if bit_setify_enum {
 				clear(&bit_set_make_constant)
 
 				bs_idx := add_type(types, Type_Bit_Set {


### PR DESCRIPTION
This pull request renames `bit_setify` to `bit_setify_enum` and implements a new feature "`bit_setify_macro`". Closes #85

### Here's an example on it's usage:

bindgen.sjson:
```
inputs = [
    "."
]

rename = {
    "NX_Flags": "InitFlags"
}

bit_setify_macro = {
    "NX_Flags": {
        "member_prefix": "NX_FLAG_",
        "new_enum_name": "InitFlag"
    }
}
```

C header file:
```c
#include <stdint.h>

typedef uint64_t NX_Flags;

#define NX_FLAG_VSYNC_HINT              (1 <<  0)  ///< Enable vertical synchronization hint
#define NX_FLAG_FULLSCREEN              (1 <<  1)  ///< Create window in fullscreen mode
#define NX_FLAG_WINDOW_OCCLUDED         (1 <<  2)  ///< Window is occluded by other windows
#define NX_FLAG_WINDOW_HIDDEN           (1 <<  3)  ///< Create window initially hidden
#define NX_FLAG_WINDOW_BORDERLESS       (1 <<  4)  ///< Create borderless window
#define NX_FLAG_WINDOW_RESIZABLE        (1 <<  5)  ///< Window can be resized by user
```

Resulting Odin file:
```odin
package test

InitFlag :: enum {
	VSYNC_HINT        = 0,
	FULLSCREEN        = 1,
	WINDOW_OCCLUDED   = 2,
	WINDOW_HIDDEN     = 3,
	WINDOW_BORDERLESS = 4,
	WINDOW_RESIZABLE  = 5,
}

InitFlags :: bit_set[InitFlag; u64]
```

#### I'm open for suggestions regarding code refactoring, renaming or other changes.