### PR TITLE
"Replace" config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ remove = [
 	// "Some_Declaration_Name"
 ]
 
-// Functions to both remove a decleration and replace any uses 
-// of the decleration with something else.
-remove_and_replace = {
-	// "Some_Declaration_Name" = "Some_Other_Type"
+// Removes the declaration named and replaces any uses of it 
+// with a new type
+replace = {
+	// "Some_Declaration_Name" = "Replacement_Type"
 }
 
 // Group all procedures at the end of the file.

--- a/src/config.odin
+++ b/src/config.odin
@@ -83,8 +83,8 @@ Config :: struct {
 	// Put the names of declarations in here to remove them.	
 	remove: []string,
 	
-	// Put the names of declarations in here to remove a type replace them.
-	remove_and_replace: map[string]string,
+	// Put the names of declarations in here to remove and replace them.
+	replace: map[string]string,
 
 	// Group all procedures at the end of the file.
 	procedures_at_end: bool,

--- a/src/main.odin
+++ b/src/main.odin
@@ -78,7 +78,7 @@ main :: proc() {
 		config.inputs = slice.clone([]string{"."})
 	}
 
-	for key, value in config.remove_and_replace {
+	for key, value in config.replace {
 		config.rename[key] = value
 	}
 

--- a/src/translate_process.odin
+++ b/src/translate_process.odin
@@ -30,7 +30,7 @@ translate_process :: proc(tcr: Translate_Collect_Result, config: Config, types: 
 		to_remove[r] = {}
 	}
 
-	for k, _ in config.remove_and_replace {
+	for k, _ in config.replace {
 		to_remove[k] = {}
 	}
 


### PR DESCRIPTION
TLDR; Adds a config option that both renames a definition and removed its decleration.

While making a binding for ImGui's dear bingings I found they have many types such as:

```c
struct ImVector_ImU16_t {
  int Size;
  int Capacity;
  ImU16* Data;
};
```

In order to make working with these easier I wrote my own type:

```odin
Vector :: struct($T: typeid) {
  Size:        i32,
  Capacity: i32,
  Data:       [^]T,
}
```

`remove_and_replace` is used as follows:

```sjson
remove_and_replace = {
  "ImVector_ImU16_t" = "Vector(ImU16)"
}
```

This functions the same as adding `ImVector_ImU16_t` to remove and `"ImVector_ImU16_t" = "Vector(ImU16)"` to rename.

Let me know what you think of this. I only made a quick impl so some more thought might be required.