### PR TITLE
Explicit link_name for renamed procs or procs with unexpected prefix

### DIFF
--- a/src/declarations_and_types.odin
+++ b/src/declarations_and_types.odin
@@ -61,6 +61,9 @@ Decl :: struct {
 
 	explicitly_created: bool,
 
+	// Only used for procs and only if it's not empty.
+	link_name: string,
+
 	// Only used for macros.
 	explicit_whitespace_before_side_comment: int,
 

--- a/src/output.odin
+++ b/src/output.odin
@@ -190,6 +190,11 @@ output :: proc(types: Type_List, decls: Decl_List, o: Output_Input, filename: st
 				}
 			}
 
+			if d.link_name != "" {
+				output_indent(sb, indent)
+				pfln(sb, "@(link_name=\"%s\")", d.link_name)
+			}
+
 			output_indent(sb, indent)
 			text := group_member_texts[i]
 			p(sb, text)

--- a/src/translate_process.odin
+++ b/src/translate_process.odin
@@ -487,7 +487,7 @@ resolve_final_names :: proc(types: Type_List, decls: Decl_List, config: Config) 
 	}
 
 	for &d in decls {
-		d.name = final_decl_name(d, types, config)
+		d.name, d.link_name = final_decl_name(d, types, config)
 		
 		switch &def in d.def {
 		case Type_Name: d.def = final_type_name(def, config)
@@ -715,21 +715,27 @@ ensure_name_valid :: proc(s: string) -> string {
 	return s
 }
 
-final_decl_name :: proc(d: Decl, types: Type_List, config: Config) -> string {
+final_decl_name :: proc(d: Decl, types: Type_List, config: Config) -> (name: string, link_name: string) {
 	if d.explicitly_created {
-		return d.name
-	}
-
-	if new_name, rename := config.rename[string(d.name)]; rename {
-		return new_name
+		return d.name, ""
 	}
 
 	_, is_proc := resolve_type_definition(types, d.def, Type_Procedure)
 
+	if new_name, rename := config.rename[string(d.name)]; rename {
+		return new_name, is_proc ? d.name : ""
+	}
+
 	if is_proc {
-		return strings.trim_prefix(d.name, config.remove_function_prefix)
+		has_prefix := strings.has_prefix(d.name, config.remove_function_prefix)
+
+		if !has_prefix {
+			return d.name, d.name
+		}
+
+		return d.name[len(config.remove_function_prefix):], ""
 	} else if d.from_macro {
-		return strings.trim_prefix(d.name, config.remove_macro_prefix)
+		return strings.trim_prefix(d.name, config.remove_macro_prefix), ""
 	} else {
 		res := strings.trim_prefix(d.name, config.remove_type_prefix)
 		res = strings.trim_suffix(res, config.remove_type_suffix)
@@ -738,10 +744,10 @@ final_decl_name :: proc(d: Decl, types: Type_List, config: Config) -> string {
 			res = strings.to_ada_case(res)
 		}
 
-		return res
+		return res, ""
 	}
 
-	return d.name
+	return d.name, ""
 }
 
 final_type_name :: proc(name: Type_Name, config: Config) -> Type_Name {


### PR DESCRIPTION
Similar to #47 (which is missing in v2), but also handles the case when file contains functions with prefix different from `remove_function_prefix`.
This PR is mainly driven by ffmpeg using multiple prefixes (`ff_`/`av_`/`avutil_`/`avpriv_`), sometimes even inside [one file](https://ffmpeg.org/doxygen/8.0/avutil_8h.html). Maybe it was better to simply log/panic? I just don't like how currently it's silently generating something with link name `prefix1_prefix2_name`, and you don't know about it until you try to use it.
Example:
```c
// test.h
void lib_func1();
void lib_func2();
void mylib_func3();
```
```
// bindgen.sjson
inputs = [ "test.h" ]
remove_function_prefix = "lib_"
rename = { "lib_func2" = "Func2" }
```
```odin
// test.odin
package test

@(default_calling_convention="c", link_prefix="lib_")
foreign lib {
	func1       :: proc() ---
	@(link_name="lib_func2")
	Func2       :: proc() ---
	@(link_name="mylib_func3")
	mylib_func3 :: proc() ---
}