### PR TITLE
Fix nested structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ procedure_type_overrides = {
 // write the plain-text Odin value as value.
 //
 // You can also add defaults for proc parameters within structs. In that case you do:
-// `Struct_Name.proc_field.parameter_name` -- This does not currently support nested structs.
+// `Struct_Name.proc_field.parameter_name`
 procedure_parameter_defaults = {
 	// "DrawTexturePro.tint" = "RED"
 	// "Some_Struct.a_field_that_is_a_proc.some_parameter" = "5"

--- a/src/config.odin
+++ b/src/config.odin
@@ -77,7 +77,7 @@ Config :: struct {
 	// write the plain-text Odin value as value.
 	//
 	// You can also add defaults for proc parameters within structs. In that case you do:
-	// `Struct_Name.proc_field.parameter_name` -- This does not currently support nested structs.
+	// `Struct_Name.proc_field.parameter_name`
 	procedure_parameter_defaults: map[string]string,
 
 	// Put the names of declarations in here to remove them.	

--- a/src/translate_collect.odin
+++ b/src/translate_collect.odin
@@ -204,10 +204,6 @@ build_cursor_children_lookup :: proc(c: clang.Cursor, res: ^Cursor_Children_Map)
 // Finds things such as procs and struct declarations and stores them in `tcs.decls`. Recursive.
 // Also runs `create_type_recursive` which will fill out `tcs.types`.
 create_declaration :: proc(c: clang.Cursor, tcs: ^Translate_Collect_State) {
-	if clang.Cursor_isAnonymous(c) == 1 && c.kind != .EnumDecl {
-		return
-	}
-
 	name := get_cursor_name(c)
 	comment_before := string_from_clang_string(clang.Cursor_getRawCommentText(c))
 	line := get_cursor_location(c).line
@@ -244,14 +240,16 @@ create_declaration :: proc(c: clang.Cursor, tcs: ^Translate_Collect_State) {
 			return
 		}
 
-		add_decl(tcs.decls, {
-			comment_before = comment_before,
-			def = ti,
-			name = name,
-			original_line = line,
-			side_comment = side_comment,
-			is_forward_declare = is_forward_declare,
-		})
+		if clang.Cursor_isAnonymous(c) == 0 {
+			add_decl(tcs.decls, {
+				comment_before = comment_before,
+				def = ti,
+				name = name,
+				original_line = line,
+				side_comment = side_comment,
+				is_forward_declare = is_forward_declare,
+			})
+		}
 
 		children := tcs.children_lookup[c]
 

--- a/src/translate_process.odin
+++ b/src/translate_process.odin
@@ -256,30 +256,8 @@ translate_process :: proc(tcr: Translate_Collect_Result, config: Config, types: 
 			}
 
 		case Type_Struct:
-			for &f in v.fields {
-				if len(f.names) != 1 {
-					continue
-				}
+			override_struct(&v, d.name, types, config)
 
-				field_key := fmt.tprintf("%s.%s", d.name, f.names[0])
-				if override, has_override := config.struct_field_overrides[field_key]; has_override {
-					if new_type, ok := augment_pointers(f.type, types, override); ok {
-						f.type = new_type
-					} else if override == "using" {
-						f.is_using = true
-					} else {
-						f.type = Fixed_Value(override)
-					}
-				}
-
-				if proc_type := resolve_type_definition_ptr(types, f.type, Type_Procedure); proc_type != nil {
-					override_procedure(proc_type, field_key, types, config)
-				}
-
-				if tag, has_tag := config.struct_field_tags[field_key]; has_tag {
-					f.tag = tag
-				}
-			}
 		case Type_Procedure:
 			override_procedure(&v, d.name, types, config)
 		}
@@ -497,6 +475,37 @@ resolve_final_names :: proc(types: Type_List, decls: Decl_List, config: Config) 
 			}
 
 		case Type_Index:
+		}
+	}
+}
+
+override_struct :: proc(p: ^Type_Struct, name: string, types: Type_List, config: Config) {
+	for &f in p.fields {
+		if len(f.names) != 1 {
+			continue
+		}
+
+		field_key := fmt.tprintf("%s.%s", name, f.names[0])
+		if override, has_override := config.struct_field_overrides[field_key]; has_override {
+			if new_type, ok := augment_pointers(f.type, types, override); ok {
+				f.type = new_type
+			} else if override == "using" {
+				f.is_using = true
+			} else {
+				f.type = Fixed_Value(override)
+			}
+		}
+
+		if proc_type := resolve_type_definition_ptr(types, f.type, Type_Procedure); proc_type != nil {
+			override_procedure(proc_type, field_key, types, config)
+		}
+
+		if struct_type := resolve_type_definition_ptr(types, f.type, Type_Struct); struct_type != nil {
+			override_struct(struct_type, field_key, types, config)
+		}
+
+		if tag, has_tag := config.struct_field_tags[field_key]; has_tag {
+			f.tag = tag
 		}
 	}
 }


### PR DESCRIPTION
Closes #76 (and a bit more, since it also enables all overrides and struct tags)
Also fixes an edge case where the definition of a non-anonymous struct declared inside an anonymous struct was missing from the output.