### PR TITLE
Add stdio.h types to c_type_mapping.odin

### DIFF
--- a/src/c_type_mapping.odin
+++ b/src/c_type_mapping.odin
@@ -61,5 +61,8 @@ c_type_mapping := map[string]string {
 	"timespec"   = "posix.timespec",
 
 	// libc
+	"FILE"   = "libc.FILE",
+	"fpos_t" = "libc.fpos_t",
+
 	"time_t" = "libc.time_t",
 }


### PR DESCRIPTION
Hello. Thank you for creating odin-c-bindgen.

I added stdio.h types to c_type_mapping.odin. Here is the C header I used to test that everything works:
```c
#include <stdio.h>

FILE* open_file(char* path);
void close_file(FILE* f);
int get_file_position(FILE* f, fpos_t* position);
int set_file_position(FILE* f, fpos_t* position);
```

This is a minimal bindgen.sjson:
```
inputs = ["."]
output_folder = "."
clang_include_paths = [
    // Needed for clang to find stdio.h on MacOS
    "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include",
]

```

And this is what was generated:
```odin
package stdio_test

import "core:c/libc"

@(default_calling_convention="c")
foreign lib {
	open_file         :: proc(path: cstring) -> ^libc.FILE ---
	close_file        :: proc(f: ^libc.FILE) ---
	get_file_position :: proc(f: ^libc.FILE, position: ^libc.fpos_t) -> i32 ---
	set_file_position :: proc(f: ^libc.FILE, position: ^libc.fpos_t) -> i32 ---
}
```
