### PR TITLE
Override procedure parameters inside procedure parameters

### DIFF
--- a/src/translate_process.odin
+++ b/src/translate_process.odin
@@ -514,6 +514,8 @@ override_procedure :: proc(p: ^Type_Procedure, name: string, types: Type_List, c
 		param_key := fmt.tprintf("%s.%s", name, param_name)
 		if override, has_override := config.procedure_type_overrides[param_key]; has_override {
 			override_procedure_parameter(&param, types, override)
+		} else if proc_type := resolve_type_definition_ptr(types, param.type, Type_Procedure); proc_type != nil {
+			override_procedure(proc_type, param_key, types, config)
 		}
 
 		if default, has_default := config.procedure_parameter_defaults[param_key]; has_default {


### PR DESCRIPTION
Found this in sqlite3 header files and realized that it's impossible to override procedure parameter inside procedure parameter (`sqlite3_value**`).
```c
struct sqlite3_api_routines {
  // ...
  int  (*create_function)(sqlite3*,const char*,int,int,void*,
                          void (*xFunc)(sqlite3_context*,int,sqlite3_value**),
                          void (*xStep)(sqlite3_context*,int,sqlite3_value**),
                          void (*xFinal)(sqlite3_context*));
  // ...
};
```
The only problem is overriding nested procedure types.
This PR just goes backwards-compatibility route: `"proc1.proc2.param" = "[^]"` works, but `"proc1.proc2" = "^int"` will still completely override `proc2` type, instead of only overriding its return type. It's inconvenient, but I'm not sure what to do about it.